### PR TITLE
Optimise view rendering removing timeout

### DIFF
--- a/libs/domains/application/src/lib/slices/applications.slice.ts
+++ b/libs/domains/application/src/lib/slices/applications.slice.ts
@@ -19,10 +19,11 @@ const applicationMainCallsApi = new ApplicationMainCallsApi()
 
 export const fetchApplications = createAsyncThunk<Application[], { environmentId: string }>(
   'applications/fetch',
-  async (data) => {
+  async (data, thunkApi) => {
     const response = await applicationsApi.listApplication(data.environmentId).then((response) => {
       return response.data
     })
+    thunkApi.dispatch(fetchApplicationsStatus({ environmentId: data.environmentId }))
     return response.results as Application[]
   }
 )

--- a/libs/domains/environment/src/lib/slices/environments.slice.ts
+++ b/libs/domains/environment/src/lib/slices/environments.slice.ts
@@ -18,8 +18,9 @@ export const environmentsAdapter = createEntityAdapter<EnvironmentEntity>()
 
 export const fetchEnvironments = createAsyncThunk<Environment[], { projectId: string }>(
   'environments/fetch',
-  async (data) => {
+  async (data, thunkApi) => {
     const response = await environmentsApi.listEnvironment(data.projectId).then((response) => response.data)
+    thunkApi.dispatch(fetchEnvironmentsStatus({ projectId: data.projectId }))
     return response.results as Environment[]
   }
 )
@@ -60,6 +61,7 @@ export const environmentsSlice = createSlice({
             ...state.joinProjectEnvironments,
           })
         })
+
         state.loadingStatus = 'loaded'
       })
       .addCase(fetchEnvironments.rejected, (state: EnvironmentsState, action) => {

--- a/libs/pages/application/feature/src/lib/application-page.tsx
+++ b/libs/pages/application/feature/src/lib/application-page.tsx
@@ -22,7 +22,7 @@ export function ApplicationPage() {
   useEffect(() => {
     setTimeout(() => {
       environmentId && getApplicationsStatus(environmentId)
-    }, 1000)
+    })
   }, [environmentId, getApplicationsStatus])
 
   return <Container application={application} environment={environment} />

--- a/libs/pages/applications/feature/src/lib/applications-page.tsx
+++ b/libs/pages/applications/feature/src/lib/applications-page.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router'
 import { selectApplicationsEntitiesByEnvId } from '@console/domains/application'
 import { useSelector } from 'react-redux'
 import { useEnvironments } from '@console/domains/projects'
-import { useEffect } from 'react'
 import { selectEnvironmentById } from '@console/domains/environment'
 import { RootState } from '@console/shared/interfaces'
 import { Application, Environment } from 'qovery-typescript-axios'
@@ -20,11 +19,11 @@ export function ApplicationsPage() {
     selectApplicationsEntitiesByEnvId(state, environmentId)
   )
 
-  useEffect(() => {
-    setTimeout(() => {
-      projectId && getEnvironmentsStatus(projectId)
-    }, 1000)
-  }, [projectId, environmentId, getEnvironmentsStatus])
+  // useEffect(() => {
+  //   setTimeout(() => {
+  //     projectId && getEnvironmentsStatus(projectId)
+  //   })
+  // }, [projectId, environmentId, getEnvironmentsStatus])
 
   return <Container applications={applicationsByEnv} environment={environment} />
 }

--- a/libs/pages/environments/feature/src/lib/components/general/general.tsx
+++ b/libs/pages/environments/feature/src/lib/components/general/general.tsx
@@ -1,6 +1,5 @@
 import { useEnvironments } from '@console/domains/projects'
 import { GeneralPage } from '@console/pages/environments/ui'
-import { useEffect } from 'react'
 import { useParams } from 'react-router'
 import { useSelector } from 'react-redux'
 import { selectEnvironmentsEntitiesByProjectId } from '@console/domains/environment'
@@ -14,11 +13,11 @@ export function General() {
     selectEnvironmentsEntitiesByProjectId(state, projectId)
   )
 
-  useEffect(() => {
-    setTimeout(() => {
-      projectId && getEnvironmentsStatus(projectId)
-    }, 1000)
-  }, [projectId, getEnvironmentsStatus])
+  // useEffect(() => {
+  //   setTimeout(() => {
+  //     projectId && getEnvironmentsStatus(projectId)
+  //   })
+  // }, [projectId, getEnvironmentsStatus])
 
   return <GeneralPage environments={environments} />
 }


### PR DESCRIPTION
In the codebase, the statuses for environments and applications were called with a weird timeout that delayed the pages' rendering. I understood that they were here to fix a API answer race. I propose this fix to launch the call as soon as possible.
It assumes that every time we fetch the applications and the environments, we also want to automatically fetch their statuses. I think it's quite reasonable.
What do you think? With this the rendering of the pages are insanely quicker from 1,20s to 150ms!

https://user-images.githubusercontent.com/6163954/168063419-b86fd944-8103-4616-803c-88f0b8d4badb.mp4

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] I have found someone to review this PR and pinged him

### Store

- [x] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
