### PR TITLE
fix(job-configure-settings): updated the hint for start event

### DIFF
--- a/libs/shared/console-shared/src/lib/job-configure-settings/ui/job-configure-settings.tsx
+++ b/libs/shared/console-shared/src/lib/job-configure-settings/ui/job-configure-settings.tsx
@@ -87,7 +87,7 @@ export function JobConfigureSettings(props: JobConfigureSettingsProps) {
                 checked={field.value}
                 title="Start"
                 name="on_start"
-                description="Execute this job when the environment starts"
+                description="Execute this job when the environment starts (Deploy and Redeploy)"
                 setChecked={field.onChange}
               >
                 <EntrypointCmdInputs


### PR DESCRIPTION
# What does this PR do?

Just update the wording on the hint for the start event on lifecycle job

> Link to the JIRA ticket

Put description here

> Screenshot of the feature

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ x] I made sure the code is type safe (no any)
