### PR TITLE
fix: add link to doc on env variables page

### DIFF
--- a/libs/pages/application/src/lib/ui/page-variables/page-variables.tsx
+++ b/libs/pages/application/src/lib/ui/page-variables/page-variables.tsx
@@ -45,7 +45,7 @@ export function PageVariablesMemo(props: PageVariablesProps) {
             description="Need help? You may find these links useful"
             links={[
               {
-                link: '#',
+                link: 'https://hub.qovery.com/docs/using-qovery/configuration/environment-variable/',
                 linkLabel: 'How to configure my environment variables',
                 external: true,
               },

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-status/sidebar-status.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-status/sidebar-status.tsx
@@ -1,5 +1,5 @@
 import { EnvironmentStatus } from 'qovery-typescript-axios'
-import { StatusChip, Tooltip } from '@qovery/shared/ui'
+import { Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { dateFullFormat } from '@qovery/shared/utils'
 
 export interface SidebarStatusProps {
@@ -12,11 +12,11 @@ export function SidebarStatus(props: SidebarStatusProps) {
   return (
     <div className="border-b border-element-light-darker-100 p-5">
       <div className="flex items-center justify-between text-text-300 text-xs mb-2">
-        Pipeline deployment status:
+        Deployment status:
         <StatusChip status={environmentStatus?.last_deployment_state || environmentStatus?.state} />
       </div>
       <p className="flex items-center justify-between text-text-300 text-xs mb-2">
-        Deployment id:
+        Deployment Execution id:
         <Tooltip content={environmentStatus?.last_deployment_id || ''}>
           <span className="text-brand-400">
             {environmentStatus?.last_deployment_id && environmentStatus?.last_deployment_id.length > 23
@@ -34,6 +34,28 @@ export function SidebarStatus(props: SidebarStatusProps) {
           <span className="text-text-100">{dateFullFormat(environmentStatus?.last_deployment_date || '')}</span>
         </p>
       )}
+      <p className="flex items-center justify-between text-text-300 text-xs mt-2">
+        Parallel Deployment:
+        <span className="flex text-text-100">
+          4{' '}
+          <Tooltip side="right" content="Number of services deployed in parallel on each pipeline stage">
+            <div className="flex items-center">
+              <Icon className="cursor-pointer ml-1 text-xs text-element-light-text-300" name="icon-solid-circle-info" />
+            </div>
+          </Tooltip>
+        </span>
+      </p>
+      <p className="flex items-center justify-between text-text-300 text-xs mt-2">
+        Assigned build resources:
+        <span className="flex text-text-100">
+          4CPU / 8GB Mem
+          <Tooltip side="right" content="Resource assigned by Qovery to build each application">
+            <div className="flex items-center">
+              <Icon className="cursor-pointer ml-1 text-xs text-element-light-text-300" name="icon-solid-circle-info" />
+            </div>
+          </Tooltip>
+        </span>
+      </p>
     </div>
   )
 }

--- a/libs/pages/settings/src/lib/ui/page-organization-roles-edit/page-organization-roles-edit.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles-edit/page-organization-roles-edit.tsx
@@ -160,7 +160,7 @@ export function PageOrganizationRolesEdit(props: PageOrganizationRolesEditProps)
         description="Need help? You may find these links useful"
         links={[
           {
-            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/#custom-roles',
+            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/members-rbac/#roles-based-access-control-rbac',
             linkLabel: 'How to configure my custom roles',
             external: true,
           },

--- a/libs/pages/settings/src/lib/ui/page-organization-roles/page-organization-roles.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles/page-organization-roles.tsx
@@ -133,7 +133,7 @@ export function PageOrganizationRoles(props: PageOrganizationRolesProps) {
         description="Need help? You may find these links useful"
         links={[
           {
-            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/members-rbac/custom-roles',
+            link: 'https://hub.qovery.com/docs/using-qovery/configuration/organization/members-rbac/#roles-based-access-control-rbac',
             linkLabel: 'How to configure my custom roles',
             external: true,
           },


### PR DESCRIPTION
# What does this PR do?
add link to doc on env variables page


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
