### PR TITLE
feat(cluster-advanced-settings): add page

### DIFF
--- a/libs/domains/organization/src/lib/slices/cluster.slice.spec.ts
+++ b/libs/domains/organization/src/lib/slices/cluster.slice.spec.ts
@@ -7,6 +7,10 @@ describe('cluster reducer', () => {
       error: null,
       joinOrganizationClusters: {},
       statusLoadingStatus: 'not loaded',
+      defaultClusterAdvancedSettings: {
+        loadingStatus: 'not loaded',
+        settings: undefined,
+      },
     })
 
     expect(clusterReducer(undefined, { type: '' })).toEqual(expected)

--- a/libs/domains/organization/src/lib/slices/cluster.slice.ts
+++ b/libs/domains/organization/src/lib/slices/cluster.slice.ts
@@ -334,7 +334,7 @@ export const clusterSlice = createSlice({
         toast(
           ToastEnum.SUCCESS,
           `Cluster updated`,
-          'You must redeploy to apply the settings update',
+          'You must update to apply the settings',
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'

--- a/libs/domains/organization/src/lib/slices/cluster.slice.ts
+++ b/libs/domains/organization/src/lib/slices/cluster.slice.ts
@@ -89,8 +89,7 @@ export const editClusterAdvancedSettings = createAsyncThunk<
 export const fetchDefaultClusterAdvancedSettings = createAsyncThunk<AdvancedSettings>(
   'cluster/defaultAdvancedSettings',
   async () => {
-    // const response = await clusterApi.getDefaultClusterAdvancedSettings()
-    const response = await clusterApi.getClusterAdvancedSettings('1', '1')
+    const response = await clusterApi.getDefaultClusterAdvancedSettings()
     return response.data
   }
 )

--- a/libs/domains/organization/src/lib/slices/cluster.slice.ts
+++ b/libs/domains/organization/src/lib/slices/cluster.slice.ts
@@ -6,8 +6,15 @@ import {
   createSelector,
   createSlice,
 } from '@reduxjs/toolkit'
-import { Cluster, ClusterLogs, ClusterRequest, ClusterStatus, ClustersApi } from 'qovery-typescript-axios'
-import { ClusterEntity, ClustersState } from '@qovery/shared/interfaces'
+import {
+  Cluster,
+  ClusterAdvancedSettings,
+  ClusterLogs,
+  ClusterRequest,
+  ClusterStatus,
+  ClustersApi,
+} from 'qovery-typescript-axios'
+import { AdvancedSettings, ClusterEntity, ClustersState } from '@qovery/shared/interfaces'
 import { ToastEnum, toast, toastError } from '@qovery/shared/ui'
 import { addOneToManyRelation, getEntitiesByIds, refactoClusterPayload } from '@qovery/shared/utils'
 import { RootState } from '@qovery/store'
@@ -61,11 +68,50 @@ export const editCluster = createAsyncThunk(
   }
 )
 
+export const editClusterAdvancedSettings = createAsyncThunk<
+  ClusterAdvancedSettings,
+  {
+    organizationId: string
+    clusterId: string
+    settings: ClusterAdvancedSettings
+    toasterCallback: () => void
+  }
+>('cluster/advancedSettings/edit', async (data) => {
+  const response = await clusterApi.editClusterAdvancedSettings(
+    data.organizationId,
+    data.clusterId,
+    data.settings as ClusterAdvancedSettings
+  )
+
+  return response.data as ClusterAdvancedSettings
+})
+
+export const fetchDefaultClusterAdvancedSettings = createAsyncThunk<AdvancedSettings>(
+  'cluster/defaultAdvancedSettings',
+  async () => {
+    // const response = await clusterApi.getDefaultClusterAdvancedSettings()
+    const response = await clusterApi.getClusterAdvancedSettings('1', '1')
+    return response.data
+  }
+)
+
+export const fetchClusterAdvancedSettings = createAsyncThunk<
+  ClusterAdvancedSettings,
+  { organizationId: string; clusterId: string }
+>('cluster/advancedSettings', async (data) => {
+  const response = await clusterApi.getClusterAdvancedSettings(data.organizationId, data.clusterId)
+  return response.data as ClusterAdvancedSettings
+})
+
 export const initialClusterState: ClustersState = clusterAdapter.getInitialState({
   loadingStatus: 'not loaded',
   error: null,
   joinOrganizationClusters: {},
   statusLoadingStatus: 'not loaded',
+  defaultClusterAdvancedSettings: {
+    loadingStatus: 'not loaded',
+    settings: undefined,
+  },
 })
 
 export const clusterSlice = createSlice({
@@ -209,6 +255,110 @@ export const clusterSlice = createSlice({
         state.loadingStatus = 'error'
         toastError(action.error)
         state.error = action.error.message
+      })
+      // default advanced settings
+      .addCase(fetchDefaultClusterAdvancedSettings.pending, (state: ClustersState, action) => {
+        state.defaultClusterAdvancedSettings.settings = action.payload
+      })
+      .addCase(fetchDefaultClusterAdvancedSettings.fulfilled, (state: ClustersState, action) => {
+        state.defaultClusterAdvancedSettings.settings = action.payload
+        state.defaultClusterAdvancedSettings.loadingStatus = 'loaded'
+      })
+      .addCase(fetchDefaultClusterAdvancedSettings.rejected, (state: ClustersState, action) => {
+        state.defaultClusterAdvancedSettings.loadingStatus = 'error'
+      })
+      // fetch cluster advanced settings
+      .addCase(fetchClusterAdvancedSettings.pending, (state: ClustersState, action) => {
+        const clusterId = action.meta.arg.clusterId
+        const update: Update<ClusterEntity> = {
+          id: clusterId,
+          changes: {
+            advanced_settings: {
+              loadingStatus: 'loading',
+              current_settings: undefined,
+            },
+          },
+        }
+        clusterAdapter.updateOne(state, update)
+      })
+      .addCase(fetchClusterAdvancedSettings.fulfilled, (state: ClustersState, action) => {
+        const clusterId = action.meta.arg.clusterId
+        const update: Update<ClusterEntity> = {
+          id: clusterId,
+          changes: {
+            advanced_settings: {
+              loadingStatus: 'loaded',
+              current_settings: action.payload,
+            },
+          },
+        }
+        clusterAdapter.updateOne(state, update)
+      })
+      .addCase(fetchClusterAdvancedSettings.rejected, (state: ClustersState, action) => {
+        const clusterId = action.meta.arg.clusterId
+        const update: Update<ClusterEntity> = {
+          id: clusterId,
+          changes: {
+            advanced_settings: {
+              loadingStatus: 'error',
+              current_settings: undefined,
+            },
+          },
+        }
+        clusterAdapter.updateOne(state, update)
+      })
+      // edit cluster advanced settings
+      .addCase(editClusterAdvancedSettings.pending, (state: ClustersState, action) => {
+        const clusterId = action.meta.arg.clusterId
+        const update: Update<ClusterEntity> = {
+          id: clusterId,
+          changes: {
+            advanced_settings: {
+              loadingStatus: 'loading',
+              current_settings: state.entities[clusterId]?.advanced_settings?.current_settings,
+            },
+          },
+        }
+        clusterAdapter.updateOne(state, update)
+      })
+      .addCase(editClusterAdvancedSettings.fulfilled, (state: ClustersState, action) => {
+        const clusterId = action.meta.arg.clusterId
+        const update: Update<ClusterEntity> = {
+          id: clusterId,
+          changes: {
+            advanced_settings: {
+              loadingStatus: 'loaded',
+              current_settings: action.payload,
+            },
+          },
+        }
+        toast(
+          ToastEnum.SUCCESS,
+          `Cluster updated`,
+          'You must redeploy to apply the settings update',
+          action.meta.arg.toasterCallback,
+          undefined,
+          'Redeploy'
+        )
+        clusterAdapter.updateOne(state, update)
+      })
+      .addCase(editClusterAdvancedSettings.rejected, (state: ClustersState, action) => {
+        const clusterId = action.meta.arg.clusterId
+        const update: Update<ClusterEntity> = {
+          id: clusterId,
+          changes: {
+            advanced_settings: {
+              loadingStatus: 'error',
+              current_settings: state.entities[clusterId]?.advanced_settings?.current_settings,
+            },
+          },
+        }
+
+        toast(
+          ToastEnum.ERROR,
+          `Your advanced settings have not been updated. Something must be wrong with the values provided`
+        )
+        clusterAdapter.updateOne(state, update)
       })
   },
 })

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.spec.ts
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.spec.ts
@@ -1,0 +1,32 @@
+import { ClusterAdvancedSettings } from 'qovery-typescript-axios'
+import { getServiceType } from '@qovery/shared/enums'
+import { applicationFactoryMock } from '@qovery/shared/factories'
+import { ApplicationEntity } from '@qovery/shared/interfaces'
+import { initFormValues } from './init-form-values'
+
+const mockCluster: ApplicationEntity = applicationFactoryMock(1)[0]
+const mockAdvancedSettings: Partial<ClusterAdvancedSettings> = {
+  'registry.image_retention_time': 60,
+  'pleco.resources_ttl': 10,
+  'load_balancer.size': '/',
+}
+mockCluster.advanced_settings = {
+  loadingStatus: 'loaded',
+  current_settings: mockAdvancedSettings,
+}
+
+describe('InitFormValues', () => {
+  it('should return the init values', () => {
+    expect(
+      initFormValues(
+        ['registry.image_retention_time', 'pleco.resources_ttl', 'load_balancer.size'],
+        mockCluster,
+        getServiceType(mockCluster)
+      )
+    ).toStrictEqual({
+      'registry.image_retention_time': '60',
+      'pleco.resources_ttl': '10',
+      'load_balancer.size': '/',
+    })
+  })
+})

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.spec.ts
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.spec.ts
@@ -7,8 +7,9 @@ import { initFormValues } from './init-form-values'
 const mockCluster: ApplicationEntity = applicationFactoryMock(1)[0]
 const mockAdvancedSettings: Partial<ClusterAdvancedSettings> = {
   'registry.image_retention_time': 60,
-  'pleco.resources_ttl': 10,
-  'load_balancer.size': '/',
+  'aws.vpc.enable_s3_flow_logs': false,
+  'aws.iam.admin_group': 'Admins',
+  'cloud_provider.container_registry.tags': {},
 }
 mockCluster.advanced_settings = {
   loadingStatus: 'loaded',
@@ -19,14 +20,19 @@ describe('InitFormValues', () => {
   it('should return the init values', () => {
     expect(
       initFormValues(
-        ['registry.image_retention_time', 'pleco.resources_ttl', 'load_balancer.size'],
-        mockCluster,
-        getServiceType(mockCluster)
+        [
+          'registry.image_retention_time',
+          'aws.vpc.enable_s3_flow_logs',
+          'aws.iam.admin_group',
+          'cloud_provider.container_registry.tags',
+        ],
+        mockCluster
       )
     ).toStrictEqual({
       'registry.image_retention_time': '60',
-      'pleco.resources_ttl': '10',
-      'load_balancer.size': '/',
+      'aws.vpc.enable_s3_flow_logs': 'false',
+      'aws.iam.admin_group': 'Admins',
+      'cloud_provider.container_registry.tags': '{}',
     })
   })
 })

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.ts
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.ts
@@ -6,8 +6,10 @@ export function initFormValues(keys: string[], cluster: ClusterEntity): { [key: 
 
   keys.forEach((key) => {
     const currentSettings = cluster?.advanced_settings?.current_settings
+
     if (currentSettings) {
-      values[key] = currentSettings[key as keyof ClusterAdvancedSettings]?.toString() || ''
+      const value = currentSettings[key as keyof ClusterAdvancedSettings]
+      values[key] = (typeof value === 'object' ? JSON.stringify(value) : value?.toString()) || ''
     }
   })
 

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.ts
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.ts
@@ -1,0 +1,15 @@
+import { ClusterAdvancedSettings } from 'qovery-typescript-axios'
+import { ClusterEntity } from '@qovery/shared/interfaces'
+
+export function initFormValues(keys: string[], cluster: ClusterEntity): { [key: string]: string } {
+  const values: { [key: string]: string } = {}
+
+  keys.forEach((key) => {
+    const currentSettings = cluster?.advanced_settings?.current_settings
+    if (currentSettings) {
+      values[key] = currentSettings[key as keyof ClusterAdvancedSettings]?.toString() || ''
+    }
+  })
+
+  return values
+}

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.spec.tsx
@@ -1,0 +1,174 @@
+import { act, fireEvent } from '@testing-library/react'
+import { render } from '__tests__/utils/setup-jest'
+import { JobAdvancedSettings } from 'qovery-typescript-axios'
+import React from 'react'
+import * as storeApplication from '@qovery/domains/application'
+import { cronjobFactoryMock } from '@qovery/shared/factories'
+import { JobApplicationEntity } from '@qovery/shared/interfaces'
+import * as InitFormValues from './init-form-values/init-form-values'
+import PageSettingsAdvancedFeature from './page-settings-advanced-feature'
+
+import SpyInstance = jest.SpyInstance
+
+const mockApplication: JobApplicationEntity = cronjobFactoryMock(1)[0]
+const mockAdvancedSettings: Partial<JobAdvancedSettings> = {
+  'liveness_probe.http_get.path': '/',
+  'cronjob.success_jobs_history_limit': 1,
+  'job.delete_ttl_seconds_after_finished': null,
+}
+
+jest.mock('./init-form-values/init-form-values', () => ({
+  ...jest.requireActual('./init-form-values/init-form-values'),
+}))
+
+jest.mock('react-router-dom', () => ({
+  ...(jest.requireActual('react-router-dom') as any),
+  useParams: () => ({ applicationId: mockApplication.id }),
+}))
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => jest.fn(),
+}))
+
+jest.mock('@qovery/domains/application', () => {
+  return {
+    ...jest.requireActual('@qovery/domains/application'),
+    editApplicationAdvancedSettings: jest.fn(),
+    fetchApplicationAdvancedSettings: jest.fn(),
+    fetchDefaultApplicationAdvancedSettings: jest.fn(),
+    getApplicationsState: () => ({
+      defaultApplicationAdvancedSettings: {
+        loadingStatus: 'loaded',
+        settings: mockAdvancedSettings,
+      },
+      loadingStatus: 'loaded',
+      ids: [mockApplication.id],
+      entities: {
+        [mockApplication.id]: mockApplication,
+      },
+      error: null,
+    }),
+    selectApplicationById: () => mockApplication,
+  }
+})
+
+describe('PageSettingsAdvancedFeature', () => {
+  let useDispatchSpy: SpyInstance
+  const setState = jest.fn()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const useStateMock: any = (initState: any) => [initState, setState]
+  let promise: Promise
+
+  beforeEach(() => {
+    mockApplication.advanced_settings = {
+      loadingStatus: 'not loaded',
+      current_settings: mockAdvancedSettings,
+    }
+    promise = Promise.resolve()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  it('should render successfully', async () => {
+    const { baseElement } = render(<PageSettingsAdvancedFeature />)
+    expect(baseElement).toBeTruthy()
+
+    await act(async () => {
+      await promise
+    })
+  })
+
+  it('should dispatch fetchDefaultApplicationAdvancedSettings', async () => {
+    const fetchDefaultApplicationAdvancedSettingsSpy: SpyInstance = jest.spyOn(
+      storeApplication,
+      'fetchDefaultApplicationAdvancedSettings'
+    )
+    render(<PageSettingsAdvancedFeature />)
+    expect(fetchDefaultApplicationAdvancedSettingsSpy).toHaveBeenCalled()
+
+    await act(async () => {
+      await promise
+    })
+  })
+
+  it('should dispatch fetchApplicationAdvancedSettings if advanced_settings does not exist', async () => {
+    mockApplication.advanced_settings = undefined
+    const fetchApplicationAdvancedSettingsSpy: SpyInstance = jest.spyOn(
+      storeApplication,
+      'fetchApplicationAdvancedSettings'
+    )
+    render(<PageSettingsAdvancedFeature />)
+    expect(fetchApplicationAdvancedSettingsSpy).toHaveBeenCalled()
+
+    await act(async () => {
+      await promise
+    })
+  })
+
+  // I think the useForm hook also use useState, this is why the first 4th call are to ignored. https://gist.github.com/mauricedb/eb2bae5592e3ddc64fa965cde4afe7bc
+  it('should set the keys if application and advanced_settings are defined', async () => {
+    mockApplication.advanced_settings!.loadingStatus = 'loaded'
+    jest.spyOn(React, 'useState').mockImplementation(useStateMock)
+    render(<PageSettingsAdvancedFeature />)
+    expect(setState).toHaveBeenNthCalledWith(
+      10,
+      Object.keys(mockApplication.advanced_settings?.current_settings || {}).sort()
+    )
+    await act(async () => {
+      await promise
+    })
+  })
+
+  it('should dispatch editApplicationAdvancedSettings if form is submitted', async () => {
+    mockApplication.advanced_settings!.loadingStatus = 'loaded'
+    const editApplicationAdvancedSettingsSpy: SpyInstance = jest.spyOn(
+      storeApplication,
+      'editApplicationAdvancedSettings'
+    )
+
+    const { getByLabelText, getByTestId } = render(<PageSettingsAdvancedFeature />)
+
+    await act(() => {
+      const input = getByLabelText('cronjob.success_jobs_history_limit')
+      fireEvent.input(input, { target: { value: '63' } })
+
+      fireEvent.input(getByLabelText('job.delete_ttl_seconds_after_finished'), { target: { value: '999999' } })
+    })
+
+    await act(() => {
+      fireEvent.input(getByLabelText('job.delete_ttl_seconds_after_finished'), { target: { value: null } })
+    })
+
+    expect(getByTestId('submit-button')).not.toBeDisabled()
+
+    await act(() => {
+      getByTestId('submit-button').click()
+    })
+
+    expect(editApplicationAdvancedSettingsSpy.mock.calls[0][0].applicationId).toBe(mockApplication.id)
+    expect(editApplicationAdvancedSettingsSpy.mock.calls[0][0].settings).toStrictEqual({
+      'liveness_probe.http_get.path': '/',
+      'cronjob.success_jobs_history_limit': 63,
+      'job.delete_ttl_seconds_after_finished': null, // getting null here is pretty important to fix an inconsitency with backend between numbers and string
+    })
+
+    await act(async () => {
+      await promise
+    })
+  })
+
+  it('should init the form', async () => {
+    mockApplication.advanced_settings!.loadingStatus = 'loaded'
+    const spy = jest.spyOn(InitFormValues, 'initFormValues')
+    render(<PageSettingsAdvancedFeature />)
+    expect(spy).toHaveBeenCalled()
+
+    await act(async () => {
+      await promise
+    })
+  })
+})

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.spec.tsx
@@ -117,7 +117,9 @@ describe('PageSettingsAdvancedFeature', () => {
       fireEvent.input(getByLabelText('loki.log_retention_in_week'), { target: { value: '2' } })
       fireEvent.input(getByLabelText('aws.vpc.enable_s3_flow_logs'), { target: { value: 'true' } })
       fireEvent.input(getByLabelText('load_balancer.size'), { target: { value: '/' } })
-      fireEvent.input(getByLabelText('cloud_provider_container_registry_tags'), { target: { value: '{}' } })
+      fireEvent.input(getByLabelText('cloud_provider_container_registry_tags'), {
+        target: { value: '{"test":"test"}' },
+      })
     })
 
     expect(getByTestId('submit-button')).not.toBeDisabled()
@@ -131,7 +133,7 @@ describe('PageSettingsAdvancedFeature', () => {
       'loki.log_retention_in_week': 2,
       'aws.vpc.enable_s3_flow_logs': true,
       'load_balancer.size': '/',
-      cloud_provider_container_registry_tags: '{}',
+      cloud_provider_container_registry_tags: { test: 'test' },
     })
 
     await act(async () => {

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.tsx
@@ -84,9 +84,16 @@ export function PageSettingsAdvancedFeature() {
     // we can't do ClusterAdvanceSettings[key] === 'string' or 'number'
     // so if field is empty string replace by value found in defaultSettings (because default value is well typed)
     Object.keys(dataFormatted).forEach((key) => {
-      if (dataFormatted[key] === '') {
-        dataFormatted[key] = defaultSettings ? defaultSettings[key as keyof AdvancedSettings] : ''
+      // check if we can convert this string to object
+      try {
+        JSON.parse(dataFormatted[key])
+      } catch (e) {
+        if (dataFormatted[key] === '') {
+          dataFormatted[key] = defaultSettings ? defaultSettings[key as keyof AdvancedSettings] : ''
+        }
+        return
       }
+      dataFormatted[key] = JSON.parse(dataFormatted[key])
     })
 
     if (cluster) {

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.tsx
@@ -10,7 +10,7 @@ import {
   postClusterActionsUpdate,
   selectClusterById,
 } from '@qovery/domains/organization'
-import { AdvancedSettings, ClusterEntity } from '@qovery/shared/interfaces'
+import { AdvancedSettings, ClusterEntity, LoadingStatus } from '@qovery/shared/interfaces'
 import { objectFlattener } from '@qovery/shared/utils'
 import { AppDispatch, RootState } from '@qovery/store'
 import PageSettingsAdvanced from '../../ui/page-settings-advanced/page-settings-advanced'
@@ -20,6 +20,9 @@ export function PageSettingsAdvancedFeature() {
   const { organizationId = '', clusterId = '' } = useParams()
 
   const cluster = useSelector<RootState, ClusterEntity | undefined>((state) => selectClusterById(state, clusterId))
+  const defaultSettingsLoadingStatus = useSelector<RootState, LoadingStatus>(
+    (state) => getClusterState(state).defaultClusterAdvancedSettings.loadingStatus
+  )
   const defaultSettings = useSelector<RootState, AdvancedSettings | undefined>(
     (state) => getClusterState(state).defaultClusterAdvancedSettings.settings
   )
@@ -30,10 +33,10 @@ export function PageSettingsAdvancedFeature() {
 
   // at the init fetch the default settings advanced settings
   useEffect(() => {
-    if (cluster) {
+    if (!cluster?.advanced_settings?.loadingStatus && defaultSettingsLoadingStatus === 'not loaded') {
       dispatch(fetchDefaultClusterAdvancedSettings())
     }
-  }, [cluster, dispatch])
+  }, [cluster, defaultSettingsLoadingStatus])
 
   // when cluster is ready, and advanced setting has never been fetched before
   useEffect(() => {
@@ -44,10 +47,8 @@ export function PageSettingsAdvancedFeature() {
 
   // init the keys when cluster is updated
   useEffect(() => {
-    if (cluster) {
-      if (cluster.advanced_settings?.current_settings && cluster.advanced_settings?.loadingStatus === 'loaded') {
-        setKeys(Object.keys(cluster.advanced_settings.current_settings).sort())
-      }
+    if (cluster?.advanced_settings?.current_settings && cluster.advanced_settings?.loadingStatus === 'loaded') {
+      setKeys(Object.keys(cluster?.advanced_settings.current_settings).sort())
     }
   }, [cluster])
 
@@ -108,7 +109,7 @@ export function PageSettingsAdvancedFeature() {
         loading={cluster?.advanced_settings?.loadingStatus}
         keys={keys}
         discardChanges={() => methods.reset()}
-        onSubmit={() => onSubmit().then()}
+        onSubmit={() => onSubmit()}
       />
     </FormProvider>
   )

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useDispatch, useSelector } from 'react-redux'
+import { useParams } from 'react-router-dom'
+import {
+  editClusterAdvancedSettings,
+  fetchClusterAdvancedSettings,
+  fetchDefaultClusterAdvancedSettings,
+  getClusterState,
+  postClusterActionsUpdate,
+  selectClusterById,
+} from '@qovery/domains/organization'
+import { AdvancedSettings, ClusterEntity } from '@qovery/shared/interfaces'
+import { objectFlattener } from '@qovery/shared/utils'
+import { AppDispatch, RootState } from '@qovery/store'
+import PageSettingsAdvanced from '../../ui/page-settings-advanced/page-settings-advanced'
+import { initFormValues } from './init-form-values/init-form-values'
+
+export function PageSettingsAdvancedFeature() {
+  const { organizationId = '', clusterId = '' } = useParams()
+
+  const cluster = useSelector<RootState, ClusterEntity | undefined>((state) => selectClusterById(state, clusterId))
+  const defaultSettings = useSelector<RootState, AdvancedSettings | undefined>(
+    (state) => getClusterState(state).defaultClusterAdvancedSettings.settings
+  )
+  const [keys, setKeys] = useState<string[]>([])
+
+  const dispatch = useDispatch<AppDispatch>()
+  const methods = useForm({ mode: 'onChange' })
+
+  // at the init fetch the default settings advanced settings
+  useEffect(() => {
+    if (cluster) {
+      dispatch(fetchDefaultClusterAdvancedSettings())
+    }
+  }, [cluster, dispatch])
+
+  // when cluster is ready, and advanced setting has never been fetched before
+  useEffect(() => {
+    if (cluster && !cluster.advanced_settings?.loadingStatus) {
+      dispatch(fetchClusterAdvancedSettings({ organizationId, clusterId }))
+    }
+  }, [dispatch, cluster, organizationId, clusterId])
+
+  // init the keys when cluster is updated
+  useEffect(() => {
+    if (cluster) {
+      if (cluster.advanced_settings?.current_settings && cluster.advanced_settings?.loadingStatus === 'loaded') {
+        setKeys(Object.keys(cluster.advanced_settings.current_settings).sort())
+      }
+    }
+  }, [cluster])
+
+  // init form
+  useEffect(() => {
+    if (cluster && cluster.advanced_settings?.loadingStatus === 'loaded') {
+      methods.reset(initFormValues(keys, cluster))
+    }
+  }, [cluster, keys, methods])
+
+  const toasterCallback = () => {
+    if (cluster) {
+      dispatch(postClusterActionsUpdate({ organizationId, clusterId }))
+    }
+  }
+
+  const onSubmit = methods.handleSubmit((data) => {
+    let dataFormatted = { ...data }
+
+    Object.keys(dataFormatted).forEach((key) => {
+      if (key.includes('.')) {
+        delete dataFormatted[key]
+      }
+    })
+
+    dataFormatted = objectFlattener(dataFormatted)
+
+    // below is a hack to handle the weird way the payload behaves
+    // empty string must be sent as ''
+    // empty numbers must be sent as null
+    // the thing is we don't know in advance if the value is a string or a number
+    // the interface has this information, but we can't check the type of the property of the interface
+    // we can't do ClusterAdvanceSettings[key] === 'string' or 'number'
+    // so if field is empty string replace by value found in defaultSettings (because default value is well typed)
+    Object.keys(dataFormatted).forEach((key) => {
+      if (dataFormatted[key] === '') {
+        dataFormatted[key] = defaultSettings ? defaultSettings[key as keyof AdvancedSettings] : ''
+      }
+    })
+
+    if (cluster) {
+      dispatch(
+        editClusterAdvancedSettings({
+          organizationId,
+          clusterId,
+          settings: dataFormatted,
+          toasterCallback,
+        })
+      )
+    }
+  })
+
+  return (
+    <FormProvider {...methods}>
+      <PageSettingsAdvanced
+        defaultAdvancedSettings={defaultSettings}
+        advancedSettings={cluster?.advanced_settings?.current_settings}
+        loading={cluster?.advanced_settings?.loadingStatus}
+        keys={keys}
+        discardChanges={() => methods.reset()}
+        onSubmit={() => onSubmit().then()}
+      />
+    </FormProvider>
+  )
+}
+
+export default PageSettingsAdvancedFeature

--- a/libs/pages/cluster/src/lib/router/router.tsx
+++ b/libs/pages/cluster/src/lib/router/router.tsx
@@ -9,6 +9,7 @@ import {
   CLUSTER_SETTINGS_URL,
   Route,
 } from '@qovery/shared/routes'
+import PageSettingsAdvancedFeature from '../feature/page-settings-advanced-feature/page-settings-advanced-feature'
 import { PageSettingsDangerZoneFeature } from '../feature/page-settings-danger-zone-feature/page-settings-danger-zone-feature'
 import { PageSettingsFeature } from '../feature/page-settings-feature/page-settings-feature'
 import PageSettingsGeneralFeature from '../feature/page-settings-general-feature/page-settings-general-feature'
@@ -44,7 +45,7 @@ export const ROUTER_CLUSTER_SETTINGS: Route[] = [
   },
   {
     path: CLUSTER_SETTINGS_ADVANCED_SETTINGS_URL,
-    component: <PageSettingsV2 />,
+    component: <PageSettingsAdvancedFeature />,
   },
   {
     path: CLUSTER_SETTINGS_DANGER_ZONE_URL,

--- a/libs/pages/cluster/src/lib/ui/page-settings-advanced/page-settings-advanced.spec.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-advanced/page-settings-advanced.spec.tsx
@@ -1,0 +1,114 @@
+import { act, fireEvent, getByTestId } from '@testing-library/react'
+import { render } from '__tests__/utils/setup-jest'
+import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
+import PageSettingsAdvanced, { PageSettingsAdvancedProps } from './page-settings-advanced'
+
+const keys = [
+  'liveness_probe.http_get.path',
+  'cronjob.success_jobs_history_limit',
+  'test_empty',
+  'job.delete_ttl_seconds_after_finished',
+]
+const defaultValues: { [key: string]: string | number | null } = {
+  'liveness_probe.http_get.path': '/',
+  'cronjob.success_jobs_history_limit': 3,
+  test_empty: '',
+  'job.delete_ttl_seconds_after_finished': 3,
+}
+
+const defaultAdvancedSetting: { [key: string]: string | number | null } = {
+  'liveness_probe.http_get.path': '/',
+  'cronjob.success_jobs_history_limit': 1,
+  test_empty: '',
+  'job.delete_ttl_seconds_after_finished': null,
+}
+
+const props: PageSettingsAdvancedProps = {
+  keys: keys,
+  discardChanges: jest.fn(),
+  onSubmit: jest.fn(),
+  defaultAdvancedSettings: defaultAdvancedSetting,
+  loading: 'loaded',
+  advancedSettings: undefined,
+}
+
+describe('PageSettingsAdvanced', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(
+      wrapWithReactHookForm(<PageSettingsAdvanced {...props} />, { defaultValues: defaultValues })
+    )
+    expect(baseElement).toBeTruthy()
+  })
+
+  it('should have three inputs', () => {
+    const { getAllByTestId } = render(
+      wrapWithReactHookForm(<PageSettingsAdvanced {...props} />, { defaultValues: defaultValues })
+    )
+    expect(getAllByTestId('input').length).toBe(4)
+  })
+
+  it('should show the sticky action bar if form dirty', async () => {
+    const { getByTestId, getByLabelText } = render(
+      wrapWithReactHookForm(<PageSettingsAdvanced {...props} />, { defaultValues: defaultValues })
+    )
+
+    await act(() => {
+      const input = getByLabelText('liveness_probe.http_get.path')
+      fireEvent.input(input, { target: { value: 'hello' } })
+    })
+
+    expect(getByTestId('sticky-action-form-toaster')).toHaveClass('visible')
+  })
+
+  it('should disabled the form submit', async () => {
+    const { getByTestId, getByLabelText } = render(
+      wrapWithReactHookForm(<PageSettingsAdvanced {...props} />, { defaultValues: defaultValues })
+    )
+
+    await act(() => {
+      const input = getByLabelText('liveness_probe.http_get.path')
+      fireEvent.input(input, { target: { value: '79' } })
+      fireEvent.input(input, { target: { value: '' } })
+    })
+
+    expect(getByTestId('submit-button')).toBeDisabled()
+  })
+
+  it('field with empty defaultValue should not be required', async () => {
+    const { getByLabelText, baseElement } = render(
+      wrapWithReactHookForm(<PageSettingsAdvanced {...props} />, { defaultValues: defaultValues })
+    )
+
+    await act(() => {
+      const input = getByLabelText('test_empty')
+      fireEvent.input(input, { target: { value: '79' } })
+      fireEvent.input(input, { target: { value: '' } })
+    })
+
+    expect(getByTestId(baseElement, 'submit-button')).not.toBeDisabled()
+  })
+
+  it('should display only overridden settings', async () => {
+    props.advancedSettings = {
+      'build.timeout_max_sec': 60,
+      'deployment.custom_domain_check_enabled': true,
+      'liveness_probe.http_get.path': '/',
+    }
+    const { getByTestId, getAllByTestId } = render(
+      wrapWithReactHookForm(<PageSettingsAdvanced {...props} />, { defaultValues: defaultValues })
+    )
+
+    await act(() => {
+      getByTestId('show-overriden-only-toggle').click()
+    })
+
+    let count = 0
+    getAllByTestId('edition-table-row').forEach((row) => {
+      if (row.classList.contains('hidden')) {
+        count++
+      }
+    })
+
+    expect(count).toBe(2)
+  })
+})

--- a/libs/pages/cluster/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
@@ -1,0 +1,188 @@
+import { ClusterAdvancedSettings } from 'qovery-typescript-axios'
+import { useState } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import { AdvancedSettings, LoadingStatus } from '@qovery/shared/interfaces'
+import {
+  CopyToClipboard,
+  HelpSection,
+  InputTextSmall,
+  InputToggle,
+  LoaderSpinner,
+  StickyActionFormToaster,
+  TableEdition,
+  TableEditionRow,
+  Tooltip,
+} from '@qovery/shared/ui'
+
+export interface PageSettingsAdvancedProps {
+  keys?: string[]
+  defaultAdvancedSettings?: AdvancedSettings
+  advancedSettings?: AdvancedSettings
+  loading: LoadingStatus
+  onSubmit?: () => void
+  discardChanges: () => void
+}
+
+export function PageSettingsAdvanced(props: PageSettingsAdvancedProps) {
+  const { control, formState } = useFormContext()
+  const [showOverriddenOnly, toggleShowOverriddenOnly] = useState(false)
+
+  let table: TableEditionRow[] = [
+    {
+      cells: [
+        {
+          content: 'Settings',
+        },
+        {
+          content: 'Default Value',
+        },
+        {
+          content: <span className="px-3">Value</span>,
+          className: '!p-1',
+        },
+      ],
+      className: 'font-medium hover:bg-white',
+    },
+  ]
+
+  const tableBody: TableEditionRow[] = props.keys
+    ? props.keys?.map((key) => {
+        return {
+          className: `${
+            showOverriddenOnly &&
+            props.defaultAdvancedSettings &&
+            props.advancedSettings &&
+            props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString() ===
+              props.advancedSettings[key as keyof ClusterAdvancedSettings]?.toString()
+              ? 'hidden'
+              : ''
+          }`,
+          cells: [
+            {
+              content: (
+                <Tooltip content={key}>
+                  <div>{key}</div>
+                </Tooltip>
+              ),
+              className: 'font-medium vis',
+            },
+            {
+              content: (
+                <>
+                  <Tooltip
+                    content={
+                      (props.defaultAdvancedSettings &&
+                        props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString()) ||
+                      ''
+                    }
+                  >
+                    <div className="inline whitespace-nowrap overflow-hidden text-ellipsis">
+                      {props.defaultAdvancedSettings &&
+                        props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString()}
+                    </div>
+                  </Tooltip>
+                  <CopyToClipboard
+                    className="ml-2 text-text-300 invisible group-hover:visible"
+                    content={
+                      (props.defaultAdvancedSettings &&
+                        props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString()) ||
+                      ''
+                    }
+                  />
+                </>
+              ),
+              className: 'group',
+            },
+            {
+              className: '!p-1',
+              content: (
+                <Controller
+                  name={key}
+                  control={control}
+                  rules={{
+                    required:
+                      props.defaultAdvancedSettings &&
+                      (props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings] === null ||
+                        props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString().length === 0)
+                        ? false
+                        : 'Please enter a value.',
+                  }}
+                  defaultValue=""
+                  render={({ field, fieldState: { error } }) => (
+                    <InputTextSmall
+                      className="shrink-0 grow flex-1"
+                      data-testid="value"
+                      name={field.name}
+                      onChange={field.onChange}
+                      value={field.value}
+                      error={error?.message}
+                      errorMessagePosition="left"
+                      label={field.name}
+                    />
+                  )}
+                />
+              ),
+            },
+          ],
+        }
+      })
+    : []
+
+  table = [...table, ...tableBody]
+
+  return (
+    <div className="flex flex-col justify-between w-full">
+      <div className="p-8 ">
+        <div className="flex justify-between mb-4">
+          <div>
+            <h1 className="h5 text-text-700 mb-2">Advanced Settings</h1>
+            <p className="text-sm text-text-500 max-w-content-with-navigation-left">
+              Settings are injected at the build and run time of your application and thus any change on this section
+              will be applied on the next manual/automatic deploy.
+            </p>
+          </div>
+        </div>
+
+        <InputToggle
+          small
+          className="mb-6"
+          dataTestId="show-overriden-only-toggle"
+          value={showOverriddenOnly}
+          onChange={toggleShowOverriddenOnly}
+          title="Show only overridden settings"
+        />
+
+        <form onSubmit={props.onSubmit}>
+          <div className="relative">
+            {(!props.loading || props.loading === 'loading') && props.keys?.length === 0 ? (
+              <div className="flex justify-center">
+                <LoaderSpinner className="w-6" />
+              </div>
+            ) : (
+              <TableEdition tableBody={table} />
+            )}
+            <StickyActionFormToaster
+              visible={formState.isDirty}
+              onSubmit={props.onSubmit}
+              onReset={props.discardChanges}
+              disabledValidation={!formState.isValid}
+              loading={props.loading === 'loading'}
+            />
+          </div>
+        </form>
+      </div>
+      <HelpSection
+        description="Need help? You may find these links useful"
+        links={[
+          {
+            link: 'https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/',
+            linkLabel: 'How to configure my cluster',
+            external: true,
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+export default PageSettingsAdvanced

--- a/libs/pages/cluster/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
@@ -67,30 +67,33 @@ export function PageSettingsAdvanced(props: PageSettingsAdvancedProps) {
               className: 'font-medium vis',
             },
             {
-              content: (
-                <>
-                  <Tooltip
-                    content={
-                      (props.defaultAdvancedSettings &&
-                        props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString()) ||
-                      ''
-                    }
-                  >
-                    <div className="inline whitespace-nowrap overflow-hidden text-ellipsis">
-                      {props.defaultAdvancedSettings &&
-                        props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString()}
-                    </div>
-                  </Tooltip>
-                  <CopyToClipboard
-                    className="ml-2 text-text-300 invisible group-hover:visible"
-                    content={
-                      (props.defaultAdvancedSettings &&
-                        props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString()) ||
-                      ''
-                    }
-                  />
-                </>
-              ),
+              content: () => {
+                const value =
+                  props.defaultAdvancedSettings && props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]
+                const displayValue = (typeof value === 'object' ? JSON.stringify(value) : value?.toString()) || ''
+
+                return (
+                  <>
+                    <Tooltip
+                      content={
+                        (props.defaultAdvancedSettings &&
+                          props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString()) ||
+                        ''
+                      }
+                    >
+                      <div className="inline whitespace-nowrap overflow-hidden text-ellipsis">{displayValue}</div>
+                    </Tooltip>
+                    <CopyToClipboard
+                      className="ml-2 text-text-300 invisible group-hover:visible"
+                      content={
+                        (props.defaultAdvancedSettings &&
+                          props.defaultAdvancedSettings[key as keyof ClusterAdvancedSettings]?.toString()) ||
+                        ''
+                      }
+                    />
+                  </>
+                )
+              },
               className: 'group',
             },
             {

--- a/libs/shared/interfaces/src/lib/domain/advanced-settings.interface.ts
+++ b/libs/shared/interfaces/src/lib/domain/advanced-settings.interface.ts
@@ -1,4 +1,4 @@
-import { ApplicationAdvancedSettings, JobAdvancedSettings } from 'qovery-typescript-axios'
+import { ApplicationAdvancedSettings, ClusterAdvancedSettings, JobAdvancedSettings } from 'qovery-typescript-axios'
 import {
   ApplicationAdvancedSettingsLivenessProbeTypeEnum,
   ApplicationAdvancedSettingsReadinessProbeTypeEnum,
@@ -10,7 +10,8 @@ import {
 // we have to omit both liveness and readiness probe type because they are not the same type in the two interfaces
 // declaring again their type like we do below is one efficient workaround
 export interface AdvancedSettings
-  extends Omit<Partial<ApplicationAdvancedSettings>, 'liveness_probe.type' | 'readiness_probe.type'>,
+  extends ClusterAdvancedSettings,
+    Omit<Partial<ApplicationAdvancedSettings>, 'liveness_probe.type' | 'readiness_probe.type'>,
     Omit<Partial<JobAdvancedSettings>, 'liveness_probe.type' | 'readiness_probe.type'> {
   'liveness_probe.type'?: JobAdvancedSettingsLivenessProbeTypeEnum | ApplicationAdvancedSettingsLivenessProbeTypeEnum
   'readiness_probe.type'?: JobAdvancedSettingsReadinessProbeTypeEnum | ApplicationAdvancedSettingsReadinessProbeTypeEnum

--- a/libs/shared/interfaces/src/lib/domain/cluster.entity.ts
+++ b/libs/shared/interfaces/src/lib/domain/cluster.entity.ts
@@ -1,5 +1,6 @@
 import { Cluster, ClusterLogs, ClusterStatusGet } from 'qovery-typescript-axios'
 import { LoadingStatus } from '../..'
+import { AdvancedSettings } from './advanced-settings.interface'
 
 export interface ClusterEntity extends Cluster {
   logs?: {
@@ -9,5 +10,13 @@ export interface ClusterEntity extends Cluster {
   extendedStatus?: {
     loadingStatus: LoadingStatus
     status?: ClusterStatusGet
+  }
+  advanced_settings?: {
+    loadingStatus: LoadingStatus
+    current_settings?: AdvancedSettings
+  }
+  default_advanced_settings?: {
+    loadingStatus: LoadingStatus
+    default_settings?: AdvancedSettings
   }
 }

--- a/libs/shared/interfaces/src/lib/states/clusters.interface.ts
+++ b/libs/shared/interfaces/src/lib/states/clusters.interface.ts
@@ -1,8 +1,13 @@
 import { LoadingStatus } from '../types/loading-status.type'
+import { AdvancedSettings } from './../domain/advanced-settings.interface'
 import { ClusterEntity } from './../domain/cluster.entity'
 import { DefaultEntityState } from './default-entity-state.interface'
 
 export interface ClustersState extends DefaultEntityState<ClusterEntity> {
   joinOrganizationClusters: Record<string, string[]>
   statusLoadingStatus: LoadingStatus
+  defaultClusterAdvancedSettings: {
+    loadingStatus: LoadingStatus
+    settings?: AdvancedSettings
+  }
 }

--- a/libs/shared/ui/src/lib/components/table-edition/table-edition.tsx
+++ b/libs/shared/ui/src/lib/components/table-edition/table-edition.tsx
@@ -1,5 +1,5 @@
 export interface TableEditionCell {
-  content?: React.ReactNode
+  content?: React.ReactNode | (() => React.ReactNode)
   className?: string
 }
 
@@ -36,7 +36,7 @@ export function TableEdition(props: TableEditionProps) {
                 cell.className || ''
               } ${row.cells && row.cells.length - 1 !== indexCell ? 'border-r' : ''}`}
             >
-              {cell.content}
+              {typeof cell.content === 'function' ? cell.content() : cell.content}
             </div>
           ))}
         </div>

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "msw": "^0.42.1",
     "postcss": "8.4.16",
     "posthog-js": "^1.24.0",
-    "qovery-typescript-axios": "^1.1.70",
+    "qovery-typescript-axios": "^1.1.76",
     "react": "18.2.0",
     "react-beautiful-dnd": "^13.1.0",
     "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16711,10 +16711,10 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
-qovery-typescript-axios@^1.1.70:
-  version "1.1.70"
-  resolved "https://registry.yarnpkg.com/qovery-typescript-axios/-/qovery-typescript-axios-1.1.70.tgz#d758a98dc4d153d6c2da4c5a9ef4e76a9b707fa7"
-  integrity sha512-AL1XDoaHgmyBHd2jeuV33bsmHT2j5af0K9crTCRjcWxvVUW4/ZO6vmpCMxZbS4zjgoo2VHmFw2fKv2N5/0sLOQ==
+qovery-typescript-axios@^1.1.76:
+  version "1.1.76"
+  resolved "https://registry.yarnpkg.com/qovery-typescript-axios/-/qovery-typescript-axios-1.1.76.tgz#d460ef97106ead12902c26fec3666bd631229ddb"
+  integrity sha512-MOS5Vw2dRS5SacTuyTsQUwnG4AFk/CNSwISrmc2zyjbL3eCZcLcHJSSC1LSqQbnC6apWKQe+X5LURYqITpa/GA==
   dependencies:
     axios "^0.21.4"
 


### PR DESCRIPTION
# What does this PR do?

[> Link to the JIRA ticket
](https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-499)

- Add advanced settings for Clusters
- For clusters, we can now add "object" for some value

<img width="1792" alt="Capture d’écran 2023-01-20 à 16 49 16" src="https://user-images.githubusercontent.com/533928/213743220-44cc3aae-8aee-492d-86ff-0ef56c0162ca.png">

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] I have found someone to review this PR and pinged him

### Store

- [x] This PR introduces new store changes

### NX

- [x] I have run the dep-graph locally and made sure the tree was clean i.e no circular dependencies
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
