### PR TITLE
fix:use message from error response in toast

### DIFF
--- a/libs/domains/application/src/lib/slices/applications.slice.ts
+++ b/libs/domains/application/src/lib/slices/applications.slice.ts
@@ -646,7 +646,9 @@ export const applicationsSlice = createSlice({
 
         toast(
           ToastEnum.ERROR,
-          `Your advanced settings have not been updated. Something must be wrong with the values provided`
+          action.error.message
+            ? action.error.message
+            : `Your advanced settings have not been updated. Something must be wrong with the values provided`
         )
         applicationsAdapter.updateOne(state, update)
       })

--- a/libs/domains/organization/src/lib/slices/cluster/cluster.slice.ts
+++ b/libs/domains/organization/src/lib/slices/cluster/cluster.slice.ts
@@ -513,7 +513,9 @@ export const clusterSlice = createSlice({
 
         toast(
           ToastEnum.ERROR,
-          `Your advanced settings have not been updated. Something must be wrong with the values provided`
+          action.error.message
+            ? action.error.message
+            : `Your advanced settings have not been updated. Something must be wrong with the values provided`
         )
         clusterAdapter.updateOne(state, update)
       })


### PR DESCRIPTION
# What does this PR do?

use the error message from the advanced settings endpoint (when available)


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
