### PR TITLE
feat(qovery-typescript-axios): update package and enums

### DIFF
--- a/libs/domains/application/src/lib/mocks/factories/application-factory.mock.ts
+++ b/libs/domains/application/src/lib/mocks/factories/application-factory.mock.ts
@@ -17,7 +17,7 @@ export const applicationFactoryMock = (howMany: number): Application[] =>
     storage: [
       {
         id: chance.guid(),
-        type: chance.pickone(Object.values([StorageTypeEnum.AWS])),
+        type: chance.pickone(Object.values([StorageTypeEnum.FAST_SSD])),
         size: 10,
         mount_point: '',
       },

--- a/libs/domains/environment/src/lib/mocks/factories/environment-factory.mock.ts
+++ b/libs/domains/environment/src/lib/mocks/factories/environment-factory.mock.ts
@@ -1,5 +1,5 @@
 import { Chance } from 'chance'
-import { EnvironmentModeEnum, GlobalDeploymentStatus, ServiceDeploymentStatusEnum } from 'qovery-typescript-axios'
+import { EnvironmentModeEnum, StateEnum, ServiceDeploymentStatusEnum } from 'qovery-typescript-axios'
 import { EnvironmentEntity } from '@console/shared/interfaces'
 
 const chance = new Chance()
@@ -24,13 +24,7 @@ export const environmentFactoryMock = (howMany: number, noStatus = false): Envir
     status: !noStatus
       ? {
           id: `${index}`,
-          state: chance.pickone(
-            Object.values([
-              GlobalDeploymentStatus.DEPLOYED,
-              GlobalDeploymentStatus.RUNNING,
-              GlobalDeploymentStatus.STOP_ERROR,
-            ])
-          ),
+          state: chance.pickone(Object.values([StateEnum.DEPLOYED, StateEnum.RUNNING, StateEnum.STOP_ERROR])),
           message: chance.word({ length: 10 }),
           service_deployment_status: chance.pickone(Object.values([ServiceDeploymentStatusEnum.UP_TO_DATE])),
         }

--- a/libs/domains/environment/src/lib/slices/environments.slice.ts
+++ b/libs/domains/environment/src/lib/slices/environments.slice.ts
@@ -34,7 +34,7 @@ export const fetchEnvironmentsStatus = createAsyncThunk<Status[], { projectId: s
   'environments-status/fetch',
   async (data) => {
     const response = await environmentsApi
-      .getProjectEnvironmentStatus(data.projectId)
+      .getProjectEnvironmentsStatus(data.projectId)
       .then((response: any) => response.data)
     return response.results as Status[]
   }

--- a/libs/pages/application/ui/src/lib/components/container/container.tsx
+++ b/libs/pages/application/ui/src/lib/components/container/container.tsx
@@ -23,7 +23,7 @@ import {
   APPLICATION_URL,
   APPLICATION_VARIABLES_URL,
 } from '@console/shared/utils'
-import { Environment, GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { Environment, StateEnum } from 'qovery-typescript-axios'
 import { useLocation, useParams } from 'react-router'
 import { ApplicationEntity } from '@console/shared/interfaces'
 
@@ -102,7 +102,7 @@ export function Container(props: ContainerProps) {
       <Skeleton width={150} height={24} show={!application?.status}>
         <StatusMenu
           statusActions={{
-            status: application?.status ? application?.status.state : GlobalDeploymentStatus.RUNNING,
+            status: application?.status ? application?.status.state : StateEnum.RUNNING,
             actions: [],
           }}
         />
@@ -127,7 +127,7 @@ export function Container(props: ContainerProps) {
 
   const tabsItems = [
     {
-      icon: <StatusChip status={GlobalDeploymentStatus.READY} />,
+      icon: <StatusChip status={StateEnum.READY} />,
       name: 'Overview',
       active:
         location.pathname ===

--- a/libs/pages/applications/ui/src/lib/components/container/container.tsx
+++ b/libs/pages/applications/ui/src/lib/components/container/container.tsx
@@ -1,4 +1,4 @@
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { useLocation, useParams } from 'react-router'
 import { APPLICATIONS_GENERAL_URL, APPLICATIONS_URL } from '@console/shared/utils'
 import {
@@ -43,7 +43,7 @@ export function Container(props: ContainerProps) {
       <Skeleton width={150} height={24} show={!environment?.status}>
         <StatusMenu
           statusActions={{
-            status: environment?.status ? environment?.status.state : GlobalDeploymentStatus.RUNNING,
+            status: environment?.status ? environment?.status.state : StateEnum.RUNNING,
             actions: [],
           }}
         />
@@ -86,7 +86,7 @@ export function Container(props: ContainerProps) {
       <Skeleton width={154} height={32} show={!environment?.status}>
         <ButtonAction
           statusActions={{
-            status: environment?.status ? environment?.status.state : GlobalDeploymentStatus.RUNNING,
+            status: environment?.status ? environment?.status.state : StateEnum.RUNNING,
             actions: [],
           }}
           iconRight="icon-solid-plus"

--- a/libs/pages/applications/ui/src/lib/components/table-row-applications/table-row-applications.tsx
+++ b/libs/pages/applications/ui/src/lib/components/table-row-applications/table-row-applications.tsx
@@ -14,7 +14,7 @@ import {
   TagCommit,
 } from '@console/shared/ui'
 import { timeAgo } from '@console/shared/utils'
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 
 export interface TableRowApplicationsProps {
   data: ApplicationEntity
@@ -61,7 +61,7 @@ export function TableRowApplications(props: TableRowApplicationsProps) {
           <Skeleton show={isLoading} width={200} height={16}>
             <div className="flex">
               <p className="leading-7 text-text-400 text-sm mr-3">
-                {data.status && data.status.state === GlobalDeploymentStatus.RUNNING ? (
+                {data.status && data.status.state === StateEnum.RUNNING ? (
                   <>
                     {timeAgo(data.updated_at ? new Date(data.updated_at) : new Date(data.created_at))}
                     <IconFa name="icon-solid-clock" className="ml-1 text-xxs" />

--- a/libs/pages/environments/ui/src/lib/components/table-row-environments/table-row-environments.tsx
+++ b/libs/pages/environments/ui/src/lib/components/table-row-environments/table-row-environments.tsx
@@ -1,4 +1,4 @@
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import {
   ButtonIconAction,
   Icon,
@@ -77,7 +77,7 @@ export function TableRowEnvironments(props: TableRowEnvironmentsProps) {
           <Skeleton show={isLoading} width={200} height={16}>
             <div className="flex">
               <p className="leading-7 text-text-400 text-sm mr-3">
-                {data.status && data.status.state === GlobalDeploymentStatus.RUNNING ? (
+                {data.status && data.status.state === StateEnum.RUNNING ? (
                   <>
                     {timeAgo(data.updated_at ? new Date(data.updated_at) : new Date(data.created_at))}
                     <IconFa name="icon-solid-clock" className="ml-1 text-xxs" />

--- a/libs/shared/ui/src/lib/components/buttons/button-action/button-action.tsx
+++ b/libs/shared/ui/src/lib/components/buttons/button-action/button-action.tsx
@@ -1,6 +1,6 @@
 import { IconEnum } from '@console/shared/enums'
 import { Icon, StatusMenuAction, StatusMenuActions } from '@console/shared/ui'
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import Menu, { MenuAlign } from '../../menu/menu'
@@ -23,7 +23,7 @@ export interface ButtonActionProps {
   onClick?: () => void
   menus?: { items: MenuItemProps[]; title?: string; button?: string; buttonLink?: string; search?: boolean }[]
   statusActions?: {
-    status: GlobalDeploymentStatus
+    status: StateEnum
     // @todo remove "any" after connected all status update
     actions: StatusMenuActions | any
   }

--- a/libs/shared/ui/src/lib/components/buttons/button-icon-action/button-icon-action-element/button-icon-action-element.tsx
+++ b/libs/shared/ui/src/lib/components/buttons/button-icon-action/button-icon-action-element/button-icon-action-element.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { Menu, StatusMenuInformation, StatusMenuActions } from '@console/shared/ui'
 import { MenuItemProps } from '../../../menu/menu-item/menu-item'
 import StatusMenuAction from '../../../status-menu-action/status-menu-action'
@@ -13,7 +13,7 @@ export interface ButtonIconActionElementProps {
   }[]
   menusClassName?: string
   statusActions?: {
-    status: GlobalDeploymentStatus | undefined
+    status: StateEnum | undefined
     // @todo remove "any" after connected all status update
     actions: StatusMenuActions | any
   }

--- a/libs/shared/ui/src/lib/components/status-chip/status-chip.spec.tsx
+++ b/libs/shared/ui/src/lib/components/status-chip/status-chip.spec.tsx
@@ -1,4 +1,4 @@
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { screen, render } from '__tests__/utils/setup-jest'
 
 import StatusChip, { StatusChipProps } from './status-chip'
@@ -8,7 +8,7 @@ describe('StatusChip', () => {
 
   beforeEach(() => {
     props = {
-      status: GlobalDeploymentStatus.DEPLOYED,
+      status: StateEnum.DEPLOYED,
     }
   })
 
@@ -18,7 +18,7 @@ describe('StatusChip', () => {
   })
 
   it('should have an error icon', () => {
-    props.status = GlobalDeploymentStatus.STOP_ERROR
+    props.status = StateEnum.STOP_ERROR
 
     render(<StatusChip {...props} />)
 

--- a/libs/shared/ui/src/lib/components/status-chip/status-chip.tsx
+++ b/libs/shared/ui/src/lib/components/status-chip/status-chip.tsx
@@ -1,10 +1,10 @@
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { IconEnum } from '@console/shared/enums'
 import { upperCaseFirstLetter } from '@console/shared/utils'
 import { Icon, Tooltip } from '@console/shared/ui'
 
 export interface StatusChipProps {
-  status: GlobalDeploymentStatus | undefined
+  status: StateEnum | undefined
   className?: string
 }
 
@@ -13,13 +13,11 @@ export function StatusChip(props: StatusChipProps) {
 
   function showReadyIcon(): boolean {
     switch (status) {
-      case GlobalDeploymentStatus.READY:
+      case StateEnum.READY:
         return true
-      case GlobalDeploymentStatus.BUILT:
+      case StateEnum.DEPLOYED:
         return true
-      case GlobalDeploymentStatus.DEPLOYED:
-        return true
-      case GlobalDeploymentStatus.RUNNING:
+      case StateEnum.RUNNING:
         return true
       default:
         return false
@@ -28,19 +26,21 @@ export function StatusChip(props: StatusChipProps) {
 
   function showProgressIcon(): boolean {
     switch (status) {
-      case GlobalDeploymentStatus.BUILDING:
+      case StateEnum.BUILDING:
         return true
-      case GlobalDeploymentStatus.STOPPING:
+      case StateEnum.STOPPING:
         return true
-      case GlobalDeploymentStatus.DEPLOYING:
+      case StateEnum.DEPLOYING:
         return true
-      case GlobalDeploymentStatus.DELETING:
+      case StateEnum.DELETING:
         return true
-      case GlobalDeploymentStatus.STOP_QUEUED:
+      case StateEnum.STOP_QUEUED:
         return true
-      case GlobalDeploymentStatus.QUEUED:
+      case StateEnum.QUEUED:
         return true
-      case GlobalDeploymentStatus.DELETE_QUEUED:
+      case StateEnum.DELETE_QUEUED:
+        return true
+      case StateEnum.DEPLOYMENT_QUEUED:
         return true
       default:
         return false
@@ -49,15 +49,11 @@ export function StatusChip(props: StatusChipProps) {
 
   function showErrorIcon(): boolean {
     switch (status) {
-      case GlobalDeploymentStatus.BUILD_ERROR:
+      case StateEnum.DEPLOYMENT_ERROR:
         return true
-      case GlobalDeploymentStatus.DEPLOYMENT_ERROR:
+      case StateEnum.STOP_ERROR:
         return true
-      case GlobalDeploymentStatus.STOP_ERROR:
-        return true
-      case GlobalDeploymentStatus.DELETE_ERROR:
-        return true
-      case GlobalDeploymentStatus.RUNNING_ERROR:
+      case StateEnum.DELETE_ERROR:
         return true
       default:
         return false
@@ -66,7 +62,7 @@ export function StatusChip(props: StatusChipProps) {
 
   function showStoppedIcon(): boolean {
     switch (status) {
-      case GlobalDeploymentStatus.STOPPED:
+      case StateEnum.STOPPED:
         return true
       default:
         return false
@@ -75,7 +71,7 @@ export function StatusChip(props: StatusChipProps) {
 
   function showDeletedIcon(): boolean {
     switch (status) {
-      case GlobalDeploymentStatus.DELETED:
+      case StateEnum.DELETED:
         return true
       default:
         return false

--- a/libs/shared/ui/src/lib/components/status-label/status-label.spec.tsx
+++ b/libs/shared/ui/src/lib/components/status-label/status-label.spec.tsx
@@ -1,4 +1,4 @@
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { screen, render } from '__tests__/utils/setup-jest'
 
 import StatusLabel, { StatusLabelProps } from './status-label'
@@ -8,7 +8,7 @@ describe('StatusLabel', () => {
 
   beforeEach(() => {
     props = {
-      status: GlobalDeploymentStatus.DEPLOYED,
+      status: StateEnum.DEPLOYED,
     }
   })
 
@@ -18,7 +18,7 @@ describe('StatusLabel', () => {
   })
 
   it('should have an error icon', () => {
-    props.status = GlobalDeploymentStatus.BUILD_ERROR
+    props.status = StateEnum.DEPLOYMENT_ERROR
 
     render(<StatusLabel {...props} />)
 

--- a/libs/shared/ui/src/lib/components/status-label/status-label.tsx
+++ b/libs/shared/ui/src/lib/components/status-label/status-label.tsx
@@ -1,10 +1,10 @@
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { upperCaseFirstLetter } from '@console/shared/utils'
 import { IconEnum } from '@console/shared/enums'
 import { Icon } from '@console/shared/ui'
 
 export interface StatusLabelProps {
-  status: GlobalDeploymentStatus | undefined
+  status: StateEnum | undefined
   className?: string
 }
 
@@ -13,13 +13,13 @@ export function StatusLabel(props: StatusLabelProps) {
 
   function showProgressIcon(): boolean {
     switch (status) {
-      case GlobalDeploymentStatus.BUILDING:
+      case StateEnum.BUILDING:
         return true
-      case GlobalDeploymentStatus.STOPPING:
+      case StateEnum.STOPPING:
         return true
-      case GlobalDeploymentStatus.DEPLOYING:
+      case StateEnum.DEPLOYING:
         return true
-      case GlobalDeploymentStatus.DELETING:
+      case StateEnum.DELETING:
         return true
       default:
         return false
@@ -28,11 +28,11 @@ export function StatusLabel(props: StatusLabelProps) {
 
   // function showSpinnerIcon(): boolean {
   //   switch (status) {
-  //     case GlobalDeploymentStatus.STOP_QUEUED:
+  //     case StateEnum.STOP_QUEUED:
   //       return true
-  //     case GlobalDeploymentStatus.QUEUED:
+  //     case StateEnum.QUEUED:
   //       return true
-  //     case GlobalDeploymentStatus.DELETE_QUEUED:
+  //     case StateEnum.DELETE_QUEUED:
   //       return true
   //     default:
   //       return false
@@ -41,15 +41,11 @@ export function StatusLabel(props: StatusLabelProps) {
 
   function showErrorIcon(): boolean {
     switch (status) {
-      case GlobalDeploymentStatus.BUILD_ERROR:
+      case StateEnum.DEPLOYMENT_ERROR:
         return true
-      case GlobalDeploymentStatus.DEPLOYMENT_ERROR:
+      case StateEnum.STOP_ERROR:
         return true
-      case GlobalDeploymentStatus.STOP_ERROR:
-        return true
-      case GlobalDeploymentStatus.DELETE_ERROR:
-        return true
-      case GlobalDeploymentStatus.RUNNING_ERROR:
+      case StateEnum.DELETE_ERROR:
         return true
       default:
         return false

--- a/libs/shared/ui/src/lib/components/status-menu-action/status-menu-action.spec.tsx
+++ b/libs/shared/ui/src/lib/components/status-menu-action/status-menu-action.spec.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@console/shared/ui'
 import { render } from '__tests__/utils/setup-jest'
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { StatusMenuAction, StatusMenuActionProps } from './status-menu-action'
 
 let props: StatusMenuActionProps
@@ -8,7 +8,7 @@ let props: StatusMenuActionProps
 beforeEach(() => {
   props = {
     statusActions: {
-      status: GlobalDeploymentStatus.DEPLOYED,
+      status: StateEnum.DEPLOYED,
       actions: [
         {
           name: 'deploy',

--- a/libs/shared/ui/src/lib/components/status-menu-action/status-menu-action.tsx
+++ b/libs/shared/ui/src/lib/components/status-menu-action/status-menu-action.tsx
@@ -7,14 +7,14 @@ import {
   isStopAvailable,
 } from '@console/shared/utils'
 import { ClickEvent } from '@szhsin/react-menu'
-import { EnvironmentModeEnum, GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { EnvironmentModeEnum, StateEnum } from 'qovery-typescript-axios'
 import { useState, useEffect, useContext } from 'react'
 import Menu, { MenuAlign, MenuDirection } from '../menu/menu'
 
 export interface StatusMenuActionProps {
   trigger: React.ReactElement
   statusActions: {
-    status: GlobalDeploymentStatus | undefined
+    status: StateEnum | undefined
     // @todo remove "any" after connected all status update
     actions: StatusMenuActions | any
   }

--- a/libs/shared/ui/src/lib/components/status-menu/status-menu.spec.tsx
+++ b/libs/shared/ui/src/lib/components/status-menu/status-menu.spec.tsx
@@ -2,7 +2,7 @@ import { render } from '__tests__/utils/setup-jest'
 import { screen } from '@testing-library/react'
 import StatusMenu, { StatusMenuProps } from './status-menu'
 import { ClickEvent } from '@szhsin/react-menu'
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 
 let props: StatusMenuProps
 
@@ -13,7 +13,7 @@ const clickAction = (e: ClickEvent, status: string) => {
 beforeEach(() => {
   props = {
     statusActions: {
-      status: GlobalDeploymentStatus.RUNNING,
+      status: StateEnum.RUNNING,
       actions: [
         {
           name: 'deploy',
@@ -31,7 +31,7 @@ describe('StatusMenu', () => {
   })
 
   it('should have accurate status', () => {
-    props.statusActions.status = GlobalDeploymentStatus.BUILD_ERROR
+    props.statusActions.status = StateEnum.DEPLOYMENT_ERROR
     render(<StatusMenu {...props} />)
     setTimeout(() => {
       const statusMenu = screen.getByTestId('statusmenu')

--- a/libs/shared/ui/src/lib/components/status-menu/status-menu.stories.tsx
+++ b/libs/shared/ui/src/lib/components/status-menu/status-menu.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react'
 import { select } from '@storybook/addon-knobs'
 import { ClickEvent } from '@szhsin/react-menu'
 import Icon from '../icon/icon'
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 
 export default {
   component: StatusMenu,
@@ -55,5 +55,5 @@ const Template: Story<StatusMenuProps> = (args) => <StatusMenu {...args} />
 export const Primary = Template.bind({})
 
 Primary.args = {
-  status: select('Status', GlobalDeploymentStatus, GlobalDeploymentStatus.RUNNING),
+  status: select('Status', StateEnum, StateEnum.RUNNING),
 }

--- a/libs/shared/ui/src/lib/components/status-menu/status-menu.tsx
+++ b/libs/shared/ui/src/lib/components/status-menu/status-menu.tsx
@@ -1,6 +1,6 @@
 import { StatusMenuAction, StatusMenuActions } from '@console/shared/ui'
 import { upperCaseFirstLetter } from '@console/shared/utils'
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { useState } from 'react'
 import Icon from '../icon/icon'
 
@@ -12,7 +12,7 @@ export enum StatusMenuType {
 }
 export interface StatusMenuProps {
   statusActions: {
-    status: GlobalDeploymentStatus
+    status: StateEnum
     // @todo remove "any" after connected all status update
     actions: StatusMenuActions | any
   }
@@ -23,27 +23,21 @@ export function StatusMenu(props: StatusMenuProps) {
 
   const [open, setOpen] = useState(false)
 
-  const getType = (currentStatus: GlobalDeploymentStatus) => {
+  const getType = (currentStatus: StateEnum) => {
     switch (currentStatus) {
-      case GlobalDeploymentStatus.RUNNING ||
-        GlobalDeploymentStatus.READY ||
-        GlobalDeploymentStatus.QUEUED ||
-        GlobalDeploymentStatus.BUILDING ||
-        GlobalDeploymentStatus.BUILT ||
-        GlobalDeploymentStatus.DEPLOYED:
+      case StateEnum.RUNNING || StateEnum.READY || StateEnum.QUEUED || StateEnum.BUILDING || StateEnum.DEPLOYED:
         return StatusMenuType.AVAILABLE
-      case GlobalDeploymentStatus.STOPPED || GlobalDeploymentStatus.STOP_QUEUED:
+      case StateEnum.STOPPED || StateEnum.STOP_QUEUED:
         return StatusMenuType.STOP
-      case GlobalDeploymentStatus.DEPLOYMENT_ERROR ||
-        GlobalDeploymentStatus.DELETE_QUEUED ||
-        GlobalDeploymentStatus.BUILD_ERROR ||
-        GlobalDeploymentStatus.STOP_ERROR ||
-        GlobalDeploymentStatus.DELETING ||
-        GlobalDeploymentStatus.DELETE_ERROR ||
-        GlobalDeploymentStatus.DELETED ||
-        GlobalDeploymentStatus.RUNNING_ERROR:
+      case StateEnum.DEPLOYMENT_ERROR ||
+        StateEnum.DELETE_QUEUED ||
+        StateEnum.STOP_ERROR ||
+        StateEnum.DELETING ||
+        StateEnum.DELETE_ERROR ||
+        StateEnum.DELETED ||
+        StateEnum.DEPLOYMENT_QUEUED:
         return StatusMenuType.WARNING
-      case GlobalDeploymentStatus.DEPLOYING || GlobalDeploymentStatus.STOPPING:
+      case StateEnum.DEPLOYING || StateEnum.STOPPING:
         return StatusMenuType.RUNNING
       default:
         return StatusMenuType.AVAILABLE

--- a/libs/shared/utils/src/lib/tools/status-actions-available.tsx
+++ b/libs/shared/utils/src/lib/tools/status-actions-available.tsx
@@ -1,89 +1,76 @@
-import { GlobalDeploymentStatus } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 
-export const isDeployAvailable = (status: GlobalDeploymentStatus): boolean => {
+export const isDeployAvailable = (status: StateEnum): boolean => {
+  return status === StateEnum.READY || status === StateEnum.STOPPED || status === StateEnum.DELETED
+}
+
+export const isRestartAvailable = (status: StateEnum): boolean => {
   return (
-    status === GlobalDeploymentStatus.READY ||
-    status === GlobalDeploymentStatus.STOPPED ||
-    status === GlobalDeploymentStatus.DELETED
+    status === StateEnum.BUILDING ||
+    status === StateEnum.QUEUED ||
+    status === StateEnum.STOP_QUEUED ||
+    status === StateEnum.DELETE_QUEUED ||
+    status === StateEnum.DEPLOYING ||
+    status === StateEnum.DEPLOYMENT_ERROR ||
+    status === StateEnum.DEPLOYED ||
+    status === StateEnum.STOPPING ||
+    status === StateEnum.STOP_ERROR ||
+    status === StateEnum.DELETING ||
+    status === StateEnum.DELETE_ERROR ||
+    status === StateEnum.RUNNING ||
+    status === StateEnum.DEPLOYMENT_QUEUED
   )
 }
 
-export const isRestartAvailable = (status: GlobalDeploymentStatus): boolean => {
+export const isStopAvailable = (status: StateEnum): boolean => {
   return (
-    status === GlobalDeploymentStatus.BUILDING ||
-    status === GlobalDeploymentStatus.QUEUED ||
-    status === GlobalDeploymentStatus.STOP_QUEUED ||
-    status === GlobalDeploymentStatus.DELETE_QUEUED ||
-    status === GlobalDeploymentStatus.BUILD_ERROR ||
-    status === GlobalDeploymentStatus.BUILT ||
-    status === GlobalDeploymentStatus.DEPLOYING ||
-    status === GlobalDeploymentStatus.DEPLOYMENT_ERROR ||
-    status === GlobalDeploymentStatus.DEPLOYED ||
-    status === GlobalDeploymentStatus.STOPPING ||
-    status === GlobalDeploymentStatus.STOP_ERROR ||
-    status === GlobalDeploymentStatus.DELETING ||
-    status === GlobalDeploymentStatus.DELETE_ERROR ||
-    status === GlobalDeploymentStatus.RUNNING ||
-    status === GlobalDeploymentStatus.RUNNING_ERROR
+    status === StateEnum.BUILDING ||
+    status === StateEnum.QUEUED ||
+    status === StateEnum.STOP_QUEUED ||
+    status === StateEnum.DELETE_QUEUED ||
+    status === StateEnum.DEPLOYING ||
+    status === StateEnum.DEPLOYED ||
+    status === StateEnum.DELETING ||
+    status === StateEnum.RUNNING ||
+    status === StateEnum.DEPLOYMENT_ERROR ||
+    status === StateEnum.DEPLOYMENT_QUEUED
   )
 }
 
-export const isStopAvailable = (status: GlobalDeploymentStatus): boolean => {
+export const isRollbackAvailable = (status: StateEnum): boolean => {
   return (
-    status === GlobalDeploymentStatus.BUILDING ||
-    status === GlobalDeploymentStatus.QUEUED ||
-    status === GlobalDeploymentStatus.STOP_QUEUED ||
-    status === GlobalDeploymentStatus.DELETE_QUEUED ||
-    status === GlobalDeploymentStatus.BUILT ||
-    status === GlobalDeploymentStatus.DEPLOYING ||
-    status === GlobalDeploymentStatus.DEPLOYED ||
-    status === GlobalDeploymentStatus.DELETING ||
-    status === GlobalDeploymentStatus.RUNNING ||
-    status === GlobalDeploymentStatus.DEPLOYMENT_ERROR ||
-    status === GlobalDeploymentStatus.RUNNING_ERROR
+    status === StateEnum.DEPLOYMENT_ERROR ||
+    status === StateEnum.STOP_ERROR ||
+    status === StateEnum.STOPPED ||
+    status === StateEnum.DELETE_ERROR ||
+    status === StateEnum.DELETED ||
+    status === StateEnum.RUNNING
   )
 }
 
-export const isRollbackAvailable = (status: GlobalDeploymentStatus): boolean => {
+export const isDeleteAvailable = (status: StateEnum): boolean => {
   return (
-    status === GlobalDeploymentStatus.BUILD_ERROR ||
-    status === GlobalDeploymentStatus.DEPLOYMENT_ERROR ||
-    status === GlobalDeploymentStatus.STOP_ERROR ||
-    status === GlobalDeploymentStatus.STOPPED ||
-    status === GlobalDeploymentStatus.DELETE_ERROR ||
-    status === GlobalDeploymentStatus.DELETED ||
-    status === GlobalDeploymentStatus.RUNNING ||
-    status === GlobalDeploymentStatus.RUNNING_ERROR
+    status === StateEnum.READY ||
+    status === StateEnum.DEPLOYMENT_ERROR ||
+    status === StateEnum.STOPPING ||
+    status === StateEnum.STOP_ERROR ||
+    status === StateEnum.STOPPED ||
+    status === StateEnum.DELETE_ERROR ||
+    status === StateEnum.RUNNING
   )
 }
 
-export const isDeleteAvailable = (status: GlobalDeploymentStatus): boolean => {
+export const isUpdateAvailable = (status: StateEnum): boolean => {
   return (
-    status === GlobalDeploymentStatus.READY ||
-    status === GlobalDeploymentStatus.BUILD_ERROR ||
-    status === GlobalDeploymentStatus.DEPLOYMENT_ERROR ||
-    status === GlobalDeploymentStatus.STOPPING ||
-    status === GlobalDeploymentStatus.STOP_ERROR ||
-    status === GlobalDeploymentStatus.STOPPED ||
-    status === GlobalDeploymentStatus.DELETE_ERROR ||
-    status === GlobalDeploymentStatus.RUNNING ||
-    status === GlobalDeploymentStatus.RUNNING_ERROR
+    status === StateEnum.DEPLOYMENT_ERROR ||
+    status === StateEnum.STOP_ERROR ||
+    status === StateEnum.STOPPED ||
+    status === StateEnum.DELETE_ERROR ||
+    status === StateEnum.DELETED ||
+    status === StateEnum.RUNNING
   )
 }
 
-export const isUpdateAvailable = (status: GlobalDeploymentStatus): boolean => {
-  return (
-    status === GlobalDeploymentStatus.BUILD_ERROR ||
-    status === GlobalDeploymentStatus.DEPLOYMENT_ERROR ||
-    status === GlobalDeploymentStatus.STOP_ERROR ||
-    status === GlobalDeploymentStatus.STOPPED ||
-    status === GlobalDeploymentStatus.DELETE_ERROR ||
-    status === GlobalDeploymentStatus.DELETED ||
-    status === GlobalDeploymentStatus.RUNNING ||
-    status === GlobalDeploymentStatus.RUNNING_ERROR
-  )
-}
-
-export const isCancelBuildAvailable = (status: GlobalDeploymentStatus): boolean => {
-  return status === GlobalDeploymentStatus.BUILDING || status === GlobalDeploymentStatus.DEPLOYING
+export const isCancelBuildAvailable = (status: StateEnum): boolean => {
+  return status === StateEnum.BUILDING || status === StateEnum.DEPLOYING
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "msw": "^0.39.2",
     "postcss": "^8.4.6",
     "posthog-js": "^1.20.0",
-    "qovery-typescript-axios": "1.0.8",
+    "qovery-typescript-axios": "1.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-hook-form": "^7.31.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15307,10 +15307,10 @@ q@^1.5.1:
   resolved "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qovery-typescript-axios@1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/qovery-typescript-axios/-/qovery-typescript-axios-1.0.8.tgz#48eaaa127e6167e683ddfc70631eeb4f835fe757"
-  integrity sha512-0pjF1QDp6oJjPIjyJimzGeBfv5frz1nNp9tsXobwdnhYoU+f4s80luFRpamZq82J/VAwDxiFAse5Lp4t+v08CA==
+qovery-typescript-axios@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/qovery-typescript-axios/-/qovery-typescript-axios-1.1.0.tgz#4270a652bd2664e43dc52bc4461383c2b596b149"
+  integrity sha512-CyrXm2mpl1MKTNn+he50JbP7h/EgT75NEB3LpY1ipzUVvWV+OUip4jCPTwpmBwaultKHvUAMru/mKo+RMcjGjg==
   dependencies:
     axios "^0.21.4"
 


### PR DESCRIPTION
# What does this PR do?

- Update package open-api
- Replace `GlobalDeploymentStatus` by `StateEnum` 
- Fixed `StorageTypeEnum` and environment request status

---

## PR Checklist

### Global

- [ ] This PR does not introduce any breaking change
- [x] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
