### PR TITLE
chore: update links in orga settings following doc structure update

### DIFF
--- a/libs/pages/settings/src/lib/ui/page-organization-api/page-organization-api.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-api/page-organization-api.tsx
@@ -101,8 +101,8 @@ export function PageOrganizationApi(props: PageOrganizationApiProps) {
         description="Need help? You may find these links useful"
         links={[
           {
-            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/#container-registry-management',
-            linkLabel: 'How to configure my container registry',
+            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/api-token',
+            linkLabel: 'How to configure the Token API',
             external: true,
           },
         ]}

--- a/libs/pages/settings/src/lib/ui/page-organization-container-registries/page-organization-container-registries.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-container-registries/page-organization-container-registries.tsx
@@ -127,7 +127,7 @@ export function PageOrganizationContainerRegistries(props: PageOrganizationConta
         description="Need help? You may find these links useful"
         links={[
           {
-            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/#container-registry-management',
+            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/container-registry',
             linkLabel: 'How to configure my container registry',
             external: true,
           },

--- a/libs/pages/settings/src/lib/ui/page-organization-github-repository-access/page-organization-github-repository-access.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-github-repository-access/page-organization-github-repository-access.tsx
@@ -107,7 +107,7 @@ export function PageOrganizationGithubRepositoryAccess(props: PageOrganizationGi
         description="Need help? You may find these links useful"
         links={[
           {
-            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/#managing-git-permissions-using-the-qovery-github-app',
+            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/git-repository-access',
             linkLabel: 'Managing Git Permissions Using the Qovery Github application',
             external: true,
           },

--- a/libs/pages/settings/src/lib/ui/page-organization-members/page-organization-members.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-members/page-organization-members.tsx
@@ -193,7 +193,7 @@ export function PageOrganizationMembers(props: PageOrganizationMembersProps) {
         description="Need help? You may find these links useful"
         links={[
           {
-            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/#organization-members',
+            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/members-rbac/#organization-members',
             linkLabel: 'How to configure my organization members',
             external: true,
           },

--- a/libs/pages/settings/src/lib/ui/page-organization-roles/page-organization-roles.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles/page-organization-roles.tsx
@@ -133,7 +133,7 @@ export function PageOrganizationRoles(props: PageOrganizationRolesProps) {
         description="Need help? You may find these links useful"
         links={[
           {
-            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/#custom-roles',
+            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/members-rbac/custom-roles',
             linkLabel: 'How to configure my custom roles',
             external: true,
           },


### PR DESCRIPTION
# What does this PR do?
it updates the links to the doc following the structure update. see https://github.com/Qovery/documentation/pull/295

> Link to the JIRA ticket

Put description here

> Screenshot of the feature

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
