### PR TITLE
Fix/Align breadcrumb style for service

### DIFF
--- a/libs/pages/database/src/lib/feature/page-settings-feature/page-settings-feature.tsx
+++ b/libs/pages/database/src/lib/feature/page-settings-feature/page-settings-feature.tsx
@@ -1,9 +1,7 @@
+import PageSettings from '../../ui/page-settings/page-settings'
+
 export function PageSettingsFeature() {
-  return (
-    <div>
-      <h1>Welcome to Settings!</h1>
-    </div>
-  )
+  return <PageSettings />
 }
 
 export default PageSettingsFeature

--- a/libs/pages/database/src/lib/ui/container/container.tsx
+++ b/libs/pages/database/src/lib/ui/container/container.tsx
@@ -11,12 +11,12 @@ import {
   TagMode,
 } from '@console/shared/ui'
 import {
-  DATABASE_DEPLOYMENTS_URL,
+  //DATABASE_DEPLOYMENTS_URL,
   DATABASE_GENERAL_URL,
-  DATABASE_METRICS_URL,
+  //DATABASE_METRICS_URL,
   DATABASE_SETTINGS_URL,
   DATABASE_URL,
-  DATABASE_VARIABLES_URL,
+  //DATABASE_VARIABLES_URL,
 } from '@console/shared/router'
 import { Environment } from 'qovery-typescript-axios'
 import { useLocation, useParams } from 'react-router'
@@ -102,33 +102,33 @@ export function Container(props: ContainerProps) {
         location.pathname === DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_GENERAL_URL,
       link: DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_GENERAL_URL,
     },
-    {
-      icon: (
-        <Skeleton width={16} height={16} rounded show={!database?.status}>
-          <StatusChip status={database?.status && database?.status.state} />
-        </Skeleton>
-      ),
-      name: 'Deployments',
-      active:
-        location.pathname ===
-        DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_DEPLOYMENTS_URL,
-      link: DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_DEPLOYMENTS_URL,
-    },
-    {
-      icon: <Icon name="icon-solid-chart-area" />,
-      name: 'Metrics',
-      active:
-        location.pathname === DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_METRICS_URL,
-      link: DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_METRICS_URL,
-    },
-    {
-      icon: <Icon name="icon-solid-wheel" />,
-      name: 'Variables',
-      active:
-        location.pathname ===
-        DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_VARIABLES_URL,
-      link: DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_VARIABLES_URL,
-    },
+    // {
+    //   icon: (
+    //     <Skeleton width={16} height={16} rounded show={!database?.status}>
+    //       <StatusChip status={database?.status && database?.status.state} />
+    //     </Skeleton>
+    //   ),
+    //   name: 'Deployments',
+    //   active:
+    //     location.pathname ===
+    //     DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_DEPLOYMENTS_URL,
+    //   link: DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_DEPLOYMENTS_URL,
+    // },
+    // {
+    //   icon: <Icon name="icon-solid-chart-area" />,
+    //   name: 'Metrics',
+    //   active:
+    //     location.pathname === DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_METRICS_URL,
+    //   link: DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_METRICS_URL,
+    // },
+    // {
+    //   icon: <Icon name="icon-solid-wheel" />,
+    //   name: 'Variables',
+    //   active:
+    //     location.pathname ===
+    //     DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_VARIABLES_URL,
+    //   link: DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_VARIABLES_URL,
+    // },
     {
       icon: <Icon name="icon-solid-wheel" />,
       name: 'Settings',

--- a/libs/pages/database/src/lib/ui/page-settings/page-settings.spec.tsx
+++ b/libs/pages/database/src/lib/ui/page-settings/page-settings.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react'
+
+import PageSettings from './page-settings'
+
+describe('PageSettings', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<PageSettings />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/pages/database/src/lib/ui/page-settings/page-settings.tsx
+++ b/libs/pages/database/src/lib/ui/page-settings/page-settings.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@console/shared/ui'
+import { useParams } from 'react-router'
+
+/* eslint-disable-next-line */
+export interface PageSettingsProps {}
+
+export function PageSettings(props: PageSettingsProps) {
+  const { organizationId, projectId, environmentId, databaseId } = useParams()
+
+  return (
+    <div className="bg-white flex-grow mt-2 flex justify-center items-center flex-col gap-3 rounded-b-sm">
+      <h2 className="text-text-500 text-base font-medium">
+        This feature is not available yet. Please continue your action on the V2
+      </h2>
+      <Button
+        external
+        link={`https://console.qovery.com/platform/organization/${organizationId}/projects/${projectId}/environments/${environmentId}/databases/${databaseId}/summary`}
+      >
+        Go to V2
+      </Button>
+    </div>
+  )
+}
+
+export default PageSettings

--- a/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
+++ b/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
@@ -106,48 +106,31 @@ export function Breadcrumb(props: BreadcrumbProps) {
     },
   ]
 
+  const mergedServices =
+    applications && databases && ([...applications, ...databases] as ApplicationEntity[] | DatabaseEntity[])
+
   const applicationMenu = [
     {
       title: 'Services',
       search: true,
       items: applications
-        ? [
-            ...(applications?.map((application: ApplicationEntity) => ({
-              name: application.name,
-              link: {
-                url: `${APPLICATION_URL(
-                  organizationId,
-                  projectId,
-                  environmentId,
-                  application.id
-                )}${APPLICATION_GENERAL_URL}`,
-              },
-              contentLeft: (
-                <div className="flex items-center">
-                  <StatusChip status={application.status?.state} />
-                  <div className="ml-3 mt-[1px]">
-                    <Icon name={IconEnum.APPLICATION} width="16" />
-                  </div>
+        ? (mergedServices?.map((service: ApplicationEntity | DatabaseEntity) => ({
+            name: service.name,
+            link: {
+              url: (service as DatabaseEntity).type
+                ? `${DATABASE_URL(organizationId, projectId, environmentId, service.id)}${DATABASE_GENERAL_URL}`
+                : `${APPLICATION_URL(organizationId, projectId, environmentId, service.id)}${APPLICATION_GENERAL_URL}`,
+            },
+            contentLeft: (
+              <div className="flex items-center">
+                <StatusChip status={service.status?.state} />
+                <div className="ml-3 mt-[1px]">
+                  <Icon name={(service as DatabaseEntity).type ? IconEnum.DATABASE : IconEnum.APPLICATION} width="16" />
                 </div>
-              ),
-              isActive: applicationId === application.id,
-            })) as MenuItemProps[]),
-            ...(databases?.map((database: DatabaseEntity) => ({
-              name: database.name,
-              link: {
-                url: `${DATABASE_URL(organizationId, projectId, environmentId, database.id)}${DATABASE_GENERAL_URL}`,
-              },
-              contentLeft: (
-                <div className="flex items-center">
-                  <StatusChip status={database.status?.state} />
-                  <div className="ml-3 mt-[1px]">
-                    <Icon name={IconEnum.DATABASE} width="16" />
-                  </div>
-                </div>
-              ),
-              isActive: applicationId === database.id,
-            })) as MenuItemProps[]),
-          ]
+              </div>
+            ),
+            isActive: applicationId === service.id,
+          })) as MenuItemProps[])
         : [],
     },
   ]
@@ -159,8 +142,6 @@ export function Breadcrumb(props: BreadcrumbProps) {
       {text}
     </div>
   )
-
-  const mergedServices = applications && databases && [...applications, ...databases]
 
   if (organizations?.length === 0) return <div />
 

--- a/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
+++ b/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
@@ -160,6 +160,8 @@ export function Breadcrumb(props: BreadcrumbProps) {
     </div>
   )
 
+  const mergedServices = applications && databases && [...applications, ...databases]
+
   if (organizations?.length === 0) return <div />
 
   return (
@@ -219,10 +221,14 @@ export function Breadcrumb(props: BreadcrumbProps) {
           <div className="flex items-center">
             {squareContent('S')}
             <BreadcrumbItem
-              data={applications || databases}
+              data={mergedServices}
               menuItems={applicationMenu}
               paramId={applicationId || databaseId || ''}
-              link={APPLICATION_URL(organizationId, projectId, environmentId, applicationId) + APPLICATION_GENERAL_URL}
+              link={
+                applicationId
+                  ? APPLICATION_URL(organizationId, projectId, environmentId, applicationId) + APPLICATION_GENERAL_URL
+                  : DATABASE_URL(organizationId, projectId, environmentId, databaseId) + DATABASE_GENERAL_URL
+              }
             />
           </div>
         </>

--- a/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
+++ b/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
@@ -11,9 +11,11 @@ import {
   OVERVIEW_URL,
   APPLICATION_URL,
   APPLICATION_GENERAL_URL,
+  DATABASE_URL,
+  DATABASE_GENERAL_URL,
 } from '@console/shared/router'
 import BreadcrumbItem from '../breadcrumb-item/breadcrumb-item'
-import { ApplicationEntity, EnvironmentEntity } from '@console/shared/interfaces'
+import { ApplicationEntity, DatabaseEntity, EnvironmentEntity } from '@console/shared/interfaces'
 import { IconEnum } from '@console/shared/enums'
 
 export interface BreadcrumbProps {
@@ -25,8 +27,8 @@ export interface BreadcrumbProps {
 }
 
 export function Breadcrumb(props: BreadcrumbProps) {
-  const { organizations, projects, environments, applications } = props
-  const { organizationId, projectId, environmentId, applicationId } = useParams()
+  const { organizations, projects, environments, applications, databases } = props
+  const { organizationId, projectId, environmentId, applicationId, databaseId } = useParams()
   const { pathname } = useLocation()
 
   const currentOrganization = organizations?.find((organization) => organizationId === organization.id)
@@ -106,32 +108,46 @@ export function Breadcrumb(props: BreadcrumbProps) {
 
   const applicationMenu = [
     {
-      title: 'Applications',
+      title: 'Services',
       search: true,
       items: applications
-        ? (applications?.map((application: ApplicationEntity) => ({
-            name: application.name,
-            link: {
-              url: `${APPLICATION_URL(
-                organizationId,
-                projectId,
-                environmentId,
-                application.id
-              )}${APPLICATION_GENERAL_URL}`,
-            },
-            contentLeft: (
-              <div className="flex items-center">
-                <StatusChip status={application.status?.state} />
-                <div className="ml-3 mt-[1px]">
-                  <Icon
-                    name={!(application as ApplicationEntity).build_mode ? IconEnum.APPLICATION : IconEnum.DATABASE}
-                    width="16"
-                  />
+        ? [
+            ...(applications?.map((application: ApplicationEntity) => ({
+              name: application.name,
+              link: {
+                url: `${APPLICATION_URL(
+                  organizationId,
+                  projectId,
+                  environmentId,
+                  application.id
+                )}${APPLICATION_GENERAL_URL}`,
+              },
+              contentLeft: (
+                <div className="flex items-center">
+                  <StatusChip status={application.status?.state} />
+                  <div className="ml-3 mt-[1px]">
+                    <Icon name={IconEnum.APPLICATION} width="16" />
+                  </div>
                 </div>
-              </div>
-            ),
-            isActive: applicationId === application.id,
-          })) as MenuItemProps[])
+              ),
+              isActive: applicationId === application.id,
+            })) as MenuItemProps[]),
+            ...(databases?.map((database: DatabaseEntity) => ({
+              name: database.name,
+              link: {
+                url: `${DATABASE_URL(organizationId, projectId, environmentId, database.id)}${DATABASE_GENERAL_URL}`,
+              },
+              contentLeft: (
+                <div className="flex items-center">
+                  <StatusChip status={database.status?.state} />
+                  <div className="ml-3 mt-[1px]">
+                    <Icon name={IconEnum.DATABASE} width="16" />
+                  </div>
+                </div>
+              ),
+              isActive: applicationId === database.id,
+            })) as MenuItemProps[]),
+          ]
         : [],
     },
   ]
@@ -197,15 +213,15 @@ export function Breadcrumb(props: BreadcrumbProps) {
           </div>
         </>
       )}
-      {applicationId && (
+      {(applicationId || databaseId) && (
         <>
           <div className="w-4 h-auto text-text-200 text-center ml-2 mr-3">/</div>
           <div className="flex items-center">
             {squareContent('S')}
             <BreadcrumbItem
-              data={applications}
+              data={applications || databases}
               menuItems={applicationMenu}
-              paramId={applicationId}
+              paramId={applicationId || databaseId || ''}
               link={APPLICATION_URL(organizationId, projectId, environmentId, applicationId) + APPLICATION_GENERAL_URL}
             />
           </div>

--- a/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
+++ b/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
@@ -206,7 +206,7 @@ export function Breadcrumb(props: BreadcrumbProps) {
               data={applications}
               menuItems={applicationMenu}
               paramId={applicationId}
-              link={SERVICES_URL(organizationId, projectId, environmentId) + SERVICES_GENERAL_URL}
+              link={APPLICATION_URL(organizationId, projectId, environmentId, applicationId) + APPLICATION_GENERAL_URL}
             />
           </div>
         </>


### PR DESCRIPTION
# What does this PR do?

> [Link to the JIRA ticket](https://qovery.atlassian.net/browse/FRT-439?atlOrigin=eyJpIjoiMDQzMzNiOGE1MDBkNDNjNDk3NmRjM2Q4ZGUwYThkYWEiLCJwIjoiaiJ9)

If you are on a service, the breadcrumb doesn't add the correct style and on click redirect to the service list

<img width="482" alt="image" src="https://user-images.githubusercontent.com/33811490/175494573-7d780dac-1d65-46ce-8ff5-9e87701bf838.png">

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
