### PR TITLE
fix(cluster-logs): disabled request environment status

### DIFF
--- a/libs/domains/environment/src/lib/slices/environments.slice.ts
+++ b/libs/domains/environment/src/lib/slices/environments.slice.ts
@@ -61,6 +61,7 @@ export const useFetchEnvironmentsStatus = (projectId: string) => {
     },
     {
       onError: (err) => toastError(err),
+      enabled: projectId !== '',
     }
   )
 }


### PR DESCRIPTION
# What does this PR do?

- Disabled environment status request for Cluster logs

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
