### PR TITLE
fix(initialisation): infinite loader after loading

### DIFF
--- a/apps/console/src/app/components/redirect-overview.tsx
+++ b/apps/console/src/app/components/redirect-overview.tsx
@@ -1,12 +1,12 @@
-import { NavLink, useParams } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
-import { AppDispatch } from '@console/store/data'
-import { useEffect, useState } from 'react'
 import { Project } from 'qovery-typescript-axios'
+import { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { NavLink, useParams } from 'react-router-dom'
+import { fetchOrganization, selectAllOrganization } from '@console/domains/organization'
 import { fetchProjects } from '@console/domains/projects'
 import { ORGANIZATION_URL, OVERVIEW_URL } from '@console/shared/router'
 import { LoadingScreen } from '@console/shared/ui'
-import { fetchOrganization, selectAllOrganization } from '@console/domains/organization'
+import { AppDispatch } from '@console/store/data'
 
 export function RedirectOverview() {
   const { organizationId = '' } = useParams()

--- a/libs/pages/login/src/lib/hooks/use-redirect-if-logged/use-redirect-if-logged.tsx
+++ b/libs/pages/login/src/lib/hooks/use-redirect-if-logged/use-redirect-if-logged.tsx
@@ -1,11 +1,11 @@
-import { useEffect } from 'react'
-import { useAuth } from '@console/shared/auth'
 import { Organization, Project } from 'qovery-typescript-axios'
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router'
 import { fetchOrganization } from '@console/domains/organization'
 import { fetchProjects } from '@console/domains/projects'
-import { ONBOARDING_URL, OVERVIEW_URL } from '@console/shared/router'
-import { useNavigate } from 'react-router'
-import { useDispatch } from 'react-redux'
+import { useAuth } from '@console/shared/auth'
+import { ONBOARDING_URL, ORGANIZATION_URL, OVERVIEW_URL } from '@console/shared/router'
 import { AppDispatch } from '@console/store/data'
 import {
   getCurrentOrganizationIdFromStorage,
@@ -35,6 +35,7 @@ export function useRedirectIfLogged() {
         const organizationId = organization[0].id
         const projects: Project[] = await dispatch(fetchProjects({ organizationId })).unwrap()
         if (projects.length > 0) navigate(OVERVIEW_URL(organizationId, projects[0].id))
+        else navigate(ORGANIZATION_URL(organizationId))
       }
       if (isOnboarding && organization.length === 0) {
         navigate(ONBOARDING_URL)


### PR DESCRIPTION
Redirect on this screen when the first organization available does not have any project to propose.
![CleanShot 2022-09-05 at 18 14 48@2x](https://user-images.githubusercontent.com/6163954/188487838-6161fd21-883c-4ab1-9f26-dbf69f033fc8.jpg)

Fixing an infinite loop that was boring on every new preview env