### PR TITLE
feat(environment-variable): toaster message and action different if scope application

### DIFF
--- a/libs/domains/environment-variable/src/lib/slices/environment-variables.slice.ts
+++ b/libs/domains/environment-variable/src/lib/slices/environment-variables.slice.ts
@@ -350,6 +350,14 @@ export const deleteEnvironmentVariable = createAsyncThunk(
   }
 )
 
+const getToasterDescription = (scope: APIVariableScopeEnum) => {
+  return scope === APIVariableScopeEnum.APPLICATION ||
+    scope === APIVariableScopeEnum.JOB ||
+    scope === APIVariableScopeEnum.CONTAINER
+    ? 'You need to redeploy your service for your changes to be applied'
+    : 'You need to redeploy your environment for your changes to be applied'
+}
+
 export const initialEnvironmentVariablesState: EnvironmentVariablesState = environmentVariablesAdapter.getInitialState({
   loadingStatus: 'not loaded',
   error: null,
@@ -392,17 +400,10 @@ export const environmentVariablesSlice = createSlice({
         addVariableToStore(state, action)
         state.error = null
 
-        const toasterDescription =
-          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
-          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
-          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
-            ? 'Your variable has been created. You need to redeploy your service for your changes to be applied'
-            : 'Your variable has been created. You need to redeploy your environment for your changes to be applied'
-
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          toasterDescription,
+          getToasterDescription(action.meta.arg.scope),
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -416,17 +417,10 @@ export const environmentVariablesSlice = createSlice({
         addVariableToStore(state, action)
         state.error = null
 
-        const toasterDescription =
-          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
-          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
-          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
-            ? 'Your variable has been created. You need to redeploy your service for your changes to be applied'
-            : 'Your variable has been created. You need to redeploy your environment for your changes to be applied'
-
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          toasterDescription,
+          getToasterDescription(action.meta.arg.scope),
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -440,17 +434,10 @@ export const environmentVariablesSlice = createSlice({
         addVariableToStore(state, action)
         state.error = null
 
-        const toasterDescription =
-          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
-          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
-          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
-            ? 'Your variable has been created. You need to redeploy your service for your changes to be applied'
-            : 'Your variable has been created. You need to redeploy your environment for your changes to be applied'
-
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          toasterDescription,
+          getToasterDescription(action.meta.arg.scope),
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -473,17 +460,10 @@ export const environmentVariablesSlice = createSlice({
         })
         state.error = null
 
-        const toasterDescription =
-          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
-          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
-          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
-            ? 'You need to redeploy your service for your changes to be applied'
-            : 'You need to redeploy your environment for your changes to be applied'
-
         toast(
           ToastEnum.SUCCESS,
           'Edition success',
-          toasterDescription,
+          getToasterDescription(action.meta.arg.scope),
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'

--- a/libs/domains/environment-variable/src/lib/slices/environment-variables.slice.ts
+++ b/libs/domains/environment-variable/src/lib/slices/environment-variables.slice.ts
@@ -391,10 +391,18 @@ export const environmentVariablesSlice = createSlice({
       .addCase(createEnvironmentVariables.fulfilled, (state: EnvironmentVariablesState, action) => {
         addVariableToStore(state, action)
         state.error = null
+
+        const toasterDescription =
+          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
+          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
+          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
+            ? 'Your variable has been created. You need to redeploy your service for your changes to be applied'
+            : 'Your variable has been created. You need to redeploy your environment for your changes to be applied'
+
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          'Your variable has been created. You need to redeploy your environment for your changes to be applied',
+          toasterDescription,
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -407,10 +415,18 @@ export const environmentVariablesSlice = createSlice({
       .addCase(createAliasEnvironmentVariables.fulfilled, (state: EnvironmentVariablesState, action) => {
         addVariableToStore(state, action)
         state.error = null
+
+        const toasterDescription =
+          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
+          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
+          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
+            ? 'Your variable has been created. You need to redeploy your service for your changes to be applied'
+            : 'Your variable has been created. You need to redeploy your environment for your changes to be applied'
+
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          'Your variable has been created. You need to redeploy your environment for your changes to be applied',
+          toasterDescription,
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -423,10 +439,18 @@ export const environmentVariablesSlice = createSlice({
       .addCase(createOverrideEnvironmentVariables.fulfilled, (state: EnvironmentVariablesState, action) => {
         addVariableToStore(state, action)
         state.error = null
+
+        const toasterDescription =
+          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
+          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
+          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
+            ? 'Your variable has been created. You need to redeploy your service for your changes to be applied'
+            : 'Your variable has been created. You need to redeploy your environment for your changes to be applied'
+
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          'Your variable has been created. You need to redeploy your environment for your changes to be applied',
+          toasterDescription,
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -448,10 +472,18 @@ export const environmentVariablesSlice = createSlice({
           changes: extendedEnv,
         })
         state.error = null
+
+        const toasterDescription =
+          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
+          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
+          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
+            ? 'You need to redeploy your service for your changes to be applied'
+            : 'You need to redeploy your environment for your changes to be applied'
+
         toast(
           ToastEnum.SUCCESS,
           'Edition success',
-          'You need to redeploy your environment for your changes to be applied',
+          toasterDescription,
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'

--- a/libs/domains/environment-variable/src/lib/slices/secret-environment-variables.slice.ts
+++ b/libs/domains/environment-variable/src/lib/slices/secret-environment-variables.slice.ts
@@ -338,10 +338,18 @@ export const secretEnvironmentVariablesSlice = createSlice({
       .addCase(createSecret.fulfilled, (state: SecretEnvironmentVariablesState, action) => {
         addSecretToStore(state, action)
         state.error = null
+
+        const toasterDescription =
+          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
+          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
+          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
+            ? 'You need to redeploy your service for your changes to be applied'
+            : 'You need to redeploy your environment for your changes to be applied'
+
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          'You need to redeploy your environment for your changes to be applied',
+          toasterDescription,
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -354,10 +362,17 @@ export const secretEnvironmentVariablesSlice = createSlice({
       .addCase(createAliasSecret.fulfilled, (state: SecretEnvironmentVariablesState, action) => {
         addSecretToStore(state, action)
         state.error = null
+        const toasterDescription =
+          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
+          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
+          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
+            ? 'You need to redeploy your service for your changes to be applied'
+            : 'You need to redeploy your environment for your changes to be applied'
+
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          'You need to redeploy your environment for your changes to be applied',
+          toasterDescription,
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -370,10 +385,17 @@ export const secretEnvironmentVariablesSlice = createSlice({
       .addCase(createOverrideSecret.fulfilled, (state: SecretEnvironmentVariablesState, action) => {
         addSecretToStore(state, action)
         state.error = null
+        const toasterDescription =
+          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
+          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
+          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
+            ? 'You need to redeploy your service for your changes to be applied'
+            : 'You need to redeploy your environment for your changes to be applied'
+
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          'You need to redeploy your environment for your changes to be applied',
+          toasterDescription,
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -394,10 +416,18 @@ export const secretEnvironmentVariablesSlice = createSlice({
           changes: extendedEnv,
         })
         state.error = null
+
+        const toasterDescription =
+          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
+          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
+          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
+            ? 'You need to redeploy your service for your changes to be applied'
+            : 'You need to redeploy your environment for your changes to be applied'
+
         toast(
           ToastEnum.SUCCESS,
           'Edition success',
-          'You need to redeploy your environment for your changes to be applied',
+          toasterDescription,
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'

--- a/libs/domains/environment-variable/src/lib/slices/secret-environment-variables.slice.ts
+++ b/libs/domains/environment-variable/src/lib/slices/secret-environment-variables.slice.ts
@@ -294,6 +294,14 @@ export const deleteSecret = createAsyncThunk(
   }
 )
 
+const getToasterDescription = (scope: APIVariableScopeEnum) => {
+  return scope === APIVariableScopeEnum.APPLICATION ||
+    scope === APIVariableScopeEnum.JOB ||
+    scope === APIVariableScopeEnum.CONTAINER
+    ? 'You need to redeploy your service for your changes to be applied'
+    : 'You need to redeploy your environment for your changes to be applied'
+}
+
 export const initialSecretEnvironmentVariablesState: SecretEnvironmentVariablesState =
   secretEnvironmentVariablesAdapter.getInitialState({
     loadingStatus: 'not loaded',
@@ -339,17 +347,10 @@ export const secretEnvironmentVariablesSlice = createSlice({
         addSecretToStore(state, action)
         state.error = null
 
-        const toasterDescription =
-          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
-          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
-          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
-            ? 'You need to redeploy your service for your changes to be applied'
-            : 'You need to redeploy your environment for your changes to be applied'
-
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          toasterDescription,
+          getToasterDescription(action.meta.arg.scope),
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -362,17 +363,11 @@ export const secretEnvironmentVariablesSlice = createSlice({
       .addCase(createAliasSecret.fulfilled, (state: SecretEnvironmentVariablesState, action) => {
         addSecretToStore(state, action)
         state.error = null
-        const toasterDescription =
-          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
-          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
-          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
-            ? 'You need to redeploy your service for your changes to be applied'
-            : 'You need to redeploy your environment for your changes to be applied'
 
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          toasterDescription,
+          getToasterDescription(action.meta.arg.scope),
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -385,17 +380,11 @@ export const secretEnvironmentVariablesSlice = createSlice({
       .addCase(createOverrideSecret.fulfilled, (state: SecretEnvironmentVariablesState, action) => {
         addSecretToStore(state, action)
         state.error = null
-        const toasterDescription =
-          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
-          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
-          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
-            ? 'You need to redeploy your service for your changes to be applied'
-            : 'You need to redeploy your environment for your changes to be applied'
 
         toast(
           ToastEnum.SUCCESS,
           'Creation success',
-          toasterDescription,
+          getToasterDescription(action.meta.arg.scope),
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'
@@ -417,17 +406,10 @@ export const secretEnvironmentVariablesSlice = createSlice({
         })
         state.error = null
 
-        const toasterDescription =
-          action.meta.arg.scope === APIVariableScopeEnum.APPLICATION ||
-          action.meta.arg.scope === APIVariableScopeEnum.JOB ||
-          action.meta.arg.scope === APIVariableScopeEnum.CONTAINER
-            ? 'You need to redeploy your service for your changes to be applied'
-            : 'You need to redeploy your environment for your changes to be applied'
-
         toast(
           ToastEnum.SUCCESS,
           'Edition success',
-          toasterDescription,
+          getToasterDescription(action.meta.arg.scope),
           action.meta.arg.toasterCallback,
           undefined,
           'Redeploy'

--- a/libs/pages/application/src/lib/feature/crud-environment-variable-modal-feature/handle-submit/handle-submit.tsx
+++ b/libs/pages/application/src/lib/feature/crud-environment-variable-modal-feature/handle-submit/handle-submit.tsx
@@ -1,4 +1,5 @@
 import { APIVariableScopeEnum } from 'qovery-typescript-axios'
+import { postApplicationActionsRestart } from '@qovery/domains/application'
 import { postEnvironmentActionsRestart } from '@qovery/domains/environment'
 import {
   createAliasEnvironmentVariables,
@@ -46,7 +47,17 @@ export function handleSubmitForEnvSecretCreation(
     }
 
     const toasterCallback = () => {
-      dispatch(postEnvironmentActionsRestart({ projectId: props.projectId, environmentId: props.environmentId }))
+      if (
+        data.scope === APIVariableScopeEnum.JOB ||
+        data.scope === APIVariableScopeEnum.CONTAINER ||
+        data.scope === APIVariableScopeEnum.APPLICATION
+      ) {
+        dispatch(
+          postApplicationActionsRestart({ applicationId: props.applicationId, environmentId: props.environmentId })
+        )
+      } else {
+        dispatch(postEnvironmentActionsRestart({ projectId: props.projectId, environmentId: props.environmentId }))
+      }
     }
 
     if (!data.isSecret) {


### PR DESCRIPTION
# What does this PR do?

[NB board - Agile board - Qovery Jira](https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-653)

if the scope of the new/edited env var / alias / override is “application” we should change the message and the redeploy should only trigger the redeploy of this service.

<img width="1423" alt="CleanShot 2023-02-23 at 17 50 56@2x" src="https://user-images.githubusercontent.com/6163954/220974862-1effecaf-78bf-453d-a852-b83599ff756e.png">

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
