### PR TITLE
fix(application-buttons-actions): cancel action after deleting

### DIFF
--- a/libs/shared/console-shared/src/lib/buttons-actions/ui/application-buttons-actions/application-buttons-actions.spec.tsx
+++ b/libs/shared/console-shared/src/lib/buttons-actions/ui/application-buttons-actions/application-buttons-actions.spec.tsx
@@ -45,6 +45,7 @@ describe('ApplicationButtonsActionsFeature', () => {
     getByText(baseElement, 'Copy identifiers')
     getByText(baseElement, 'Open settings')
     getByText(baseElement, 'Delete service')
+    getByText(baseElement, 'Deploy other version')
   })
 
   it('should render actions for STOPPED status', async () => {
@@ -57,6 +58,19 @@ describe('ApplicationButtonsActionsFeature', () => {
     getByText(baseElement, 'Copy identifiers')
     getByText(baseElement, 'Open settings')
     getByText(baseElement, 'Delete service')
+    getByText(baseElement, 'Deploy other version')
+  })
+
+  it('should render actions for DELETING status', async () => {
+    mockApplication.status.state = StateEnum.DELETING
+    const { baseElement } = render(<ApplicationButtonsActions {...props} />)
+
+    getByText(baseElement, 'Edit code')
+    getByText(baseElement, 'Logs')
+    getByText(baseElement, 'Deploy other version')
+    getByText(baseElement, 'Copy identifiers')
+    getByText(baseElement, 'Cancel delete')
+    getByText(baseElement, 'Open settings')
   })
 
   it('should not render Restart Service if running status is not running', async () => {

--- a/libs/shared/console-shared/src/lib/buttons-actions/ui/application-buttons-actions/application-buttons-actions.tsx
+++ b/libs/shared/console-shared/src/lib/buttons-actions/ui/application-buttons-actions/application-buttons-actions.tsx
@@ -1,4 +1,5 @@
 import { ClickEvent } from '@szhsin/react-menu'
+import { StateEnum } from 'qovery-typescript-axios'
 import { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
@@ -90,6 +91,11 @@ export function ApplicationButtonsActions(props: ApplicationButtonsActionsProps)
         ),
     }
 
+    const state = application.status?.state
+    const runningState = application.running_status?.state
+    const topItems: MenuItemProps[] = []
+    const bottomItems: MenuItemProps[] = []
+
     const redeployButton: MenuItemProps = {
       name: 'Redeploy',
       contentLeft: <Icon name={IconAwesomeEnum.ROTATE_RIGHT} className="text-sm text-brand-400" />,
@@ -163,12 +169,12 @@ export function ApplicationButtonsActions(props: ApplicationButtonsActionsProps)
     }
 
     const cancelBuildButton: MenuItemProps = {
-      name: 'Cancel deployment',
+      name: state === StateEnum.DELETE_QUEUED || state === StateEnum.DELETING ? 'Cancel delete' : 'Cancel deployment',
       onClick: (e: ClickEvent) => {
         e.syntheticEvent.preventDefault()
         openModalConfirmation({
           mode: environmentMode,
-          title: 'Confirm cancel deployment',
+          title: 'Confirm cancel',
           description:
             'Stopping a deployment for your service will stop the deployment of the whole environment. It may take a while, as a safe point needs to be reached. Some operations cannot be stopped (i.e: terraform actions) and need to be completed before stopping the deployment. Any action performed before won’t be rolled back. To confirm the cancellation of your deployment, please type the name of the application:',
           name: application.name,
@@ -187,11 +193,6 @@ export function ApplicationButtonsActions(props: ApplicationButtonsActionsProps)
       },
       contentLeft: <Icon name={IconAwesomeEnum.XMARK} className="text-sm text-brand-400" />,
     }
-
-    const state = application.status?.state
-    const runningState = application.running_status?.state
-    const topItems: MenuItemProps[] = []
-    const bottomItems: MenuItemProps[] = []
 
     if (state) {
       if (isCancelBuildAvailable(state)) {

--- a/libs/shared/console-shared/src/lib/buttons-actions/ui/database-buttons-actions/database-buttons-actions.spec.tsx
+++ b/libs/shared/console-shared/src/lib/buttons-actions/ui/database-buttons-actions/database-buttons-actions.spec.tsx
@@ -53,6 +53,14 @@ describe('DatabaseButtonsActionsFeature', () => {
     getByText(baseElement, 'Delete database')
   })
 
+  it('should render actions for DELETING status', async () => {
+    mockDatabase.status.state = StateEnum.DELETING
+    const { baseElement } = render(<DatabaseButtonsActions {...props} />)
+
+    getByText(baseElement, 'Copy identifiers')
+    getByText(baseElement, 'Cancel delete')
+  })
+
   it('should not render Restart Database if running status is not running', async () => {
     if (mockDatabase.running_status) {
       mockDatabase.running_status.state = RunningStatus.STOPPED

--- a/libs/shared/console-shared/src/lib/environment-buttons-actions/ui/environment-buttons-actions.spec.tsx
+++ b/libs/shared/console-shared/src/lib/environment-buttons-actions/ui/environment-buttons-actions.spec.tsx
@@ -51,4 +51,14 @@ describe('EnvironmentButtonsActions', () => {
     getByText(baseElement, 'Clone')
     getByText(baseElement, 'Delete environment')
   })
+
+  it('should render actions for DELETING status', async () => {
+    mockEnvironment.status.state = StateEnum.DELETING
+    const { baseElement } = render(<EnvironmentButtonsActions {...props} />)
+
+    getByText(baseElement, 'Logs')
+    getByText(baseElement, 'Copy identifiers')
+    getByText(baseElement, 'Clone')
+    getByText(baseElement, 'Cancel delete')
+  })
 })

--- a/libs/shared/console-shared/src/lib/environment-buttons-actions/ui/environment-buttons-actions.tsx
+++ b/libs/shared/console-shared/src/lib/environment-buttons-actions/ui/environment-buttons-actions.tsx
@@ -1,4 +1,5 @@
 import { ClickEvent } from '@szhsin/react-menu'
+import { StateEnum } from 'qovery-typescript-axios'
 import { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
@@ -74,6 +75,10 @@ export function EnvironmentButtonsActions(props: EnvironmentButtonsActionsProps)
         ),
     }
 
+    const state = environment.status?.state
+    const topItems: MenuItemProps[] = []
+    const bottomItems: MenuItemProps[] = []
+
     const redeployButton: MenuItemProps = {
       name: 'Redeploy',
       contentLeft: <Icon name={IconAwesomeEnum.ROTATE_RIGHT} className="text-sm text-brand-400" />,
@@ -125,7 +130,7 @@ export function EnvironmentButtonsActions(props: EnvironmentButtonsActionsProps)
     }
 
     const cancelDeploymentButton = {
-      name: 'Cancel Deployment',
+      name: state === StateEnum.DELETE_QUEUED || state === StateEnum.DELETING ? 'Cancel delete' : 'Cancel deployment',
       onClick: (e: ClickEvent) => {
         e.syntheticEvent.preventDefault()
 
@@ -149,10 +154,6 @@ export function EnvironmentButtonsActions(props: EnvironmentButtonsActionsProps)
       },
       contentLeft: <Icon name={IconAwesomeEnum.XMARK} className="text-sm text-brand-400" />,
     }
-
-    const state = environment.status?.state
-    const topItems: MenuItemProps[] = []
-    const bottomItems: MenuItemProps[] = []
 
     if (state) {
       if (isCancelBuildAvailable(state)) {

--- a/libs/shared/utils/src/lib/tools/status-actions-available.tsx
+++ b/libs/shared/utils/src/lib/tools/status-actions-available.tsx
@@ -87,7 +87,9 @@ export const isCancelBuildAvailable = (status: StateEnum): boolean => {
     status === StateEnum.BUILDING ||
     status === StateEnum.DEPLOYING ||
     status === StateEnum.DEPLOYMENT_QUEUED ||
-    status === StateEnum.RESTART_QUEUED
+    status === StateEnum.RESTART_QUEUED ||
+    status === StateEnum.DELETE_QUEUED ||
+    status === StateEnum.DELETING
   )
 }
 


### PR DESCRIPTION
# What does this PR do?

- Cancel deployment after deleting action available
- [Romain's request](https://qovery.slack.com/archives/C02P2JB4SEM/p1677230799228619)

<img width="294" alt="Capture d’écran 2023-02-27 à 16 27 57" src="https://user-images.githubusercontent.com/533928/221606117-ab31ff7d-892d-49ff-a897-be2b9f94a55b.png">


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
