### PR TITLE
feat(navigation-left): add component 

### DIFF
--- a/libs/shared/ui/src/index.ts
+++ b/libs/shared/ui/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/components/navigation-left/navigation-left'
 export * from './lib/components/copy-to-clipboard/copy-to-clipboard'
 export * from './lib/components/warning-screen-mobile/warning-screen-mobile'
 // components

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left-sub-link/navigation-left-sub-link.spec.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left-sub-link/navigation-left-sub-link.spec.tsx
@@ -37,4 +37,14 @@ describe('NavigationLeftSubLink', () => {
 
     expect(subLinks).toBeTruthy()
   })
+
+  it('should have rotate the arrow', () => {
+    render(<NavigationLeftSubLink {...props} />)
+
+    const trigger = screen.getByTestId('link')
+
+    fireEvent.click(trigger)
+
+    expect(trigger.querySelector('.icon-solid-angle-down')?.classList.contains('rotate-180')).toBeTruthy()
+  })
 })

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left-sub-link/navigation-left-sub-link.spec.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left-sub-link/navigation-left-sub-link.spec.tsx
@@ -1,0 +1,40 @@
+import { screen, render } from '__tests__/utils/setup-jest'
+import { fireEvent } from '@testing-library/react'
+import NavigationLeftSubLink, { NavigationLeftSubLinkProps } from './navigation-left-sub-link'
+
+describe('NavigationLeftSubLink', () => {
+  const props: NavigationLeftSubLinkProps = {
+    linkContent: jest.fn(),
+    link: {
+      title: 'my-title',
+      icon: 'icon-solid-angle-down',
+      url: '/general',
+      onClick: jest.fn(),
+      subLinks: [
+        {
+          title: 'title',
+          url: '/general-second',
+          onClick: jest.fn(),
+        },
+      ],
+    },
+    linkClassName: jest.fn(),
+  }
+
+  it('should render successfully', () => {
+    const { baseElement } = render(<NavigationLeftSubLink {...props} />)
+    expect(baseElement).toBeTruthy()
+  })
+
+  it('should open sub links', () => {
+    render(<NavigationLeftSubLink {...props} />)
+
+    const trigger = screen.getByTestId('link')
+
+    fireEvent.click(trigger)
+
+    const subLinks = screen.getByTestId('sub-links')
+
+    expect(subLinks).toBeTruthy()
+  })
+})

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left-sub-link/navigation-left-sub-link.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left-sub-link/navigation-left-sub-link.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { useLocation } from 'react-router'
+import { Icon } from '@console/shared/ui'
+import { NavigationLeftLinkProps } from '../navigation-left'
+
+export interface NavigationLeftSubLinkProps {
+  linkContent: (link: NavigationLeftLinkProps) => React.ReactNode
+  link: NavigationLeftLinkProps
+  linkClassName: (pathname: string, url?: string) => void
+}
+
+export function NavigationLeftSubLink(props: NavigationLeftSubLinkProps) {
+  const { link, linkClassName, linkContent } = props
+  const { pathname } = useLocation()
+
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <div
+        data-testid="link"
+        onClick={() => setOpen(!open)}
+        className={`flex justify-between select-none ${linkClassName(pathname, link.url)}`}
+      >
+        <span>{linkContent(link)}</span>
+        <Icon
+          name="icon-solid-angle-down"
+          className={`transition-transform ease-out duration-200 ${open ? 'rotate-180' : ''}`}
+        />
+      </div>
+      {link.subLinks && (
+        <div
+          data-testid="sub-links"
+          className={`w-full ${open ? 'opacity-100 h-full' : 'opacity-0 h-0 pointer-events-none'}`}
+        >
+          {link.subLinks.map((subLink, index) => (
+            <div key={index} className={`${linkClassName(pathname, subLink.url)} pl-[37px]`}>
+              {subLink.title}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+export default NavigationLeftSubLink

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.spec.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.spec.tsx
@@ -1,4 +1,5 @@
 import { screen, render } from '__tests__/utils/setup-jest'
+import { fireEvent } from '@testing-library/react'
 import NavigationLeft, { NavigationLeftProps, linkClassName } from './navigation-left'
 
 describe('NavigationLeft', () => {
@@ -69,5 +70,24 @@ describe('NavigationLeft', () => {
     const link = screen.getByTestId('link')
 
     expect(link.textContent).toBe(props.links[0].title)
+  })
+
+  it('should have a click emitted', () => {
+    const onClick = jest.fn()
+
+    props.links = [
+      {
+        title: 'General',
+        onClick: onClick,
+      },
+    ]
+
+    render(<NavigationLeft {...props} />)
+
+    const link = screen.getByTestId('link')
+
+    fireEvent.click(link)
+
+    expect(onClick.mock.calls.length).toEqual(1)
   })
 })

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.spec.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react'
+
+import NavigationLeft from './navigation-left'
+
+describe('NavigationLeft', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<NavigationLeft />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.spec.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.spec.tsx
@@ -1,10 +1,73 @@
-import { render } from '@testing-library/react'
-
-import NavigationLeft from './navigation-left'
+import { screen, render } from '__tests__/utils/setup-jest'
+import NavigationLeft, { NavigationLeftProps, linkClassName } from './navigation-left'
 
 describe('NavigationLeft', () => {
+  const props: NavigationLeftProps = {
+    links: [
+      {
+        title: 'my-title',
+        icon: 'icon-solid-angle-down',
+        url: '/general',
+        onClick: jest.fn(),
+        subLinks: [
+          {
+            title: 'title',
+            url: '/general-second',
+            onClick: jest.fn(),
+          },
+        ],
+      },
+    ],
+  }
+
   it('should render successfully', () => {
-    const { baseElement } = render(<NavigationLeft />)
+    const { baseElement } = render(<NavigationLeft {...props} />)
     expect(baseElement).toBeTruthy()
+  })
+
+  it('should have active class', () => {
+    props.links = [
+      {
+        title: 'General',
+        url: '/general',
+        onClick: jest.fn(),
+        icon: 'icon-solid-angle-down',
+      },
+    ]
+
+    expect(
+      linkClassName('/general', props.links[0].url) ===
+        'py-2 px-3 text-ssm rounded font-medium cursor-pointer mt-0.5 transition ease-out duration-300 text-brand-500 bg-brand-50 hover:text-brand-600 hover:bg-brand-100'
+    ).toBe(true)
+  })
+
+  it('should have an icon', () => {
+    props.links = [
+      {
+        title: 'General',
+        onClick: jest.fn(),
+        icon: 'icon-solid-angle-down',
+      },
+    ]
+
+    render(<NavigationLeft {...props} />)
+
+    const link = screen.getByTestId('link')
+
+    expect(link.querySelector('span')?.classList.contains('icon-solid-angle-down')).toBe(true)
+  })
+
+  it('should have an title', () => {
+    props.links = [
+      {
+        title: 'General',
+      },
+    ]
+
+    render(<NavigationLeft {...props} />)
+
+    const link = screen.getByTestId('link')
+
+    expect(link.textContent).toBe(props.links[0].title)
   })
 })

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.stories.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.stories.tsx
@@ -24,7 +24,11 @@ Primary.args = {
     },
     {
       title: 'Deployment',
-      url: '/deployment',
+      subLinks: [
+        {
+          title: 'General',
+        },
+      ],
     },
   ],
 }

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.stories.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.stories.tsx
@@ -1,0 +1,30 @@
+import { Meta, Story } from '@storybook/react'
+import { NavigationLeft, NavigationLeftProps } from './navigation-left'
+
+export default {
+  component: NavigationLeft,
+  title: 'NavigationLeft',
+  parameters: {
+    backgrounds: {
+      default: 'white',
+      values: [{ name: 'white', value: '#fff' }],
+    },
+  },
+} as Meta
+
+const Template: Story<NavigationLeftProps> = (args) => <NavigationLeft {...args} />
+
+export const Primary = Template.bind({})
+
+Primary.args = {
+  links: [
+    {
+      title: 'General',
+      url: '/general',
+    },
+    {
+      title: 'Deployment',
+      url: '/deployment',
+    },
+  ],
+}

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.stories.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.stories.tsx
@@ -20,10 +20,32 @@ Primary.args = {
   links: [
     {
       title: 'General',
-      url: '/general',
+      url: '/',
+      icon: 'icon-solid-wheel',
     },
     {
       title: 'Deployment',
+      icon: 'icon-solid-wheel',
+      subLinks: [
+        {
+          title: 'General',
+        },
+        {
+          title: 'Dependencies',
+          url: '/',
+        },
+        {
+          title: 'Restrictions',
+        },
+      ],
+    },
+    {
+      title: 'Preview Environments',
+      icon: 'icon-solid-wheel',
+    },
+    {
+      title: 'Advanced settings',
+      icon: 'icon-solid-wheel',
       subLinks: [
         {
           title: 'General',

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
-import { Icon } from '@console/shared/ui'
+import { Icon } from '../icon/icon'
 import NavigationLeftSubLink from './navigation-left-sub-link/navigation-left-sub-link'
 export interface NavigationLeftProps {
   links: NavigationLeftLinkProps[]
@@ -51,7 +51,7 @@ export function NavigationLeft(props: NavigationLeftProps) {
           <span
             data-testid="link"
             key={index}
-            onClick={() => link.onClick}
+            onClick={link.onClick}
             className={linkClassName(link.url || '', pathname)}
           >
             {linkContent(link)}

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
@@ -1,11 +1,13 @@
 import { Link } from 'react-router-dom'
-
+import { useLocation } from 'react-router-dom'
+import { Icon } from '@console/shared/ui'
+import NavigationLeftSubLink from './navigation-left-sub-link/navigation-left-sub-link'
 export interface NavigationLeftProps {
-  links: LinkProps[]
+  links: NavigationLeftLinkProps[]
   className?: string
 }
 
-interface LinkProps {
+export interface NavigationLeftLinkProps {
   title: string
   icon?: string
   url?: string
@@ -17,40 +19,42 @@ interface LinkProps {
   }[]
 }
 
+export const linkClassName = (pathname: string, url?: string) =>
+  `py-2 px-3 text-ssm rounded font-medium cursor-pointer mt-0.5 transition ease-out duration-300 ${
+    url === pathname
+      ? 'text-brand-500 bg-brand-50 hover:text-brand-600 hover:bg-brand-100'
+      : 'text-text-400 hover:text-text-500 hover:bg-element-light-lighter-300'
+  }`
+
 export function NavigationLeft(props: NavigationLeftProps) {
   const { links, className = '' } = props
 
-  const isActive = false
+  const { pathname } = useLocation()
 
-  const linkClassName = `px-2 py-[6px] rounded font-medium cursor-pointer ${
-    isActive
-      ? 'text-brand-500 bg-brand-50 hover:text-text-600'
-      : 'text-text-400 hover:text-text-500 hover:bg-element-light-lighter-300'
-  }`
+  const linkContent = (link: NavigationLeftLinkProps) => (
+    <>
+      {link.icon && <Icon name={link.icon} className="mr-3" />}
+      {link.title}
+    </>
+  )
 
   return (
     <div className={`flex flex-col px-5 ${className}`}>
       {links.map((link, index) =>
         !link.onClick && !link.subLinks && link.url ? (
-          <Link key={index} to={link.url} className={linkClassName}>
-            {link.title}
+          <Link data-testid="link" key={index} to={link.url} className={linkClassName(link.url, pathname)}>
+            {linkContent(link)}
           </Link>
         ) : !link.onClick && link.subLinks ? (
-          <>
-            <span key={index} className={linkClassName}>
-              {link.title}
-            </span>
-            <div className="w-full h-full">
-              {link.subLinks.map((subLink, index) => (
-                <div key={index} className={`${linkClassName} pl-9`}>
-                  {subLink.title}
-                </div>
-              ))}
-            </div>
-          </>
+          <NavigationLeftSubLink key={index} link={link} linkClassName={linkClassName} linkContent={linkContent} />
         ) : (
-          <span key={index} onClick={() => link.onClick} className={linkClassName}>
-            {link.title}
+          <span
+            data-testid="link"
+            key={index}
+            onClick={() => link.onClick}
+            className={linkClassName(link.url || '', pathname)}
+          >
+            {linkContent(link)}
           </span>
         )
       )}

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
@@ -7,6 +7,7 @@ export interface NavigationLeftProps {
 
 interface LinkProps {
   title: string
+  icon?: string
   url?: string
   onClick?: () => void
   subLinks?: {
@@ -21,8 +22,10 @@ export function NavigationLeft(props: NavigationLeftProps) {
 
   const isActive = false
 
-  const linkClassName = `p-2 rounded font-medium ${
-    isActive ? 'text-brand-500 bg-brand-50' : 'hover:text-text-500 hover:bg-element-light-lighter-300'
+  const linkClassName = `px-2 py-[6px] rounded font-medium cursor-pointer ${
+    isActive
+      ? 'text-brand-500 bg-brand-50 hover:text-text-600'
+      : 'text-text-400 hover:text-text-500 hover:bg-element-light-lighter-300'
   }`
 
   return (
@@ -37,9 +40,11 @@ export function NavigationLeft(props: NavigationLeftProps) {
             <span key={index} className={linkClassName}>
               {link.title}
             </span>
-            <div>
+            <div className="w-full h-full">
               {link.subLinks.map((subLink, index) => (
-                <span key={index}>{subLink.title}</span>
+                <div key={index} className={`${linkClassName} pl-9`}>
+                  {subLink.title}
+                </div>
               ))}
             </div>
           </>

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
@@ -1,0 +1,56 @@
+import { Link } from 'react-router-dom'
+
+export interface NavigationLeftProps {
+  links: LinkProps[]
+  className?: string
+}
+
+export interface LinkProps {
+  title: string
+  url: string
+  onClick?: () => void
+  subLinks?: {
+    title: string
+    link: string
+    onClick?: () => void
+  }[]
+}
+
+export function NavigationLeft(props: NavigationLeftProps) {
+  const { links, className = '' } = props
+
+  const isActive = false
+
+  const linkClassName = `p-2 rounded font-medium ${
+    isActive ? 'text-brand-500 bg-brand-50' : 'hover:text-text-500 hover:bg-element-light-lighter-300'
+  }`
+
+  return (
+    <div className={`flex flex-col px-5 ${className}`}>
+      {links.map((link, index) =>
+        !link.onClick && !link.subLinks ? (
+          <Link key={index} to={link.url} className={linkClassName}>
+            {link.title}
+          </Link>
+        ) : !link.onClick && link.subLinks ? (
+          <>
+            <span key={index} onClick={() => link.onClick} className={linkClassName}>
+              {link.title}
+            </span>
+            <div>
+              {link.subLinks.map((subLink, index) => (
+                <span key={index}>{subLink.title}</span>
+              ))}
+            </div>
+          </>
+        ) : (
+          <span key={index} onClick={() => link.onClick} className={linkClassName}>
+            {link.title}
+          </span>
+        )
+      )}
+    </div>
+  )
+}
+
+export default NavigationLeft

--- a/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
+++ b/libs/shared/ui/src/lib/components/navigation-left/navigation-left.tsx
@@ -5,13 +5,13 @@ export interface NavigationLeftProps {
   className?: string
 }
 
-export interface LinkProps {
+interface LinkProps {
   title: string
-  url: string
+  url?: string
   onClick?: () => void
   subLinks?: {
     title: string
-    link: string
+    url?: string
     onClick?: () => void
   }[]
 }
@@ -28,13 +28,13 @@ export function NavigationLeft(props: NavigationLeftProps) {
   return (
     <div className={`flex flex-col px-5 ${className}`}>
       {links.map((link, index) =>
-        !link.onClick && !link.subLinks ? (
+        !link.onClick && !link.subLinks && link.url ? (
           <Link key={index} to={link.url} className={linkClassName}>
             {link.title}
           </Link>
         ) : !link.onClick && link.subLinks ? (
           <>
-            <span key={index} onClick={() => link.onClick} className={linkClassName}>
+            <span key={index} className={linkClassName}>
               {link.title}
             </span>
             <div>


### PR DESCRIPTION
# What does this PR do?

[> Link to the JIRA ticket
](https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-351)

- Add the navigation left with react-router logic
- I didn't add an animation when we opened the sub links, it was too much

[Link](http://localhost:4400/?path=/story/navigationleft--primary)

<img width="888" alt="Capture d’écran 2022-07-07 à 17 35 30" src="https://user-images.githubusercontent.com/533928/177813726-b427f685-1e3f-4726-8514-9e2817dd9fe0.png">

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
