### PR TITLE
feat(preview-environments): add on demand preview flag to environment deployment rule

### DIFF
--- a/libs/pages/services/src/lib/ui/page-settings-preview-environments/page-settings-preview-environments.spec.tsx
+++ b/libs/pages/services/src/lib/ui/page-settings-preview-environments/page-settings-preview-environments.spec.tsx
@@ -7,17 +7,21 @@ import PageSettingsPreviewEnvironments, {
 } from './page-settings-preview-environments'
 
 const props: PageSettingsPreviewEnvironmentsProps = {
+  loading: false,
   onSubmit: jest.fn(),
   applications: applicationFactoryMock(3),
   toggleAll: jest.fn(),
+  toggleEnablePreview: jest.fn(),
 }
 
 describe('PageSettingsPreviewEnvironments', () => {
   const defaultValues: any = {
     auto_preview: false,
+    on_demand_preview: false,
     0: true,
     1: true,
   }
+
   it('should render successfully', async () => {
     const { baseElement } = render(wrapWithReactHookForm(<PageSettingsPreviewEnvironments {...props} />))
 
@@ -44,12 +48,30 @@ describe('PageSettingsPreviewEnvironments', () => {
       expect(screen.getByTestId(`toggle-1`).querySelector('input')?.getAttribute('value')).toBe('true')
     })
   })
+  it('should have the toggle with on_demand_preview', async () => {
+    render(
+      wrapWithReactHookForm(<PageSettingsPreviewEnvironments {...props} />, {
+        defaultValues,
+      })
+    )
+
+    await act(() => {
+      const toggle = screen.getByTestId('toggle-on-demand-preview')
+      fireEvent.click(toggle)
+    })
+
+    await waitFor(async () => {
+      expect(screen.getByTestId(`toggle-on-demand-preview`)?.querySelector('input')?.getAttribute('value')).toBe('true')
+    })
+  })
 
   it(`should have margin when we have applications`, () => {
     render(wrapWithReactHookForm(<PageSettingsPreviewEnvironments {...props} />))
 
     const toggles = screen.getByTestId('toggles')
-
     expect(toggles.classList.contains('mt-5')).toBe(true)
+
+    const applicationTitle = screen.getByTestId('applications-title')
+    expect(applicationTitle).toBeTruthy()
   })
 })

--- a/libs/pages/services/src/lib/ui/page-settings-preview-environments/page-settings-preview-environments.tsx
+++ b/libs/pages/services/src/lib/ui/page-settings-preview-environments/page-settings-preview-environments.tsx
@@ -8,10 +8,11 @@ export interface PageSettingsPreviewEnvironmentsProps {
   loading: boolean
   applications?: ApplicationEntity[]
   toggleAll: (value: boolean) => void
+  toggleEnablePreview: (value: boolean) => void
 }
 
 export function PageSettingsPreviewEnvironments(props: PageSettingsPreviewEnvironmentsProps) {
-  const { onSubmit, applications, loading, toggleAll } = props
+  const { onSubmit, applications, loading, toggleAll, toggleEnablePreview } = props
   const { control, formState } = useFormContext()
 
   return (
@@ -23,26 +24,49 @@ export function PageSettingsPreviewEnvironments(props: PageSettingsPreviewEnviro
           </div>
         </div>
         <form onSubmit={onSubmit}>
-          <BlockContent title="General">
+          <BlockContent title="Global settings">
             <Controller
               name="auto_preview"
               control={control}
               render={({ field }) => (
                 <InputToggle
                   dataTestId="toggle-all"
+                  className="mb-5"
                   value={field.value}
                   onChange={(value) => {
                     toggleAll(value)
                     field.onChange(value)
                   }}
-                  title="Activate preview environment for all applications"
-                  description="Automatically create a preview environment when a merge/pull request is submitted on one of your applications."
+                  title="Turn on Preview Environments"
+                  description="Use this environment as Blueprint to create a preview environment when a Pull Request is submitted on one of your applications."
                   forceAlignTop
                   small
                 />
               )}
             />
+            <Controller
+              name="on_demand_preview"
+              control={control}
+              render={({ field }) => (
+                <InputToggle
+                  dataTestId="toggle-on-demand-preview"
+                  className="mb-5"
+                  value={field.value}
+                  onChange={field.onChange}
+                  title="Create on demand"
+                  description="Trigger the creation only when requested within the Pull Request. Disabling this option will create a preview environment for each Pull Request."
+                  forceAlignTop
+                  small
+                />
+              )}
+            />
+
             <div data-testid="toggles" className={applications && applications.length > 0 ? 'mt-5' : ''}>
+              {applications && applications.length > 0 && (
+                <h2 data-testid="applications-title" className="font-medium text-text-600 text-ssm mb-5">
+                  Create Preview for PR opened on those services
+                </h2>
+              )}
               {applications?.map((application: ApplicationEntity) => (
                 <div key={application.id} className="h-9 flex items-center">
                   <Controller
@@ -52,7 +76,10 @@ export function PageSettingsPreviewEnvironments(props: PageSettingsPreviewEnviro
                       <InputToggle
                         dataTestId={`toggle-${application.id}`}
                         value={field.value}
-                        onChange={field.onChange}
+                        onChange={(value) => {
+                          toggleEnablePreview(value)
+                          field.onChange(value)
+                        }}
                         title={
                           <span className="flex items-center -top-1 relative">
                             <Icon name={IconEnum.APPLICATION} className="mr-3" /> {application.name}


### PR DESCRIPTION
# What does this PR do?

The PR introduces a new flag on environment deployment rule. This flag disable automatic preview environment and enable instead a new git flow, to let user select which and when a preview should be created.

> Link to the JIRA ticket

https://qovery.atlassian.net/browse/COR-614
add trigger to create preview environments (activation mode)

> Screenshot of the feature

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
