### PR TITLE
page deployments filter stays

### DIFF
--- a/libs/pages/services/src/lib/ui/page-deployments/page-deployments.tsx
+++ b/libs/pages/services/src/lib/ui/page-deployments/page-deployments.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { DeploymentService } from '@qovery/shared/interfaces'
 import { BaseLink, HelpSection, Table, TableRowDeployment } from '@qovery/shared/ui'
 
@@ -8,7 +8,7 @@ export interface PageDeploymentsProps {
   isLoading?: boolean
 }
 
-export function PageDeployments(props: PageDeploymentsProps) {
+export function PageDeploymentsMemo(props: PageDeploymentsProps) {
   const { deployments = [], listHelpfulLinks, isLoading } = props
 
   const [data, setData] = useState<DeploymentService[]>([])
@@ -99,5 +99,21 @@ export function PageDeployments(props: PageDeploymentsProps) {
     </>
   )
 }
+
+export const PageDeployments = React.memo(PageDeploymentsMemo, (prevProps, nextProps) => {
+  // Stringify is necessary to avoid Redux selector behavior
+  return (
+    JSON.stringify(
+      prevProps.deployments?.map((service) => ({
+        id: service.id,
+      }))
+    ) ===
+    JSON.stringify(
+      nextProps.deployments?.map((service) => ({
+        id: service.id,
+      }))
+    )
+  )
+})
 
 export default PageDeployments


### PR DESCRIPTION
# What does this PR do?

> [Link to the JIRA ticket](https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-568)

![CleanShot 2022-11-08 at 14 57 41@2x](https://user-images.githubusercontent.com/6163954/200583625-436d6067-2539-4f03-8b6e-a7da5194b908.jpg)

As long as we have the same values, we don't loose the filter