### PR TITLE
fix(api-calls): remove unnecessary api calls on each URL changes

### DIFF
--- a/libs/pages/layout/src/lib/feature/layout/layout.tsx
+++ b/libs/pages/layout/src/lib/feature/layout/layout.tsx
@@ -1,7 +1,7 @@
 import { Cluster } from 'qovery-typescript-axios'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useNavigate, useParams } from 'react-router-dom'
+import { redirect, useParams } from 'react-router-dom'
 import { fetchApplications } from '@qovery/domains/application'
 import { fetchDatabases } from '@qovery/domains/database'
 import { fetchEnvironments } from '@qovery/domains/environment'
@@ -30,7 +30,7 @@ export function Layout(props: LayoutProps) {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
 
   const dispatch = useDispatch<AppDispatch>()
-  const navigate = useNavigate()
+
   const clusters = useSelector<RootState, Cluster[]>((state) =>
     selectClustersEntitiesByOrganizationId(state, organizationId)
   )
@@ -50,13 +50,13 @@ export function Layout(props: LayoutProps) {
         if (result.length > 0 && !organizationIds.includes(organizationId)) {
           dispatch(fetchOrganizationById({ organizationId }))
             .unwrap()
-            .catch(() => navigate(ORGANIZATION_URL(result[0].id)))
+            .catch(() => redirect(ORGANIZATION_URL(result[0].id))) // using redirect instead of navigate because navigate was needed in useEffect deps and retriggering everytime we change location https://github.com/remix-run/react-router/discussions/8465#discussioncomment-4051081
         }
       })
       .catch((error) => console.error(error))
 
     dispatch(fetchUserSignUp())
-  }, [dispatch, organizationId, navigate])
+  }, [dispatch, organizationId])
 
   useEffect(() => {
     dispatch(fetchOrganization())


### PR DESCRIPTION
# What does this PR do?

We had a two API calls that was triggered every time we were changing URL on the app. 
<img width="422" alt="CleanShot 2023-02-06 at 12 01 26@2x" src="https://user-images.githubusercontent.com/6163954/216955171-2ef3c970-4c71-4260-bf2e-ffffc83e17cd.png">

The navigate in the useEffect deps was triggering that. After some research about how to deal with that trying to avoid adding an eslint comment to disable the check here, I found this issue on react-router repo:
https://github.com/remix-run/react-router/discussions/8465
where the owner of the repo was suggesting that we use redirect over navigate in this kind of case. We remove the dependence need to navigate and it fixes the problem.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
