### PR TITLE
Application overview improved

### DIFF
--- a/libs/pages/application/src/lib/feature/page-general-feature/page-general-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-general-feature/page-general-feature.tsx
@@ -20,7 +20,24 @@ export function PageGeneralFeature() {
   ]
   const loadingStatus = useSelector<RootState, LoadingStatus>((state) => applicationsLoadingStatus(state))
 
-  return <PageGeneral application={application} listHelpfulLinks={listHelpfulLinks} loadingStatus={loadingStatus} />
+  const computeStability = (): number => {
+    let c = 0
+
+    application?.running_status?.pods.forEach((pod) => {
+      c += pod.restart_count
+    })
+
+    return c
+  }
+
+  return (
+    <PageGeneral
+      application={application}
+      listHelpfulLinks={listHelpfulLinks}
+      loadingStatus={loadingStatus}
+      serviceStability={computeStability()}
+    />
+  )
 }
 
 export default PageGeneralFeature

--- a/libs/pages/application/src/lib/ui/instances-table/instances-table.tsx
+++ b/libs/pages/application/src/lib/ui/instances-table/instances-table.tsx
@@ -23,10 +23,10 @@ export function InstancesTable(props: InstancesTableProps) {
             <tr className="text-xs text-text-500 font-medium" key={instance.name}>
               <td className="border border-element-light-lighter-400 px-6 py-4">{instance.name}</td>
               <td className="border border-element-light-lighter-400 px-6 py-4">
-                {instance.memory?.consumed_in_percent}%
+                {Math.round((instance.memory?.consumed_in_percent || 0) * 10) / 10}%
               </td>
               <td className="border border-element-light-lighter-400 px-6 py-4">
-                {instance.cpu?.consumed_in_percent}%
+                {Math.round((instance.cpu?.consumed_in_percent || 0) * 10) / 10}%
               </td>
               <td className="border border-element-light-lighter-400 px-6 py-4">–</td>
             </tr>

--- a/libs/pages/application/src/lib/ui/page-general/page-general.tsx
+++ b/libs/pages/application/src/lib/ui/page-general/page-general.tsx
@@ -26,12 +26,12 @@ export function PageGeneral(props: PageGeneralProps) {
               </Skeleton>
             </div>
             <div className="flex-1  px-6 py-3">
-              <strong className="text-sm mb-1 text-text-400">Service Stability</strong>
+              <strong className="text-sm mb-1 text-text-400">Service Restart</strong>
               <div className="h4 text-black flex items-center gap-2">
                 {serviceStability}{' '}
                 <Tooltip
                   side="right"
-                  content="Number of application instance restarts since the last rollout due to application errors"
+                  content="Number of application instance restarts since the last deployment due to application errors"
                 >
                   <div className="flex items-center">
                     <Icon className="text-caption text-element-light-lighter-700" name="icon-solid-circle-info"></Icon>

--- a/libs/pages/application/src/lib/ui/page-general/page-general.tsx
+++ b/libs/pages/application/src/lib/ui/page-general/page-general.tsx
@@ -1,5 +1,5 @@
 import { ApplicationEntity, LoadingStatus } from '@console/shared/interfaces'
-import { BaseLink, HelpSection, Skeleton } from '@console/shared/ui'
+import { BaseLink, HelpSection, Icon, Skeleton, Tooltip } from '@console/shared/ui'
 import About from '../about/about'
 import InstancesTable from '../instances-table/instances-table'
 import LastCommitFeature from '../../feature/last-commit-feature/last-commit-feature'
@@ -8,10 +8,11 @@ export interface PageGeneralProps {
   application?: ApplicationEntity
   listHelpfulLinks: BaseLink[]
   loadingStatus?: LoadingStatus
+  serviceStability?: number
 }
 
 export function PageGeneral(props: PageGeneralProps) {
-  const { application, listHelpfulLinks, loadingStatus } = props
+  const { application, listHelpfulLinks, loadingStatus, serviceStability = 0 } = props
 
   return (
     <div className="mt-2 bg-white rounded flex flex-grow min-h-0">
@@ -26,7 +27,17 @@ export function PageGeneral(props: PageGeneralProps) {
             </div>
             <div className="flex-1  px-6 py-3">
               <strong className="text-sm mb-1 text-text-400">Service Stability</strong>
-              <div className="h4 text-black">–</div>
+              <div className="h4 text-black flex items-center gap-2">
+                {serviceStability}{' '}
+                <Tooltip
+                  side="right"
+                  content="Number of application instance restarts since the last rollout due to application errors"
+                >
+                  <div className="flex items-center">
+                    <Icon className="text-caption text-element-light-lighter-700" name="icon-solid-circle-info"></Icon>
+                  </div>
+                </Tooltip>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
# What does this PR do?

- Stability: https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-436
- Rounding: https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-417

This pr implement the rounding of the percentage in the application overview and display the stability but for this point, I think that it's super weird to display `Service Stability: 0` and this means that application is alright there is no problem. It means that there were no reboot. But I read it that the score of my stability is 0. Could we not change the wording to fix that? 

<img width="1920" alt="CleanShot 2022-06-21 at 15 40 49@2x" src="https://user-images.githubusercontent.com/6163954/174813837-92f4d042-c01c-4213-a786-6c73112a3387.png">

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
