### PR TITLE
fix(cluster-banner): hide when cluster is deployed

### DIFF
--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
@@ -1,6 +1,6 @@
-import { Cluster, StateEnum } from 'qovery-typescript-axios'
+import { StateEnum } from 'qovery-typescript-axios'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import { OrganizationEntity } from '@qovery/shared/interfaces'
+import { ClusterEntity, OrganizationEntity } from '@qovery/shared/interfaces'
 import { INFRA_LOGS_URL } from '@qovery/shared/routes'
 import { Banner, BannerStyle, WarningScreenMobile } from '@qovery/shared/ui'
 import Navigation from '../navigation/navigation'
@@ -10,7 +10,7 @@ export interface LayoutPageProps {
   children?: React.ReactElement
   topBar?: boolean
   organization?: OrganizationEntity
-  cluster?: Cluster
+  cluster?: ClusterEntity
 }
 
 export function LayoutPage(props: LayoutPageProps) {
@@ -32,6 +32,8 @@ export function LayoutPage(props: LayoutPageProps) {
     }
   }
 
+  const clusterIsDeployed = cluster?.extendedStatus?.status?.is_deployed
+
   return (
     <>
       <WarningScreenMobile />
@@ -42,7 +44,7 @@ export function LayoutPage(props: LayoutPageProps) {
           </div>
           <div className="w-full">
             {topBar && <TopBar />}
-            {!matchLogInfraRoute && cluster && displayBanner(cluster.status) && (
+            {!matchLogInfraRoute && cluster && displayBanner(cluster.status) && !clusterIsDeployed && (
               <Banner
                 bannerStyle={BannerStyle.PRIMARY}
                 onClickButton={() => navigate(INFRA_LOGS_URL(organizationId, cluster.id))}


### PR DESCRIPTION
# What does this PR do?

- Hide this banner when cluster is deployed

<img width="1792" alt="Capture d’écran 2023-02-02 à 14 19 41" src="https://user-images.githubusercontent.com/533928/216335836-4bcb7ee7-2915-484e-befa-8e845c542438.png">


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
