### PR TITLE
feat(billing): upgrade plan with modal

### DIFF
--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/checkout-upgrade-modal-feature/checkout-upgrade-modal-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/checkout-upgrade-modal-feature/checkout-upgrade-modal-feature.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react'
+import CheckoutUpgradeModalFeature from './checkout-upgrade-modal-feature'
+
+describe('CheckoutUpgradeModalFeature', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<CheckoutUpgradeModalFeature />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/checkout-upgrade-modal-feature/checkout-upgrade-modal-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/checkout-upgrade-modal-feature/checkout-upgrade-modal-feature.tsx
@@ -1,0 +1,26 @@
+import { PlanEnum } from 'qovery-typescript-axios'
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { fetchMembers } from '@qovery/domains/organization'
+import { OrganizationEntity } from '@qovery/shared/interfaces'
+import { AppDispatch } from '@qovery/store'
+import CheckoutUpgradeModal from '../../../ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal'
+
+export interface CheckoutUpgradeModalFeatureProps {
+  plan: PlanEnum
+  organization: OrganizationEntity
+}
+
+export function CheckoutUpgradeModalFeature(props: CheckoutUpgradeModalFeatureProps) {
+  const dispatch = useDispatch<AppDispatch>()
+
+  useEffect(() => {
+    if (!props.organization.members?.loadingStatus) {
+      dispatch(fetchMembers({ organizationId: props.organization.id }))
+    }
+  }, [props.organization.members?.loadingStatus, dispatch, props.organization.id])
+
+  return <CheckoutUpgradeModal plan={props.plan} memberCount={props.organization.members?.items?.length || 1} />
+}
+
+export default CheckoutUpgradeModalFeature

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/checkout-upgrade-modal-feature/checkout-upgrade-modal-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/checkout-upgrade-modal-feature/checkout-upgrade-modal-feature.tsx
@@ -1,9 +1,18 @@
 import { PlanEnum } from 'qovery-typescript-axios'
-import { useEffect } from 'react'
-import { useDispatch } from 'react-redux'
-import { fetchMembers } from '@qovery/domains/organization'
-import { OrganizationEntity } from '@qovery/shared/interfaces'
-import { AppDispatch } from '@qovery/store'
+import { useEffect, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { CardImages } from 'react-payment-inputs/images'
+import { useDispatch, useSelector } from 'react-redux'
+import {
+  fetchCreditCards,
+  fetchMembers,
+  getCreditCardsState,
+  selectCreditCardsByOrganizationId,
+} from '@qovery/domains/organization'
+import { CreditCardFormValues } from '@qovery/shared/console-shared'
+import { OrganizationEntity, Value } from '@qovery/shared/interfaces'
+import { imagesCreditCart } from '@qovery/shared/ui'
+import { AppDispatch, RootState } from '@qovery/store'
 import CheckoutUpgradeModal from '../../../ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal'
 
 export interface CheckoutUpgradeModalFeatureProps {
@@ -14,13 +23,68 @@ export interface CheckoutUpgradeModalFeatureProps {
 export function CheckoutUpgradeModalFeature(props: CheckoutUpgradeModalFeatureProps) {
   const dispatch = useDispatch<AppDispatch>()
 
+  const methods = useForm<CreditCardFormValues>({ mode: 'all' })
+
+  const onCardSubmit = methods.handleSubmit((data) => {
+    setShowAddCardForm(false)
+  })
+
+  const creditCards = useSelector((state: RootState) =>
+    selectCreditCardsByOrganizationId(state, props.organization.id || '')
+  )
+  const creditCardLoadingStatus = useSelector<RootState, string | undefined>(
+    (state) => getCreditCardsState(state).loadingStatus
+  )
+  const [creditCardsOptions, setCreditCardsOptions] = useState<Value[]>([])
+
+  const [showAddCardForm, setShowAddCardForm] = useState(false)
+  const [selectedCard, setSelectedCard] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (props.organization.id && creditCardLoadingStatus === 'not loaded')
+      dispatch(fetchCreditCards({ organizationId: props.organization.id }))
+  }, [props.organization.id, dispatch, creditCardLoadingStatus])
+
   useEffect(() => {
     if (!props.organization.members?.loadingStatus) {
       dispatch(fetchMembers({ organizationId: props.organization.id }))
     }
   }, [props.organization.members?.loadingStatus, dispatch, props.organization.id])
 
-  return <CheckoutUpgradeModal plan={props.plan} memberCount={props.organization.members?.items?.length || 1} />
+  useEffect(() => {
+    if (creditCards.length > 0) {
+      setCreditCardsOptions(
+        creditCards.map((card) => ({
+          label: '**** ' + card.last_digit,
+          value: card.id,
+          icon: (
+            <svg
+              data-testid="credit-card-image"
+              className="absolute -translate-x-full -ml-3 -translate-y-1/2 top-1/2 z-10 w-6 h-4"
+              {...{ children: imagesCreditCart[card.brand as keyof CardImages] }}
+            ></svg>
+          ),
+        }))
+      )
+    }
+  }, [creditCards])
+
+  return (
+    <FormProvider {...methods}>
+      <CheckoutUpgradeModal
+        toggleShowAddForm={(value: boolean) => {
+          setShowAddCardForm(value)
+        }}
+        showAddCardForm={showAddCardForm}
+        plan={props.plan}
+        memberCount={props.organization.members?.items?.length || 1}
+        onCardSubmit={onCardSubmit}
+        setSelectedCard={setSelectedCard}
+        selectedCard={selectedCard}
+        creditCardsOptions={creditCardsOptions}
+      />
+    </FormProvider>
+  )
 }
 
 export default CheckoutUpgradeModalFeature

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/page-organization-billing-summary-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/page-organization-billing-summary-feature.tsx
@@ -71,6 +71,9 @@ export function PageOrganizationBillingSummaryFeature() {
   const openUpgradeModal = () => {
     openModal({
       content: <UpgradePlanModalFeature closeModal={closeModal} organization={organization} />,
+      options: {
+        width: 624,
+      },
     })
   }
 

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/page-organization-billing-summary-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/page-organization-billing-summary-feature.tsx
@@ -2,7 +2,6 @@ import { StateEnum } from 'qovery-typescript-axios'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
-import { useIntercom } from 'react-use-intercom'
 import {
   fetchClusters,
   fetchCreditCards,
@@ -18,6 +17,7 @@ import { useDocumentTitle } from '@qovery/shared/utils'
 import { AppDispatch, RootState } from '@qovery/store'
 import PageOrganizationBillingSummary from '../../ui/page-organization-billing-summary/page-organization-billing-summary'
 import PromoCodeModalFeature from './promo-code-modal-feature/promo-code-modal-feature'
+import UpgradePlanModalFeature from './upgrade-plan-modal-feature/upgrade-plan-modal-feature'
 
 export function PageOrganizationBillingSummaryFeature() {
   useDocumentTitle('Billing summary - Organization settings')
@@ -36,7 +36,6 @@ export function PageOrganizationBillingSummaryFeature() {
   const creditCardLoadingStatus = useSelector<RootState, string | undefined>(
     (state) => getCreditCardsState(state).loadingStatus
   )
-  const { show: showIntercom } = useIntercom()
 
   const numberOfRunningClusters =
     clusters?.reduce((acc, cluster) => {
@@ -51,7 +50,7 @@ export function PageOrganizationBillingSummaryFeature() {
     if (organizationId && !organization?.currentCost?.loadingStatus) {
       dispatch(fetchCurrentCost({ organizationId }))
     }
-  }, [organizationId, dispatch, organization?.billingInfos?.loadingStatus])
+  }, [organizationId, dispatch, organization?.currentCost?.loadingStatus])
 
   useEffect(() => {
     if (organizationId && creditCardLoadingStatus === 'not loaded') dispatch(fetchCreditCards({ organizationId }))
@@ -69,6 +68,12 @@ export function PageOrganizationBillingSummaryFeature() {
     })
   }
 
+  const openUpgradeModal = () => {
+    openModal({
+      content: <UpgradePlanModalFeature closeModal={closeModal} organization={organization} />,
+    })
+  }
+
   return (
     <PageOrganizationBillingSummary
       organization={organization}
@@ -77,7 +82,7 @@ export function PageOrganizationBillingSummaryFeature() {
       creditCard={creditCard}
       creditCardLoading={creditCardLoadingStatus === 'loading'}
       onPromoCodeClick={openPromoCodeModal}
-      openIntercom={showIntercom}
+      openUpgradeModal={openUpgradeModal}
     />
   )
 }

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/upgrade-plan-modal-feature/upgrade-plan-modal-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/upgrade-plan-modal-feature/upgrade-plan-modal-feature.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react'
+import UpgradePlanModalFeature from './upgrade-plan-modal-feature'
+
+describe('UpgradePlanModalFeature', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<UpgradePlanModalFeature />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/upgrade-plan-modal-feature/upgrade-plan-modal-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/upgrade-plan-modal-feature/upgrade-plan-modal-feature.tsx
@@ -1,5 +1,10 @@
+import { PlanEnum } from 'qovery-typescript-axios'
+import { useEffect } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
 import { OrganizationEntity } from '@qovery/shared/interfaces'
+import { useModal } from '@qovery/shared/ui'
 import UpgradePlanModal from '../../../ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal'
+import CheckoutUpgradeModalFeature from '../checkout-upgrade-modal-feature/checkout-upgrade-modal-feature'
 
 export interface UpgradePlanModalFeatureProps {
   organization?: OrganizationEntity
@@ -7,7 +12,36 @@ export interface UpgradePlanModalFeatureProps {
 }
 
 export function UpgradePlanModalFeature(props: UpgradePlanModalFeatureProps) {
-  return <UpgradePlanModal currentPlan={props.organization?.currentCost?.value?.plan} onClose={props.closeModal} />
+  const methods = useForm<{ plan: PlanEnum }>({ defaultValues: { plan: props.organization?.currentCost?.value?.plan } })
+  const { openModal } = useModal()
+
+  const onSubmit = methods.handleSubmit((data) => {
+    console.log(data)
+  })
+
+  useEffect(() => {
+    if (props.organization?.currentCost?.value?.plan)
+      methods.setValue('plan', props.organization.currentCost.value.plan)
+  }, [props.organization?.currentCost?.value?.plan, methods])
+
+  const openCheckout = (plan: PlanEnum) => {
+    if (props.organization) {
+      openModal({
+        content: <CheckoutUpgradeModalFeature organization={props.organization} plan={plan} />,
+      })
+    }
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <UpgradePlanModal
+        currentPlan={props.organization?.currentCost?.value?.plan}
+        onClose={props.closeModal}
+        onSubmit={onSubmit}
+        openCheckout={openCheckout}
+      />
+    </FormProvider>
+  )
 }
 
 export default UpgradePlanModalFeature

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/upgrade-plan-modal-feature/upgrade-plan-modal-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/upgrade-plan-modal-feature/upgrade-plan-modal-feature.tsx
@@ -1,0 +1,13 @@
+import { OrganizationEntity } from '@qovery/shared/interfaces'
+import UpgradePlanModal from '../../../ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal'
+
+export interface UpgradePlanModalFeatureProps {
+  organization?: OrganizationEntity
+  closeModal: () => void
+}
+
+export function UpgradePlanModalFeature(props: UpgradePlanModalFeatureProps) {
+  return <UpgradePlanModal currentPlan={props.organization?.currentCost?.value?.plan} onClose={props.closeModal} />
+}
+
+export default UpgradePlanModalFeature

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/upgrade-plan-modal-feature/upgrade-plan-modal-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/upgrade-plan-modal-feature/upgrade-plan-modal-feature.tsx
@@ -12,7 +12,7 @@ export interface UpgradePlanModalFeatureProps {
 }
 
 export function UpgradePlanModalFeature(props: UpgradePlanModalFeatureProps) {
-  const methods = useForm<{ plan: PlanEnum }>({ defaultValues: { plan: props.organization?.currentCost?.value?.plan } })
+  const methods = useForm<{ plan: PlanEnum }>({ defaultValues: { plan: props.organization?.plan } })
   const { openModal } = useModal()
 
   const onSubmit = methods.handleSubmit((data) => {
@@ -20,9 +20,9 @@ export function UpgradePlanModalFeature(props: UpgradePlanModalFeatureProps) {
   })
 
   useEffect(() => {
-    if (props.organization?.currentCost?.value?.plan)
-      methods.setValue('plan', props.organization.currentCost.value.plan)
-  }, [props.organization?.currentCost?.value?.plan, methods])
+    console.log(props.organization?.plan)
+    if (props.organization?.plan) methods.setValue('plan', props.organization.plan)
+  }, [props.organization, methods])
 
   const openCheckout = (plan: PlanEnum) => {
     if (props.organization) {
@@ -35,7 +35,7 @@ export function UpgradePlanModalFeature(props: UpgradePlanModalFeatureProps) {
   return (
     <FormProvider {...methods}>
       <UpgradePlanModal
-        currentPlan={props.organization?.currentCost?.value?.plan}
+        currentPlan={props.organization?.plan}
         onClose={props.closeModal}
         onSubmit={onSubmit}
         openCheckout={openCheckout}

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal.spec.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react'
+import CheckoutUpgradeModal from './checkout-upgrade-modal'
+
+describe('CheckoutUpgradeModal', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<CheckoutUpgradeModal />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal.tsx
@@ -1,18 +1,31 @@
 import { PlanEnum } from 'qovery-typescript-axios'
+import { FormEventHandler } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { CreditCardForm, CreditCardFormValues } from '@qovery/shared/console-shared'
+import { Value } from '@qovery/shared/interfaces'
+import { Button, ButtonSize, ButtonStyle, InputSelect } from '@qovery/shared/ui'
 import { upperCaseFirstLetter } from '@qovery/shared/utils'
 
 export interface CheckoutUpgradeModalProps {
   plan: PlanEnum
   memberCount: number
+  onCardSubmit: FormEventHandler<HTMLFormElement>
+  showAddCardForm: boolean
+  toggleShowAddForm: (value: boolean) => void
+  selectedCard: string | undefined
+  setSelectedCard: (value: string) => void
+  creditCardsOptions: Value[]
 }
 
 export function CheckoutUpgradeModal(props: CheckoutUpgradeModalProps) {
+  const { formState } = useFormContext<CreditCardFormValues>()
+
   return (
     <div className="p-6">
       <h2 className="h4 text-text-600 mb-2 max-w-lg mb-8">
         Confirm your change to the {upperCaseFirstLetter(props.plan)} plan for $49 per user
       </h2>
-      <div className="bg-element-light-lighter-200 border border-element-light-lighter-500 rounded px-6 py-5">
+      <div className="bg-element-light-lighter-200 border border-element-light-lighter-500 rounded px-6 py-5 mb-8">
         <div className="flex items-center justify-between font-medium text-sm text-text-600 mb-1">
           <span>Total seat</span>
           <span>{props.memberCount}</span>
@@ -29,6 +42,75 @@ export function CheckoutUpgradeModal(props: CheckoutUpgradeModalProps) {
           <span>$124,00 HT</span>
         </div>
       </div>
+
+      {!props.showAddCardForm ? (
+        <div className="bg-brand-50 rounded-lg p-6">
+          <div className="flex items-center justify-between mb-3">
+            <div className="text-text-500 font-medium">Pay with</div>
+            <div
+              className="text-brand-500 font-medium text-sm cursor-pointer"
+              onClick={() => props.toggleShowAddForm(true)}
+            >
+              Add a new card
+            </div>
+          </div>
+          <div className="">
+            <InputSelect
+              className="mb-5"
+              label="Card number"
+              options={[]}
+              portal
+              onChange={(value) => props.setSelectedCard(value as string)}
+            />
+
+            <p className="text-text-500 text-sm mb-6">
+              Price paid and delta Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint. Velit
+              officia consequat duis enim velit mollit. Exercitation veniam consequat sunt nostrud amet.
+            </p>
+            <p className="text-center text-text-500 text-sm mb-6">
+              Card information are secured by <strong>Stripe</strong>
+            </p>
+
+            <Button
+              className="w-full"
+              style={ButtonStyle.BASIC}
+              size={ButtonSize.XLARGE}
+              disabled={!props.selectedCard}
+            >
+              Confirm
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="bg-brand-50 rounded-lg p-6">
+          <div className="flex items-center justify-between mb-3">
+            <div className="text-text-500 font-medium">Register your credit card</div>
+            <div
+              className="text-brand-500 font-medium text-sm cursor-pointer"
+              onClick={() => props.toggleShowAddForm(false)}
+            >
+              Cancel
+            </div>
+          </div>
+          <div className="">
+            <form onSubmit={props.onCardSubmit}>
+              <CreditCardForm />
+              <p className="text-center text-text-500 text-sm my-6">
+                Card information are secured by <strong>Stripe</strong>
+              </p>
+              <Button
+                className="w-full"
+                style={ButtonStyle.BASIC}
+                size={ButtonSize.XLARGE}
+                type="submit"
+                disabled={!formState.isValid}
+              >
+                Confirm
+              </Button>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal.tsx
@@ -1,0 +1,20 @@
+import { PlanEnum } from 'qovery-typescript-axios'
+import { upperCaseFirstLetter } from '@qovery/shared/utils'
+
+export interface CheckoutUpgradeModalProps {
+  plan: PlanEnum
+  memberCount: number
+}
+
+export function CheckoutUpgradeModal(props: CheckoutUpgradeModalProps) {
+  return (
+    <div className="p-6">
+      <h2 className="h4 text-text-600 mb-2 max-w-lg">
+        Confirm your change to the {upperCaseFirstLetter(props.plan)} plan for $49 per user
+      </h2>
+      <p>You have {props.memberCount} users</p>
+    </div>
+  )
+}
+
+export default CheckoutUpgradeModal

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/checkout-upgrade-modal/checkout-upgrade-modal.tsx
@@ -9,10 +9,26 @@ export interface CheckoutUpgradeModalProps {
 export function CheckoutUpgradeModal(props: CheckoutUpgradeModalProps) {
   return (
     <div className="p-6">
-      <h2 className="h4 text-text-600 mb-2 max-w-lg">
+      <h2 className="h4 text-text-600 mb-2 max-w-lg mb-8">
         Confirm your change to the {upperCaseFirstLetter(props.plan)} plan for $49 per user
       </h2>
-      <p>You have {props.memberCount} users</p>
+      <div className="bg-element-light-lighter-200 border border-element-light-lighter-500 rounded px-6 py-5">
+        <div className="flex items-center justify-between font-medium text-sm text-text-600 mb-1">
+          <span>Total seat</span>
+          <span>{props.memberCount}</span>
+        </div>
+        <p className="text-text-400 text-sm mb-4">
+          At the beginning of each month, you will be charged $49 per user plus tax for the selected package
+        </p>
+        <div className="flex items-center justify-between font-medium text-sm text-text-600 border-t border-element-light-lighter-400 py-4">
+          <span>TVA amount</span>
+          <span>$19,98 HT</span>
+        </div>
+        <div className="flex items-center justify-between font-medium text-sm text-text-600 border-t border-element-light-lighter-400 pt-4">
+          <span>Amount billed now</span>
+          <span>$124,00 HT</span>
+        </div>
+      </div>
     </div>
   )
 }

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/page-organization-billing-summary.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/page-organization-billing-summary.tsx
@@ -13,7 +13,7 @@ export interface PageOrganizationBillingSummaryProps {
   numberOfClusters?: number
   creditCardLoading?: boolean
   onPromoCodeClick?: () => void
-  openIntercom?: () => void
+  openUpgradeModal?: () => void
 }
 
 export function PageOrganizationBillingSummary(props: PageOrganizationBillingSummaryProps) {
@@ -28,7 +28,7 @@ export function PageOrganizationBillingSummary(props: PageOrganizationBillingSum
             <Button style={ButtonStyle.STROKED} dataTestId="promo-code-button" onClick={props.onPromoCodeClick}>
               Promo code
             </Button>
-            <Button dataTestId="upgrade-button" onClick={props.openIntercom}>
+            <Button dataTestId="upgrade-button" onClick={props.openUpgradeModal}>
               Upgrade plan
             </Button>
           </div>

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/page-organization-billing-summary.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/page-organization-billing-summary.tsx
@@ -28,7 +28,7 @@ export function PageOrganizationBillingSummary(props: PageOrganizationBillingSum
             <Button style={ButtonStyle.STROKED} dataTestId="promo-code-button" onClick={props.onPromoCodeClick}>
               Promo code
             </Button>
-            <Button dataTestId="upgrade-button" onClick={props.openUpgradeModal}>
+            <Button dataTestId="upgrade-button" onClick={props.openUpgradeModal} disabled={!props.organization}>
               Upgrade plan
             </Button>
           </div>

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal.spec.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react'
+import UpgradePlanModal from './upgrade-plan-modal'
+
+describe('UpgradePlanModal', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<UpgradePlanModal />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal.tsx
@@ -1,12 +1,19 @@
 import { PlanEnum } from 'qovery-typescript-axios'
-import { Button, ButtonStyle, IconAwesomeEnum, Link } from '@qovery/shared/ui'
+import { FormEventHandler } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import { Button, ButtonSize, ButtonStyle, Icon, IconAwesomeEnum, InputRadioBox, Link } from '@qovery/shared/ui'
 
 export interface UpgradePlanModalProps {
   currentPlan?: PlanEnum
   onClose: () => void
+  onSubmit: FormEventHandler<HTMLFormElement>
+  openCheckout: (plan: PlanEnum) => void
 }
 
 export function UpgradePlanModal(props: UpgradePlanModalProps) {
+  const { control, watch } = useFormContext<{ plan: PlanEnum }>()
+  const watchPlan = watch('plan')
+
   return (
     <div className="p-6">
       <h2 className="h4 text-text-600 mb-2 max-w-sm">Change plan</h2>
@@ -21,15 +28,165 @@ export function UpgradePlanModal(props: UpgradePlanModalProps) {
         iconRight={IconAwesomeEnum.ARROW_UP_RIGHT_FROM_SQUARE}
         linkLabel="See details plan"
       ></Link>
-      <div>{/* todo put here the three radio box in a Controller*/}</div>
-      <div className="flex gap-3 justify-end">
-        <Button className="btn--no-min-w" style={ButtonStyle.STROKED} onClick={props.onClose}>
-          Cancel
-        </Button>
-        <Button className="btn--no-min-w" dataTestId="submit-button" type="submit">
-          Submit
-        </Button>
+      <div className="my-8">
+        <Controller
+          name={'plan'}
+          control={control}
+          render={({ field }) => (
+            <>
+              <InputRadioBox
+                name={field.name}
+                onChange={field.onChange}
+                fieldValue={field.value}
+                label="Free plan"
+                value={PlanEnum.FREE}
+                description="Adapted for small company"
+                rightElement={
+                  <div className="flex flex-col align-bottom text-right">
+                    <strong className="text-text-500 text-xl font-bold">$0</strong>
+                    {props.currentPlan === PlanEnum.FREE && (
+                      <span className="text-brand-500 text-xs font-medium">Current plan</span>
+                    )}
+                  </div>
+                }
+              />
+              <InputRadioBox
+                name={field.name}
+                onChange={field.onChange}
+                fieldValue={field.value}
+                label="Team plan"
+                value={PlanEnum.BUSINESS}
+                description="For medium company"
+                rightElement={
+                  <div className="flex flex-col text-right text-text-500 text-sm">
+                    <span>
+                      <strong className="text-text-700 text-xl font-bold">$49</strong> / user
+                    </span>
+                    {props.currentPlan === PlanEnum.BUSINESS && (
+                      <span className="text-brand-500 text-xs font-medium mt-0.5">Current plan</span>
+                    )}
+                  </div>
+                }
+              />
+              <InputRadioBox
+                name={field.name}
+                onChange={field.onChange}
+                fieldValue={field.value}
+                label="Enterprise plan"
+                description="For large company"
+                value={PlanEnum.ENTERPRISE}
+                rightElement={
+                  <div className="flex flex-col align-bottom  text-right text-text-500 text-sm flex flex-col ">
+                    <span>Contact us</span>
+                    {props.currentPlan === PlanEnum.ENTERPRISE && (
+                      <span className="text-brand-500 text-xs font-medium">Current plan</span>
+                    )}
+                  </div>
+                }
+              />
+            </>
+          )}
+        />
       </div>
+
+      {watchPlan === PlanEnum.FREE &&
+        (props.currentPlan === PlanEnum.TEAM ||
+          props.currentPlan === PlanEnum.BUSINESS ||
+          props.currentPlan === PlanEnum.ENTERPRISE) && (
+          <div className="bg-brand-50 rounded-lg p-6">
+            <div className="text-text-500 font-medium mb-3">You will also no longer receive the following benefits</div>
+
+            <ul className="flex flex-col gap-2 text-sm text-text-500 mb-3">
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CROSS} className="text-error-500 relative top-[1px]" />
+                Deploy on your cloud
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CROSS} className="text-error-500 relative top-[1px]" />
+                Deployments unlimited
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CROSS} className="text-error-500 relative top-[1px]" />
+                API included
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CROSS} className="text-error-500 relative top-[1px]" />
+                Preview environments
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CROSS} className="text-error-500 relative top-[1px]" />
+                Containers
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CROSS} className="text-error-500 relative top-[1px]" />3 clusters
+              </li>
+            </ul>
+
+            <p className="text-text-500 text-sm mb-5">
+              Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis
+              enim velit mollit.
+            </p>
+
+            <div className="text-text-500 font-medium mb-2">Make the following changes before proceeding</div>
+            <div className="rounded border border-brand-500 bg-white p-4 flex gap-2 mb-5">
+              <Icon name={IconAwesomeEnum.CROSS} className="text-error-500 top-[-1px] relative" />
+              <div className="flex flex-col gap-1">
+                <span className="text-text-600 font-bold text-sm">Reduce clusters</span>
+                <p className="text-sm text-text-400">The selected package is available for 1 cluster only</p>
+              </div>
+            </div>
+
+            <Button className="w-full" style={ButtonStyle.BASIC} disabled size={ButtonSize.XLARGE}>
+              Downgrade plan
+            </Button>
+          </div>
+        )}
+
+      {props.currentPlan === PlanEnum.FREE &&
+        (watchPlan === PlanEnum.TEAM || watchPlan === PlanEnum.BUSINESS || watchPlan === PlanEnum.ENTERPRISE) && (
+          <div className="bg-brand-50 rounded-lg p-6">
+            <div className="text-text-500 font-medium mb-3">You will also benefit from the following services</div>
+
+            <ul className="flex flex-col gap-2 text-sm text-text-500 mb-3">
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CHECK} className="text-success-500 relative top-[1px]" />
+                Deploy on your cloud
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.FIRE} className="text-error-500 relative top-[1px]" />
+                Deployments unlimited
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CHECK} className="text-success-500 relative top-[1px]" />
+                API included
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CHECK} className="text-success-500 relative top-[1px]" />
+                Preview environments
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CHECK} className="text-success-500 relative top-[1px]" />
+                Containers
+              </li>
+              <li className="flex items-center gap-2">
+                <Icon name={IconAwesomeEnum.CHECK} className="text-success-500 relative top-[1px]" />3 clusters
+              </li>
+            </ul>
+
+            <p className="text-text-500 text-sm mb-5">You will be charged $49 per user.</p>
+
+            <Button
+              className="w-full"
+              style={ButtonStyle.BASIC}
+              size={ButtonSize.XLARGE}
+              onClick={() => {
+                props.openCheckout(watchPlan)
+              }}
+            >
+              Upgrade plan
+            </Button>
+          </div>
+        )}
     </div>
   )
 }

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal.tsx
@@ -88,7 +88,6 @@ export function UpgradePlanModal(props: UpgradePlanModalProps) {
           )}
         />
       </div>
-
       {watchPlan === PlanEnum.FREE &&
         (props.currentPlan === PlanEnum.TEAM ||
           props.currentPlan === PlanEnum.BUSINESS ||
@@ -141,7 +140,6 @@ export function UpgradePlanModal(props: UpgradePlanModalProps) {
             </Button>
           </div>
         )}
-
       {props.currentPlan === PlanEnum.FREE &&
         (watchPlan === PlanEnum.TEAM || watchPlan === PlanEnum.BUSINESS || watchPlan === PlanEnum.ENTERPRISE) && (
           <div className="bg-brand-50 rounded-lg p-6">

--- a/libs/pages/settings/src/lib/ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-billing-summary/upgrade-plan-modal/upgrade-plan-modal.tsx
@@ -1,0 +1,37 @@
+import { PlanEnum } from 'qovery-typescript-axios'
+import { Button, ButtonStyle, IconAwesomeEnum, Link } from '@qovery/shared/ui'
+
+export interface UpgradePlanModalProps {
+  currentPlan?: PlanEnum
+  onClose: () => void
+}
+
+export function UpgradePlanModal(props: UpgradePlanModalProps) {
+  return (
+    <div className="p-6">
+      <h2 className="h4 text-text-600 mb-2 max-w-sm">Change plan</h2>
+      <p className="text-text-500 text-sm mb-1">
+        Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim
+        velit mollit.
+      </p>
+      <Link
+        link="https://qovery.com/pricing"
+        className="text-text-500 text-sm"
+        external
+        iconRight={IconAwesomeEnum.ARROW_UP_RIGHT_FROM_SQUARE}
+        linkLabel="See details plan"
+      ></Link>
+      <div>{/* todo put here the three radio box in a Controller*/}</div>
+      <div className="flex gap-3 justify-end">
+        <Button className="btn--no-min-w" style={ButtonStyle.STROKED} onClick={props.onClose}>
+          Cancel
+        </Button>
+        <Button className="btn--no-min-w" dataTestId="submit-button" type="submit">
+          Submit
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default UpgradePlanModal

--- a/libs/shared/ui/src/lib/components/icon/icon-awesome.enum.tsx
+++ b/libs/shared/ui/src/lib/components/icon/icon-awesome.enum.tsx
@@ -98,5 +98,6 @@ export enum IconAwesomeEnum {
   ELLIPSIS = 'icon-solid-ellipsis',
   ARROW_DOWN_19 = 'icon-solid-arrow-down-1-9',
   DOWNLOAD = 'icon-solid-download',
+  FIRE = 'icon-solid-fire',
   // schema: favicons name
 }

--- a/libs/shared/ui/src/lib/components/inputs/input-radio-box/input-radio-box.spec.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-radio-box/input-radio-box.spec.tsx
@@ -1,4 +1,4 @@
-import { act, getByTestId, waitFor } from '@testing-library/react'
+import { act, getByTestId, getByText, waitFor } from '@testing-library/react'
 import { render } from '__tests__/utils/setup-jest'
 import InputRadioBox, { InputRadioBoxProps } from './input-radio-box'
 
@@ -43,5 +43,10 @@ describe('InputRadioBox', () => {
   it('should display description if provided', async () => {
     const { baseElement } = render(<InputRadioBox {...props} />)
     getByTestId(baseElement, 'description')
+  })
+
+  it('should display right element', async () => {
+    const { baseElement } = render(<InputRadioBox {...props} rightElement={<h1>Right Element</h1>} />)
+    getByText(baseElement, 'Right Element')
   })
 })

--- a/libs/shared/ui/src/lib/components/inputs/input-radio-box/input-radio-box.stories.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-radio-box/input-radio-box.stories.tsx
@@ -18,4 +18,5 @@ Primary.args = {
   },
   value: 'start',
   description: <p data-testid="description">Description</p>,
+  rightElement: <h3>49$</h3>,
 }

--- a/libs/shared/ui/src/lib/components/inputs/input-radio-box/input-radio-box.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-radio-box/input-radio-box.tsx
@@ -8,10 +8,11 @@ export interface InputRadioBoxProps {
   label: string
   value: string
   description?: ReactNode | undefined
+  rightElement?: ReactNode | undefined
 }
 
 export function InputRadioBox(props: InputRadioBoxProps) {
-  const { name, value, description, onChange, fieldValue, label } = props
+  const { name, value, description, onChange, fieldValue, label, rightElement } = props
 
   return (
     <div
@@ -23,8 +24,13 @@ export function InputRadioBox(props: InputRadioBoxProps) {
           : 'bg-element-light-lighter-200 border-element-light-lighter-500'
       }`}
     >
-      <InputRadio big name={name} value={value} label={label} onChange={onChange} formValue={fieldValue} />
-      {description && <div className="ml-[31px] text-text-500 text-sm mt-1">{description}</div>}
+      <div className="flex items-center justify-between w-full">
+        <div>
+          <InputRadio big name={name} value={value} label={label} onChange={onChange} formValue={fieldValue} />
+          {description && <div className="ml-[31px] text-text-500 text-sm mt-1">{description}</div>}
+        </div>
+        {rightElement}
+      </div>
     </div>
   )
 }

--- a/libs/shared/ui/src/lib/styles/base/icons.scss
+++ b/libs/shared/ui/src/lib/styles/base/icons.scss
@@ -432,3 +432,7 @@
 .icon-solid-download:before {
   content: '\f019';
 }
+
+.icon-solid-fire:before {
+  content: '\f06d';
+}


### PR DESCRIPTION
# What does this PR do?

This PR allows to upgrade through the modal flow instead of Intercom. Backend was not fully ready for this feature yet so we paused it.

<img width="1391" alt="CleanShot 2023-03-28 at 16 49 13@2x" src="https://user-images.githubusercontent.com/6163954/228277465-9d7e3a3f-83d9-40b8-874e-1c21965de411.png">

- This PR misses some tests
- This PR misses so api wiring because backend is not ready.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [x] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
