### PR TITLE
fix(cyclic-dep): removing the cyclic dep from websocket lib

### DIFF
--- a/libs/shared/utils/src/lib/hooks/use-running-status-websocket/use-running-status-websocket.tsx
+++ b/libs/shared/utils/src/lib/hooks/use-running-status-websocket/use-running-status-websocket.tsx
@@ -1,17 +1,16 @@
+import { GetTokenSilentlyOptions } from '@auth0/auth0-react'
 import { useCallback, useState } from 'react'
-import { useAuth } from '@qovery/shared/auth'
 
 export interface RunningStatusWebsocketProps {
-  organizationId: string
+  getAccessTokenSilently: (options?: GetTokenSilentlyOptions) => Promise<string>
 }
 
 const baseUrl = 'wss://ws.qovery.com/service/status'
 
-export function useRunningStatusWebsocket() {
+export function useRunningStatusWebsocket(props: RunningStatusWebsocketProps) {
+  const { getAccessTokenSilently } = props
   const [websockets, setWebsockets] = useState<string[]>([])
   const [websocketsUrl, setWebsocketsUrl] = useState<string[]>([])
-  const { getAccessTokenSilently } = useAuth()
-
   const closeSockets = useCallback((): void => {
     setWebsockets([])
     setWebsocketsUrl([])

--- a/libs/shared/websockets/src/lib/components/websocket-container/websocket-container.tsx
+++ b/libs/shared/websockets/src/lib/components/websocket-container/websocket-container.tsx
@@ -2,17 +2,19 @@ import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { selectClustersEntitiesByOrganizationId } from '@qovery/domains/organization'
+import { useAuth } from '@qovery/shared/auth'
 import { useRunningStatusWebsocket } from '@qovery/shared/utils'
 import { RootState } from '@qovery/store'
 import { ClusterWebSocket } from '../cluster-web-socket/cluster-web-socket'
 
 export function WebsocketContainer() {
   const { organizationId = '' } = useParams()
+  const { getAccessTokenSilently } = useAuth()
 
-  const { openWebSockets, closeSockets, websocketsUrl } = useRunningStatusWebsocket()
+  const { openWebSockets, closeSockets, websocketsUrl } = useRunningStatusWebsocket({
+    getAccessTokenSilently,
+  })
 
-  // const clusters = useSelector<RootState, Cluster[]>(selectClustersEntitiesByOrganizationIdMemoized(organizationId))
-  // const clusters = useSelector<RootState, Cluster[]>(selectAllCluster)
   const clusters = useSelector((state: RootState) => selectClustersEntitiesByOrganizationId(state, organizationId))
 
   useEffect(() => {


### PR DESCRIPTION
# What does this PR do?

Fixing an annoying cyclic dependency in the websocket lib.

![image](https://user-images.githubusercontent.com/6163954/212643687-e4cd9527-c49f-4079-9358-5c2af62e26df.png)


---

## PR Checklist

### Global

- [ ] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [ ] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [ ] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
