### PR TITLE
fix(input-select): add tooltip and truncate for long value

### DIFF
--- a/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
@@ -12,6 +12,7 @@ import Select, {
 import { Value } from '@qovery/shared/interfaces'
 import Icon from '../../icon/icon'
 import { IconAwesomeEnum } from '../../icon/icon-awesome.enum'
+import Tooltip from '../../tooltip/tooltip'
 
 export interface InputSelectProps {
   className?: string
@@ -102,8 +103,9 @@ export function InputSelect(props: InputSelectProps) {
       ) : (
         <Icon name={IconAwesomeEnum.CHECK} className="opacity-0" />
       )}
-
-      <label className="ml-2">{props.label}</label>
+      <Tooltip content={props.label}>
+        <label className="ml-2 truncate">{props.label}</label>
+      </Tooltip>
     </components.Option>
   )
 

--- a/libs/shared/ui/src/lib/styles/components/select.scss
+++ b/libs/shared/ui/src/lib/styles/components/select.scss
@@ -13,10 +13,12 @@
 }
 
 .input-select__value-container {
-  overflow: visible !important;
+  overflow: scroll !important;
   padding: 0 !important;
   cursor: pointer;
   display: flex !important;
+  flex-wrap: nowrap !important;
+  white-space: nowrap;
   @apply mt-2 top-1;
 }
 
@@ -74,7 +76,7 @@
   }
 
   .input-select__checkbox {
-    @apply bg-white border-2 border-element-light-lighter-700 rounded-sm w-4 h-4 flex items-center justify-center;
+    @apply bg-white border-2 border-element-light-lighter-700 rounded-sm w-4 h-4 flex items-center justify-center shrink-0;
   }
 
   &:hover {


### PR DESCRIPTION
# What does this PR do?

- Fixed bug when we have long value on the Input Select
- Added tooltip and truncate

<img width="721" alt="Capture d’écran 2022-11-10 à 17 26 02" src="https://user-images.githubusercontent.com/533928/201151481-c6db6759-c39c-493e-884d-f2d3119c1d1e.png">

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
