### PR TITLE
fix unavailable restart action

### DIFF
--- a/libs/shared/utils/src/lib/tools/status-actions-available.tsx
+++ b/libs/shared/utils/src/lib/tools/status-actions-available.tsx
@@ -9,7 +9,9 @@ export const isDeployAvailable = (status: StateEnum): boolean => {
 }
 
 export const isRestartAvailable = (runningStatus: RunningStatus, status: StateEnum): boolean => {
-  return runningStatus === RunningStatus.DEPLOYED && isRedeployAvailable(status)
+  return (
+    (runningStatus === RunningStatus.RUNNING || runningStatus === RunningStatus.DEPLOYED) && isRedeployAvailable(status)
+  )
 }
 
 export const isRedeployAvailable = (status: StateEnum): boolean => {


### PR DESCRIPTION
# What does this PR do?

Restart action is not available anymore, due to runningStatus being in 'RUNNING' state.

Should fix this file, because RunningStatus is used for live status returned from agents and does not condition the availability of some actions.

Also isRedeployAvailable contains "in progress" deployment status, which is not going to allow a redeploy