### PR TITLE
chore(api): safer way to prepare api payload

### DIFF
--- a/libs/shared/interfaces/src/lib/domain/application.entity.ts
+++ b/libs/shared/interfaces/src/lib/domain/application.entity.ts
@@ -1,4 +1,12 @@
-import { Application, Commit, DeploymentHistoryApplication, Instance, Link, Status } from 'qovery-typescript-axios'
+import {
+  Application,
+  ApplicationAdvancedSettings,
+  Commit,
+  DeploymentHistoryApplication,
+  Instance,
+  Link,
+  Status,
+} from 'qovery-typescript-axios'
 import { LoadingStatus } from '../types/loading-status.type'
 import { ServiceRunningStatus } from './service-running-status.interface'
 
@@ -20,5 +28,10 @@ export interface ApplicationEntity extends Application {
   deployments?: {
     loadingStatus: LoadingStatus
     items: DeploymentHistoryApplication[]
+  }
+  advanced_settings?: {
+    loadingStatus: LoadingStatus
+    default_settings: ApplicationAdvancedSettings
+    current_settings: ApplicationAdvancedSettings
   }
 }

--- a/libs/shared/utils/src/lib/tools/refacto-payload.spec.ts
+++ b/libs/shared/utils/src/lib/tools/refacto-payload.spec.ts
@@ -44,14 +44,20 @@ describe('testing payload refactoring', () => {
     }
 
     expect(refactoApplicationPayload(response)).toEqual({
-      name: 'hello-2',
-      test: 'test',
-      storage: [{ mount_point: '', size: 4, type: StorageTypeEnum.FAST_SSD }],
+      storage: [
+        {
+          id: '1',
+          mount_point: '',
+          size: 4,
+          type: StorageTypeEnum.FAST_SSD,
+        },
+      ],
       git_repository: {
         url: '',
         branch: '',
         root_path: '',
       },
+      name: 'hello-2',
     })
   })
 })

--- a/libs/shared/utils/src/lib/tools/refacto-payload.ts
+++ b/libs/shared/utils/src/lib/tools/refacto-payload.ts
@@ -53,5 +53,5 @@ export function refactoApplicationPayload(application: Partial<ApplicationEntity
     min_running_instances: application.min_running_instances,
   }
 
-  return refactoPayload(applicationRequestPayload)
+  return applicationRequestPayload
 }


### PR DESCRIPTION
Because the `put` method is a little bit strange backend side, we can't have any information outside of the one accepted by the API.
If we send our application object with additional properties, backend will reject our `put`.
So everytime we were adding some stuff for development purpose on the application or everytime the backend was adding properties on the application object that we fetch with get, we had to manually suppress the extra properties. Which was not super safe and could break at any API changes if the response of the get was changed.
With this fix, we pass only what is asked by the Payload Interface.