### PR TITLE
fix(table): performance services and environments

### DIFF
--- a/libs/pages/environments/ui/src/lib/components/general/general.tsx
+++ b/libs/pages/environments/ui/src/lib/components/general/general.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import { BaseLink, HelpSection, StatusMenuActions, Table } from '@console/shared/ui'
 import { SERVICES_GENERAL_URL, SERVICES_URL } from '@console/shared/router'
@@ -11,7 +11,7 @@ export interface GeneralProps {
   listHelpfulLinks: BaseLink[]
 }
 
-export function GeneralPage(props: GeneralProps) {
+function General(props: GeneralProps) {
   const { environments, buttonActions, listHelpfulLinks } = props
   const { organizationId, projectId } = useParams()
 
@@ -90,4 +90,15 @@ export function GeneralPage(props: GeneralProps) {
   )
 }
 
-export default GeneralPage
+export const GeneralPage = React.memo(General, (prevProps, nextProps) => {
+  // Stringify is necessary to avoid Redux selector behavior
+  const isEqual =
+    JSON.stringify(prevProps.environments.map((environment) => environment.status?.state)) ===
+    JSON.stringify(nextProps.environments.map((environment) => environment.status?.state))
+
+  if (isEqual) {
+    return true
+  }
+
+  return false
+})

--- a/libs/pages/services/ui/src/lib/components/general/general.tsx
+++ b/libs/pages/services/ui/src/lib/components/general/general.tsx
@@ -1,19 +1,19 @@
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'react-router'
 import { ServicesEnum } from '@console/shared/enums'
 import { ApplicationEntity, DatabaseEntity } from '@console/shared/interfaces'
 import { BaseLink, HelpSection, StatusMenuActions, Table } from '@console/shared/ui'
 import { APPLICATION_URL, SERVICES_GENERAL_URL } from '@console/shared/router'
-import { useEffect, useState } from 'react'
-import { useParams } from 'react-router'
 import TableRowServices from '../table-row-services/table-row-services'
 
-export interface GeneralPageProps {
+export interface GeneralProps {
   environmentMode: string
   services: (ApplicationEntity | DatabaseEntity)[]
   buttonActions: StatusMenuActions[]
   listHelpfulLinks: BaseLink[]
 }
 
-export function GeneralPage(props: GeneralPageProps) {
+function General(props: GeneralProps) {
   const { environmentMode, services, buttonActions, listHelpfulLinks } = props
   const { organizationId, projectId, environmentId } = useParams()
 
@@ -93,4 +93,15 @@ export function GeneralPage(props: GeneralPageProps) {
   )
 }
 
-export default GeneralPage
+export const GeneralPage = React.memo(General, (prevProps, nextProps) => {
+  // Stringify is necessary to avoid Redux selector behavior
+  const isEqual =
+    JSON.stringify(prevProps.services.map((service) => service.status?.state)) ===
+    JSON.stringify(nextProps.services.map((service) => service.status?.state))
+
+  if (isEqual) {
+    return true
+  }
+
+  return false
+})

--- a/libs/shared/ui/src/lib/components/table/table.tsx
+++ b/libs/shared/ui/src/lib/components/table/table.tsx
@@ -1,5 +1,5 @@
 import { TableHeadSort } from '@console/shared/ui'
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import React, { Dispatch, SetStateAction, useState } from 'react'
 import { TableHeadFilter } from './table-head-filter/table-head-filter'
 
 export interface TableProps {


### PR DESCRIPTION
# What does this PR do?

- Fix issue performance for Table, no useless re-render now, even with auto-refetch status

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
