### PR TITLE
fix(page-application): remove useless application rendering

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-feature/page-settings-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-feature/page-settings-feature.tsx
@@ -1,7 +1,8 @@
+import equal from 'fast-deep-equal'
 import { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { Navigate, Route, Routes, useParams } from 'react-router-dom'
-import { getApplicationsState } from '@qovery/domains/application'
+import { selectApplicationById } from '@qovery/domains/application'
 import { isJob } from '@qovery/shared/enums'
 import { ApplicationEntity } from '@qovery/shared/interfaces'
 import {
@@ -35,7 +36,8 @@ export function PageSettingsFeature() {
   )}${APPLICATION_SETTINGS_URL}`
 
   const application = useSelector<RootState, ApplicationEntity | undefined>(
-    (state) => getApplicationsState(state).entities[applicationId]
+    (state) => selectApplicationById(state, applicationId),
+    equal
   )
 
   const getLinks = useCallback(() => {

--- a/libs/pages/application/src/lib/feature/page-settings-general-feature/page-settings-general-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-general-feature/page-settings-general-feature.tsx
@@ -100,6 +100,7 @@ export function PageSettingsGeneralFeature() {
       a?.buildpack_language === b?.buildpack_language &&
       a?.dockerfile_path === b?.dockerfile_path
   )
+
   const organization = useSelector<RootState, OrganizationEntity | undefined>((state) =>
     selectOrganizationById(state, organizationId)
   )

--- a/libs/pages/application/src/lib/page-application.tsx
+++ b/libs/pages/application/src/lib/page-application.tsx
@@ -22,8 +22,9 @@ import Container from './ui/container/container'
 
 export function PageApplication() {
   const { applicationId = '', environmentId = '', organizationId = '', projectId = '' } = useParams()
-  const environment = useSelector<RootState, Environment | undefined>((state) =>
-    selectEnvironmentById(state, environmentId)
+  const environment = useSelector<RootState, Environment | undefined>(
+    (state) => selectEnvironmentById(state, environmentId),
+    equal
   )
   const application = useSelector<RootState, ApplicationEntity | undefined>(
     (state) => selectApplicationById(state, applicationId),


### PR DESCRIPTION
# What does this PR do?

Remove useless multiple rendering
- For all application pages with Environment selector
- For application settings page with Application selector

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
