### PR TITLE
fix(env-variable): fix environment variable creation without mount_file

### DIFF
--- a/libs/pages/application/src/lib/feature/crud-environment-variable-modal-feature/crud-environment-variable-modal-feature.tsx
+++ b/libs/pages/application/src/lib/feature/crud-environment-variable-modal-feature/crud-environment-variable-modal-feature.tsx
@@ -68,11 +68,15 @@ export function CrudEnvironmentVariableModalFeature(props: CrudEnvironmentVariab
     mode: 'onChange',
   })
 
-  const onSubmit = methods.handleSubmit(
-    (data) =>
-      props.serviceType &&
-      handleSubmitForEnvSecretCreation(data, setLoading, props, dispatch, setClosing, props.serviceType)
-  )
+  const onSubmit = methods.handleSubmit((data) => {
+    if (props.serviceType) {
+      const cloneData = { ...data }
+      if (!isFile) {
+        delete cloneData.mountPath
+      }
+      handleSubmitForEnvSecretCreation(cloneData, setLoading, props, dispatch, setClosing, props.serviceType)
+    }
+  })
 
   useEffect(() => {
     enableAlertClickOutside(methods.formState.isDirty)


### PR DESCRIPTION
# What does this PR do?

> Link to the JIRA ticket

Creation of normal environment variable was broken because mount_path was '' instead of null


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
