### PR TITLE
fix(create-clone-environment-modal): redirect after request

### DIFF
--- a/libs/shared/console-shared/src/lib/create-clone-environment-modal/feature/create-clone-environment-modal-feature.tsx
+++ b/libs/shared/console-shared/src/lib/create-clone-environment-modal/feature/create-clone-environment-modal-feature.tsx
@@ -7,9 +7,11 @@ import {
 import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
 import { cloneEnvironment, createEnvironment } from '@qovery/domains/environment'
 import { selectClustersEntitiesByOrganizationId } from '@qovery/domains/organization'
 import { ClusterEntity, EnvironmentEntity } from '@qovery/shared/interfaces'
+import { SERVICES_GENERAL_URL, SERVICES_URL } from '@qovery/shared/router'
 import { useModal } from '@qovery/shared/ui'
 import { AppDispatch, RootState } from '@qovery/store'
 import CreateCloneEnvironmentModal from '../ui/create-clone-environment-modal'
@@ -43,6 +45,8 @@ export function CreateCloneEnvironmentModalFeature(props: CreateCloneEnvironment
 
   const dispatch = useDispatch<AppDispatch>()
 
+  const navigate = useNavigate()
+
   const onSubmit = methods.handleSubmit(async (data) => {
     const dataFormatted: { name: string; cluster?: string; mode?: string } = {
       name: data.name,
@@ -63,7 +67,8 @@ export function CreateCloneEnvironmentModalFeature(props: CreateCloneEnvironment
       }
       dispatch(cloneEnvironment({ environmentId: props.environmentToClone.id, cloneRequest }))
         .unwrap()
-        .then(() => {
+        .then((result) => {
+          navigate(SERVICES_URL(props.organizationId, props.projectId, result.id) + SERVICES_GENERAL_URL)
           setLoading(false)
           props.onClose()
         })
@@ -79,7 +84,8 @@ export function CreateCloneEnvironmentModalFeature(props: CreateCloneEnvironment
       }
       dispatch(createEnvironment({ projectId: props.projectId, environmentRequest }))
         .unwrap()
-        .then(() => {
+        .then((result) => {
+          navigate(SERVICES_URL(props.organizationId, props.projectId, result.id) + SERVICES_GENERAL_URL)
           setLoading(false)
           props.onClose()
         })


### PR DESCRIPTION
# What does this PR do?

- Redirection to the Services page after cloning or creating Environment

<img width="1789" alt="Capture d’écran 2023-01-02 à 09 19 52" src="https://user-images.githubusercontent.com/533928/210207629-3ac3e54e-d802-477f-bc8f-b9357dc58351.png">

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
