### PR TITLE
Rewrite store selector by id and moving slices

### DIFF
--- a/apps/console/src/app/app.tsx
+++ b/apps/console/src/app/app.tsx
@@ -1,22 +1,21 @@
 import { useEffect } from 'react'
 import LogRocket from 'logrocket'
-import posthog from 'posthog-js'
 import axios from 'axios'
 import { GTMProvider } from '@elgorditosalsero/react-gtm-hook'
-import { Navigate, Routes, Route, useParams } from 'react-router-dom'
+import { Navigate, Route, Routes, useParams } from 'react-router-dom'
 import {
+  APPLICATION_URL,
+  APPLICATIONS_URL,
+  ENVIRONMENTS_URL,
   LOGIN_URL,
+  ONBOARDING_URL,
+  ORGANIZATION_URL,
   OVERVIEW_URL,
   ProtectedRoute,
-  useAuth,
-  useDocumentTitle,
-  useAuthInterceptor,
   SETTINGS_URL,
-  ONBOARDING_URL,
-  ENVIRONMENTS_URL,
-  APPLICATIONS_URL,
-  APPLICATION_URL,
-  ORGANIZATION_URL,
+  useAuth,
+  useAuthInterceptor,
+  useDocumentTitle,
 } from '@console/shared/utils'
 import { LoadingScreen } from '@console/shared/ui'
 import { LoginPage } from '@console/pages/login/feature'
@@ -27,7 +26,7 @@ import { ApplicationsPage } from '@console/pages/applications/feature'
 import { OnboardingPage } from '@console/pages/onboarding/feature'
 import { ApplicationPage } from '@console/pages/application/feature'
 import { Layout } from '@console/shared/layout'
-import { environments, useProjects } from '@console/domains/projects'
+import { useProjects } from '@console/domains/projects'
 import { environment } from '../environments/environment'
 
 function RedirectOverview() {

--- a/libs/domains/environment/src/index.ts
+++ b/libs/domains/environment/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/mocks/factories/environment-factory.mock'
+export * from './lib/slices/environments.slice'

--- a/libs/domains/environment/src/lib/slices/environments.slice.spec.ts
+++ b/libs/domains/environment/src/lib/slices/environments.slice.spec.ts
@@ -1,10 +1,11 @@
-import { fetchEnvironments, environmentsAdapter, environments } from './environments.slice'
+import { environments, environmentsAdapter, fetchEnvironments } from './environments.slice'
 
 describe('environments reducer', () => {
   it('should handle initial state', () => {
     const expected = environmentsAdapter.getInitialState({
       loadingStatus: 'not loaded',
       error: null,
+      joinProjectEnvironments: {},
     })
 
     expect(environments(undefined, { type: '' })).toEqual(expected)

--- a/libs/domains/organization/src/lib/provider/organization-provider.tsx
+++ b/libs/domains/organization/src/lib/provider/organization-provider.tsx
@@ -4,10 +4,9 @@ import { OrganizationRequest } from 'qovery-typescript-axios'
 import { useAuth } from '@console/shared/utils'
 import {
   fetchOrganization,
-  selectAllOrganization,
-  selectOrganizationById,
-  selectOrganizationLoadingStatus,
   postOrganization,
+  selectAllOrganization,
+  selectOrganizationLoadingStatus,
 } from '../slices/organization.slice'
 
 export function useOrganization() {
@@ -25,5 +24,5 @@ export function useOrganization() {
     return result.payload
   }
 
-  return { organization, loadingStatus, getOrganization, createOrganization, selectOrganizationById }
+  return { organization, loadingStatus, getOrganization, createOrganization }
 }

--- a/libs/domains/organization/src/lib/slices/organization.slice.ts
+++ b/libs/domains/organization/src/lib/slices/organization.slice.ts
@@ -86,7 +86,7 @@ export const getOrganizationState = (rootState: any): OrganizationState => rootS
 
 export const selectAllOrganization = createSelector(getOrganizationState, selectAll)
 
-export const selectOrganizationById = (organizationId: string) =>
-  createSelector(getOrganizationState, (state) => selectById(state, organizationId))
+export const selectOrganizationById = (state: any, organizationId: string) =>
+  getOrganizationState(state).entities[organizationId]
 
 export const selectOrganizationLoadingStatus = createSelector(getOrganizationState, (state) => state.loadingStatus)

--- a/libs/domains/projects/src/index.ts
+++ b/libs/domains/projects/src/index.ts
@@ -1,6 +1,4 @@
-export * from './lib/slices/environments.slice'
 export * from './lib/provider/projects-provider'
 export * from './lib/provider/environments-provider'
-export * from './lib/slices/environments.slice'
 export * from './lib/slices/projects.slice'
 export * from './lib/mocks/factories/projects-factory.mock'

--- a/libs/domains/projects/src/lib/provider/environments-provider.spec.ts
+++ b/libs/domains/projects/src/lib/provider/environments-provider.spec.ts
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useEnviroments } from './environments-provider'
+import { useEnvironments } from './environments-provider'
 
 describe('Environments Provider', () => {
   it('should render successfully', () => {
-    const { result } = renderHook(() => useEnviroments())
+    const { result } = renderHook(() => useEnvironments())
 
     expect(result).toBeTruthy()
   })

--- a/libs/domains/projects/src/lib/provider/environments-provider.ts
+++ b/libs/domains/projects/src/lib/provider/environments-provider.ts
@@ -1,6 +1,10 @@
 import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { selectAllEnvironments, fetchEnvironments, fetchEnvironmentsStatus } from './../slices/environments.slice'
+import {
+  fetchEnvironments,
+  fetchEnvironmentsStatus,
+  selectAllEnvironments,
+} from 'libs/domains/environment/src/lib/slices/environments.slice'
 
 export function useEnvironments() {
   const dispatch = useDispatch<any>()

--- a/libs/domains/projects/src/lib/provider/projects-provider.tsx
+++ b/libs/domains/projects/src/lib/provider/projects-provider.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ProjectRequest } from 'qovery-typescript-axios'
-import { postProjects, fetchProjects, selectAllProjects } from '../slices/projects.slice'
+import { fetchProjects, postProjects, selectAllProjects } from '../slices/projects.slice'
 
 export function useProjects() {
   const dispatch = useDispatch<any>()

--- a/libs/domains/projects/src/lib/slices/projects.slice.spec.ts
+++ b/libs/domains/projects/src/lib/slices/projects.slice.spec.ts
@@ -5,6 +5,7 @@ describe('projects reducer', () => {
     const expected = projectsAdapter.getInitialState({
       loadingStatus: 'not loaded',
       error: null,
+      joinOrganizationProject: {},
     })
 
     expect(projects(undefined, { type: '' })).toEqual(expected)

--- a/libs/pages/application/feature/src/lib/application-page.tsx
+++ b/libs/pages/application/feature/src/lib/application-page.tsx
@@ -4,7 +4,7 @@ import { selectApplicationById, useApplications } from '@console/domains/applica
 import { useParams } from 'react-router'
 import { useSelector } from 'react-redux'
 import { useEffect } from 'react'
-import { selectEnvironmentById } from '@console/domains/projects'
+import { selectEnvironmentById } from '@console/domains/environment'
 
 export function ApplicationPage() {
   useDocumentTitle('Application - Qovery')

--- a/libs/pages/applications/feature/src/lib/applications-page.tsx
+++ b/libs/pages/applications/feature/src/lib/applications-page.tsx
@@ -3,8 +3,9 @@ import { Container } from '@console/pages/applications/ui'
 import { useParams } from 'react-router'
 import { selectApplicationsEntitiesByEnvId } from '@console/domains/application'
 import { useSelector } from 'react-redux'
-import { selectEnvironmentById, useEnvironments } from '@console/domains/projects'
+import { useEnvironments } from '@console/domains/projects'
 import { useEffect } from 'react'
+import { selectEnvironmentById } from '@console/domains/environment'
 
 export function ApplicationsPage() {
   useDocumentTitle('Applications - Qovery')

--- a/libs/pages/environments/feature/src/lib/components/general/general.tsx
+++ b/libs/pages/environments/feature/src/lib/components/general/general.tsx
@@ -2,10 +2,15 @@ import { useEnvironments } from '@console/domains/projects'
 import { GeneralPage } from '@console/pages/environments/ui'
 import { useEffect } from 'react'
 import { useParams } from 'react-router'
+import { useSelector } from 'react-redux'
+import { selectEnvironmentsEntitiesByProjectId } from '@console/domains/environment'
 
 export function General() {
   const { environments, getEnvironmentsStatus } = useEnvironments()
   const { projectId } = useParams()
+  const { getEnvironmentsStatus } = useEnvironments()
+  const { projectId = '' } = useParams()
+  const environments = useSelector((state) => selectEnvironmentsEntitiesByProjectId(state, projectId))
 
   useEffect(() => {
     setTimeout(() => {

--- a/libs/pages/environments/feature/src/lib/components/general/general.tsx
+++ b/libs/pages/environments/feature/src/lib/components/general/general.tsx
@@ -6,8 +6,6 @@ import { useSelector } from 'react-redux'
 import { selectEnvironmentsEntitiesByProjectId } from '@console/domains/environment'
 
 export function General() {
-  const { environments, getEnvironmentsStatus } = useEnvironments()
-  const { projectId } = useParams()
   const { getEnvironmentsStatus } = useEnvironments()
   const { projectId = '' } = useParams()
   const environments = useSelector((state) => selectEnvironmentsEntitiesByProjectId(state, projectId))

--- a/libs/shared/layout/src/lib/layout.tsx
+++ b/libs/shared/layout/src/lib/layout.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useParams } from 'react-router'
 import { useOrganization } from '@console/domains/organization'
-import { useEnvironments, useProjects } from '@console/domains/projects'
+import { selectProjectsEntitiesByOrgId, useEnvironments, useProjects } from '@console/domains/projects'
 import { useUser } from '@console/domains/user'
 import { selectApplicationById, useApplication, useApplications } from '@console/domains/application'
 import { LayoutPage } from '@console/shared/ui'
@@ -16,12 +16,13 @@ export function Layout(props: LayoutProps) {
   const { children } = props
   const { authLogout } = useAuth()
   const { organization, getOrganization } = useOrganization()
-  const { projects, getProjects } = useProjects()
+  const { getProjects } = useProjects()
   const { userSignUp, getUserSignUp } = useUser()
   const { environments, getEnvironments } = useEnvironments()
   const { applications, getApplications } = useApplications()
   const { getApplication } = useApplication()
-  const { organizationId, projectId, environmentId, applicationId = '' } = useParams()
+  const { organizationId = '', projectId, environmentId, applicationId = '' } = useParams()
+  const projects = useSelector((state) => selectProjectsEntitiesByOrgId(state, organizationId))
 
   const application = useSelector((state) => selectApplicationById(state, applicationId))
 

--- a/libs/shared/layout/src/lib/layout.tsx
+++ b/libs/shared/layout/src/lib/layout.tsx
@@ -7,6 +7,7 @@ import { selectApplicationById, useApplication, useApplications } from '@console
 import { LayoutPage } from '@console/shared/ui'
 import { useAuth } from '@console/shared/utils'
 import { useSelector } from 'react-redux'
+import { selectEnvironmentsEntitiesByProjectId } from '@console/domains/environment'
 
 export interface LayoutProps {
   children: React.ReactElement
@@ -15,13 +16,14 @@ export interface LayoutProps {
 export function Layout(props: LayoutProps) {
   const { children } = props
   const { authLogout } = useAuth()
+  const { organizationId = '', projectId = '', environmentId, applicationId = '' } = useParams()
   const { organization, getOrganization } = useOrganization()
   const { getProjects } = useProjects()
   const { userSignUp, getUserSignUp } = useUser()
-  const { environments, getEnvironments } = useEnvironments()
+  const { getEnvironments } = useEnvironments()
+  const environments = useSelector((state) => selectEnvironmentsEntitiesByProjectId(state, projectId))
   const { applications, getApplications } = useApplications()
   const { getApplication } = useApplication()
-  const { organizationId = '', projectId, environmentId, applicationId = '' } = useParams()
   const projects = useSelector((state) => selectProjectsEntitiesByOrgId(state, organizationId))
 
   const application = useSelector((state) => selectApplicationById(state, applicationId))

--- a/libs/store/data/src/lib/root.ts
+++ b/libs/store/data/src/lib/root.ts
@@ -1,16 +1,10 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { User } from 'qovery-typescript-axios'
 import { initialOrganizationState, organization, OrganizationState } from '@console/domains/organization'
-import {
-  initialProjectsState,
-  ProjectsState,
-  projects,
-  EnvironmentsState,
-  environments,
-  initialEnvironmentsState,
-} from '@console/domains/projects'
-import { initialUserSignUpState, initialUserState, user, UserSignUpState, userSignUp } from '@console/domains/user'
+import { initialProjectsState, projects, ProjectsState } from '@console/domains/projects'
+import { initialUserSignUpState, initialUserState, user, userSignUp, UserSignUpState } from '@console/domains/user'
 import { applications, ApplicationsState, initialApplicationsState } from '@console/domains/application'
+import { environments, EnvironmentsState, initialEnvironmentsState } from '@console/domains/environment'
 
 export const rootReducer = combineReducers({
   user: user,


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-370

This PR remove set the one-to-many redux relationship for the existing entities and move the slices definition in the correct libs. Before this PR, the slices where following the api-doc (for example environment slice was declared in project lib) which was not super trivial for our project. Now environment slice is declared in environment lib.

<img width="318" alt="image" src="https://user-images.githubusercontent.com/6163954/167819214-d47e6996-28ea-4e7c-be65-b96fb84ed6a0.png">

---

## PR Checklist

### Global

- [ ] This PR does not introduce any breaking change
- [x] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [x] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [x] I have included a feature flag on my feature, if applicable
