### PR TITLE
fix(service): lifting the maximum hardcoded allowed value for memory

### DIFF
--- a/libs/shared/console-shared/src/lib/setting-resources/ui/setting-resources.tsx
+++ b/libs/shared/console-shared/src/lib/setting-resources/ui/setting-resources.tsx
@@ -29,7 +29,8 @@ export function SettingResources(props: SettingResourcesProps) {
   let maxMemoryBySize = application?.maximum_memory
 
   if (!application) {
-    maxMemoryBySize = 8192
+    // until api allows us to fetch the max possible value
+    maxMemoryBySize = 128000
   }
 
   const watchInstances = watch('instances')


### PR DESCRIPTION
# What does this PR do?

https://qovery.slack.com/archives/C02P2JB4SEM/p1677678320092069

Until api allow us to fetch the maximum allowed memory, we hardcoded the maximum value to a super large one. If it's not possible, backend will return an error but at least clients are not blocked.

![image](https://user-images.githubusercontent.com/6163954/222502864-2beba786-0caf-4ffb-8465-4a4d20f863a7.png)

<img width="332" alt="CleanShot 2023-03-02 at 18 17 09@2x" src="https://user-images.githubusercontent.com/6163954/222503173-96b70b08-6bbe-46a8-89dc-88bc65f7edd7.png">

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
