### PR TITLE
feat(breadcrumb): add cluster

### DIFF
--- a/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
+++ b/libs/shared/ui/src/lib/components/layouts/breadcrumb/breadcrumb.tsx
@@ -1,5 +1,5 @@
 import equal from 'fast-deep-equal'
-import { Database, Environment, Organization, Project } from 'qovery-typescript-axios'
+import { Cluster, Database, Environment, Organization, Project } from 'qovery-typescript-axios'
 import React, { useEffect } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { IconEnum } from '@qovery/shared/enums'
@@ -10,6 +10,7 @@ import {
   APPLICATION_LOGS_URL,
   APPLICATION_URL,
   CLUSTERS_URL,
+  CLUSTER_URL,
   DATABASE_GENERAL_URL,
   DATABASE_URL,
   DEPLOYMENT_LOGS_URL,
@@ -60,6 +61,29 @@ export function BreadcrumbMemo(props: BreadcrumbProps) {
     location.pathname.includes(INFRA_LOGS_URL(organizationId, clusterId)) ||
     locationIsApplicationLogs ||
     locationIsDeploymentLogs
+
+  const clustersMenu = [
+    {
+      title: 'Clusters',
+      search: true,
+      items: clusters
+        ? clusters?.map((cluster: Cluster) => ({
+            name: cluster.name,
+            link: {
+              url: matchLogsRoute
+                ? INFRA_LOGS_URL(organizationId, cluster.id)
+                : CLUSTER_URL(organizationId, cluster.id),
+            },
+            contentLeft: (
+              <Icon
+                name="icon-solid-check"
+                className={`text-sm ${clusterId === cluster.id ? 'text-success-400' : 'text-transparent'}`}
+              />
+            ),
+          }))
+        : [],
+    },
+  ]
 
   const projectMenu = [
     {
@@ -191,9 +215,9 @@ export function BreadcrumbMemo(props: BreadcrumbProps) {
             isLast={!projectId}
             label="Cluster"
             data={clusters}
-            menuItems={[]}
+            menuItems={clustersMenu}
             paramId={clusterId}
-            link={INFRA_LOGS_URL(organizationId, clusterId)}
+            link={matchLogsRoute ? INFRA_LOGS_URL(organizationId, clusterId) : CLUSTER_URL(organizationId, clusterId)}
           />
         )}
         {projectId && (


### PR DESCRIPTION
# What does this PR do?

- Add Breadcrumb menu for Clusters 

<img width="602" alt="Capture d’écran 2023-01-17 à 16 20 30" src="https://user-images.githubusercontent.com/533928/212937789-3832751c-7e98-438c-8c99-f90aaf4c2d55.png">

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [ ] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
