### PR TITLE
chore(css-size): cut size from 4mo to 100kb

### DIFF
--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -1,16 +1,15 @@
 import { AppState, Auth0Provider } from '@auth0/auth0-react'
-import { store } from '@console/store/data'
-import { ModalProvider, ToastBehavior } from '@console/shared/ui'
 import { createBrowserHistory } from 'history'
+import posthog from 'posthog-js'
+import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { BrowserRouter } from 'react-router-dom'
 import { IntercomProvider } from 'react-use-intercom'
+import { LOGIN_AUTH_REDIRECT_URL, LOGIN_URL } from '@console/shared/router'
+import { ModalProvider, ToastBehavior } from '@console/shared/ui'
+import { store } from '@console/store/data'
 import App from './app/app'
 import { environment } from './environments/environment'
-import './styles.scss'
-import posthog from 'posthog-js'
-import { createRoot } from 'react-dom/client'
-import { LOGIN_AUTH_REDIRECT_URL, LOGIN_URL } from '@console/shared/router'
 
 export const history = createBrowserHistory()
 

--- a/tailwind-workspace-preset.js
+++ b/tailwind-workspace-preset.js
@@ -196,14 +196,5 @@ module.exports = {
   variants: {
     extend: {},
   },
-  safelist: [
-    {
-      pattern: /(bg|border|text|fill)-(violet|red|brand|error|success|bg-element-light-lighter|accent)(-\w+\d+)*/,
-      variants: ['focus', 'hover'],
-    },
-    {
-      pattern: /(w|h)-(\w+\d+)*/,
-    },
-  ],
   plugins: [],
 }


### PR DESCRIPTION
- The css file was imported twice in two different files with the same exact huge content (2,8mo unminified)
- Removing safelist from tailwind config that was keeping way too much CSS properties. From 2,8mo to 200kb unmodified

In the end, with the minified version the prod comes from 2x1,8mb to 1x100kb.
We can already file the first loading of the pages much responsive and fast.