### PR TITLE
fix(service): current label on deploy other commit for job

### DIFF
--- a/libs/shared/console-shared/src/lib/deploy-other-commit-modal/feature/deploy-other-commit-modal-feature.tsx
+++ b/libs/shared/console-shared/src/lib/deploy-other-commit-modal/feature/deploy-other-commit-modal-feature.tsx
@@ -92,7 +92,10 @@ export function DeployOtherCommitModalFeature(props: DeployOtherCommitModalFeatu
       isLoading={isLoading === 'loading'}
       selectedCommitId={selectedCommitId}
       setSelectedCommitId={setSelectedCommitId}
-      currentCommitId={application?.git_repository?.deployed_commit_id}
+      currentCommitId={
+        application?.git_repository?.deployed_commit_id ||
+        application?.source?.docker?.git_repository?.deployed_commit_id
+      }
       buttonDisabled={buttonDisabled()}
       handleDeploy={handleDeploy}
       deployLoading={deployLoading}


### PR DESCRIPTION
# What does this PR do?

https://qovery.slack.com/archives/C02NPSG2HBL/p1683703783833349

For job, the `Current Version` label was missing
![CleanShot 2023-05-10 at 10 35 27](https://github.com/Qovery/console/assets/6163954/c1390ea9-aaa5-4591-a701-f2e20020d665)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
