### PR TITLE
fix(redirection): save orgId and projectId on localStorage

### DIFF
--- a/libs/pages/layout/src/lib/feature/layout/layout.spec.tsx
+++ b/libs/pages/layout/src/lib/feature/layout/layout.spec.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { render } from '__tests__/utils/setup-jest'
-
+import { setCurrentOrganizationIdOnStorage, setCurrentProjectIdOnStorage } from '../../utils/utils'
 import Layout, { LayoutProps } from './layout'
+
+jest.mock('../../utils/utils')
 
 describe('Layout', () => {
   let props: LayoutProps
@@ -15,5 +17,17 @@ describe('Layout', () => {
   it('should render successfully', () => {
     const { baseElement } = render(<Layout {...props} />)
     expect(baseElement).toBeTruthy()
+  })
+
+  it('should save the current organization id on local storage', () => {
+    setCurrentOrganizationIdOnStorage.mockImplementation((orgId: string) => orgId)
+    render(<Layout {...props} />)
+    expect(setCurrentOrganizationIdOnStorage).toBeCalled()
+  })
+
+  it('should save the current project id on local storage', () => {
+    setCurrentProjectIdOnStorage.mockImplementation((projectId: string) => projectId)
+    render(<Layout {...props} />)
+    expect(setCurrentProjectIdOnStorage).toBeCalled()
   })
 })

--- a/libs/pages/layout/src/lib/feature/layout/layout.spec.tsx
+++ b/libs/pages/layout/src/lib/feature/layout/layout.spec.tsx
@@ -20,14 +20,18 @@ describe('Layout', () => {
   })
 
   it('should save the current organization id on local storage', () => {
-    setCurrentOrganizationIdOnStorage.mockImplementation((orgId: string) => orgId)
+    const mockSetOrganizationId = setCurrentOrganizationIdOnStorage as jest.Mock<
+      typeof setCurrentOrganizationIdOnStorage
+    >
+    mockSetOrganizationId.mockImplementation()
     render(<Layout {...props} />)
-    expect(setCurrentOrganizationIdOnStorage).toBeCalled()
+    expect(mockSetOrganizationId).toBeCalled()
   })
 
   it('should save the current project id on local storage', () => {
-    setCurrentProjectIdOnStorage.mockImplementation((projectId: string) => projectId)
+    const mockSetProjectId = setCurrentProjectIdOnStorage as jest.Mock<typeof setCurrentProjectIdOnStorage>
+    mockSetProjectId.mockImplementation()
     render(<Layout {...props} />)
-    expect(setCurrentProjectIdOnStorage).toBeCalled()
+    expect(mockSetProjectId).toBeCalled()
   })
 })

--- a/libs/pages/layout/src/lib/feature/layout/layout.tsx
+++ b/libs/pages/layout/src/lib/feature/layout/layout.tsx
@@ -46,6 +46,11 @@ export function Layout(props: LayoutProps) {
     }
   }, [dispatch, organizationId])
 
+  useEffect(() => {
+    localStorage.setItem('currentOrganizationId', organizationId)
+    localStorage.setItem('currentProjectId', projectId)
+  }, [organizationId, projectId])
+
   return (
     <LayoutPage user={userSignUp} darkMode={darkMode}>
       <>

--- a/libs/pages/layout/src/lib/feature/layout/layout.tsx
+++ b/libs/pages/layout/src/lib/feature/layout/layout.tsx
@@ -10,6 +10,7 @@ import { WebsocketContainer } from '@console/shared/websockets'
 import { fetchDatabases } from '@console/domains/database'
 import { fetchEnvironments } from '@console/domains/environment'
 import LayoutPage from '../../ui/layout-page/layout-page'
+import { setCurrentOrganizationIdOnStorage, setCurrentProjectIdOnStorage } from '../../utils/utils'
 
 export interface LayoutProps {
   children: React.ReactElement
@@ -47,8 +48,8 @@ export function Layout(props: LayoutProps) {
   }, [dispatch, organizationId])
 
   useEffect(() => {
-    localStorage.setItem('currentOrganizationId', organizationId)
-    localStorage.setItem('currentProjectId', projectId)
+    setCurrentOrganizationIdOnStorage(organizationId)
+    setCurrentProjectIdOnStorage(projectId)
   }, [organizationId, projectId])
 
   return (

--- a/libs/pages/layout/src/lib/utils/utils.tsx
+++ b/libs/pages/layout/src/lib/utils/utils.tsx
@@ -1,0 +1,7 @@
+export function setCurrentOrganizationIdOnStorage(organizationId: string) {
+  localStorage.setItem('currentOrganizationId', organizationId)
+}
+
+export function setCurrentProjectIdOnStorage(projectId: string) {
+  localStorage.setItem('currentProjectId', projectId)
+}

--- a/libs/pages/login/src/lib/hooks/use-redirect-if-logged/use-redirect-if-logged.spec.tsx
+++ b/libs/pages/login/src/lib/hooks/use-redirect-if-logged/use-redirect-if-logged.spec.tsx
@@ -23,14 +23,17 @@ describe('UseRedirectIfLogged', () => {
   })
 
   it('should redirect to the stored localStorage last visited URL', () => {
-    getRedirectLoginUriFromStorage.mockImplementation(() => '/login')
+    const mockRedirect = getRedirectLoginUriFromStorage as jest.Mock<string | null>
+    mockRedirect.mockImplementation(() => '/login')
     renderHook(useRedirectIfLogged, { wrapper: Wrapper })
     expect(mockedUsedNavigate).toHaveBeenCalledWith('/login')
   })
 
   it('should redirect to the last visited project', () => {
-    getCurrentOrganizationIdFromStorage.mockImplementation(() => 'fff')
-    getCurrentProjectIdFromStorage.mockImplementation(() => 'iii')
+    const mockGetCurrentOrganizationId = getCurrentOrganizationIdFromStorage as jest.Mock<string | null>
+    const mockGetCurrentProjectId = getCurrentProjectIdFromStorage as jest.Mock<string | null>
+    mockGetCurrentOrganizationId.mockImplementation(() => 'fff')
+    mockGetCurrentProjectId.mockImplementation(() => 'iii')
     renderHook(useRedirectIfLogged, { wrapper: Wrapper })
     expect(mockedUsedNavigate).toHaveBeenCalledWith(OVERVIEW_URL('fff', 'iii'))
   })


### PR DESCRIPTION
# What does this PR do?

Fix redirection to the previous orgnization/project

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [ ] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [ ] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
