### PR TITLE
fix: missing icon for live status

### DIFF
--- a/libs/shared/enums/src/lib/running-status.enum.ts
+++ b/libs/shared/enums/src/lib/running-status.enum.ts
@@ -1,6 +1,7 @@
 export enum RunningStatus {
   STARTING = 'STARTING',
   DEPLOYED = 'DEPLOYED',
+  RUNNING = 'RUNNING',
   WARNING = 'WARNING',
   ERROR = 'ERROR',
   STOPPING = 'STOPPING',

--- a/libs/shared/ui/src/lib/components/status-chip/status-chip.tsx
+++ b/libs/shared/ui/src/lib/components/status-chip/status-chip.tsx
@@ -18,6 +18,7 @@ export function StatusChip(props: StatusChipProps) {
     switch (status) {
       case StateEnum.DEPLOYED:
       case RunningStatus.COMPLETED:
+      case RunningStatus.RUNNING:
         return true
       default:
         return false


### PR DESCRIPTION
# What does this PR do?

Fix missing live service status icon since last change.