### PR TITLE
fix(cluster): changing api call for scaleway available instance type

### DIFF
--- a/libs/domains/organization/src/lib/slices/cluster/cluster.slice.ts
+++ b/libs/domains/organization/src/lib/slices/cluster/cluster.slice.ts
@@ -151,7 +151,7 @@ export const fetchAvailableInstanceTypes = createAsyncThunk<
       response = await cloudProviderApi.listAWSEKSInstanceType(data.region)
     }
   } else {
-    response = await cloudProviderApi.listScalewayInstanceType()
+    response = await cloudProviderApi.listScalewayKapsuleInstanceType(data.region)
   }
 
   return response.data


### PR DESCRIPTION
# What does this PR do?

Changing the endpoint to call available instance type in function of region for scaleway too.

<img width="516" alt="CleanShot 2023-02-09 at 12 54 34@2x" src="https://user-images.githubusercontent.com/6163954/217805948-4ce64f07-c223-4ddb-ab0a-5b6418a88ace.png">

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
