### PR TITLE
chore(cluster-settings): change default disk_size from 20 to 50

### DIFF
--- a/libs/pages/cluster/src/lib/ui/page-settings-resources/page-settings-resources.spec.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-resources/page-settings-resources.spec.tsx
@@ -17,7 +17,7 @@ describe('PageSettingsResources', () => {
   beforeEach(() => {
     defaultValues = {
       instance_type: 't3.medium',
-      disk_size: 20,
+      disk_size: 50,
       cluster_type: 'MANAGED',
       nodes: [1, 3],
     }

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/page-clusters-create-feature.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/page-clusters-create-feature.tsx
@@ -65,7 +65,7 @@ export const steps = (cloudProvider?: CloudProviderEnum, clusterType?: string) =
 
 export const defaultResourcesData: ClusterResourcesData = {
   cluster_type: '',
-  disk_size: 20,
+  disk_size: 50,
   instance_type: '',
   nodes: [3, 10],
 }

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-resources-feature/step-resources-feature.spec.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-resources-feature/step-resources-feature.spec.tsx
@@ -64,7 +64,7 @@ const ContextWrapper = (props: { children: ReactNode }) => {
         setResourcesData: mockSetResourceData,
         resourcesData: {
           instance_type: 't3.medium',
-          disk_size: 20,
+          disk_size: 50,
           cluster_type: 'MANAGED',
           nodes: [1, 3],
         },

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-summary-feature/step-summary-feature.spec.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-summary-feature/step-summary-feature.spec.tsx
@@ -44,7 +44,7 @@ const ContextWrapper = (props: { children: ReactNode }) => {
           cluster_type: 'MANAGED',
           instance_type: 't2.micro',
           nodes: [1, 4],
-          disk_size: 20,
+          disk_size: 50,
         },
         setResourcesData: mockSetResourcesData,
         remoteData: {
@@ -110,7 +110,7 @@ describe('StepSummaryFeature', () => {
         max_running_nodes: 4,
         kubernetes: 'MANAGED',
         instance_type: 't2.micro',
-        disk_size: 20,
+        disk_size: 50,
         ssh_keys: ['ssh_key'],
         features: [
           {

--- a/libs/pages/clusters/src/lib/ui/page-clusters-create/step-resources/step-resources.spec.tsx
+++ b/libs/pages/clusters/src/lib/ui/page-clusters-create/step-resources/step-resources.spec.tsx
@@ -11,7 +11,7 @@ describe('StepResources', () => {
   beforeEach(() => {
     defaultValues = {
       instance_type: 't3.medium',
-      disk_size: 20,
+      disk_size: 50,
       cluster_type: 'MANAGED',
       nodes: [1, 3],
     }

--- a/libs/pages/clusters/src/lib/ui/page-clusters-create/step-summary/step-summary.spec.tsx
+++ b/libs/pages/clusters/src/lib/ui/page-clusters-create/step-summary/step-summary.spec.tsx
@@ -19,7 +19,7 @@ const props: StepSummaryProps = {
     cluster_type: 'MANAGED',
     instance_type: 't2.micro',
     nodes: [1, 4],
-    disk_size: 20,
+    disk_size: 50,
   },
   featuresData: {
     [STATIC_IP]: {

--- a/libs/shared/console-shared/src/lib/cluster-settings/feature/cluster-resources-settings-feature/cluster-resources-settings-feature.spec.tsx
+++ b/libs/shared/console-shared/src/lib/cluster-settings/feature/cluster-resources-settings-feature/cluster-resources-settings-feature.spec.tsx
@@ -13,7 +13,7 @@ describe('ClusterResourcesSettingsFeature', () => {
   beforeEach(() => {
     defaultValues = {
       instance_type: 't3.medium',
-      disk_size: 20,
+      disk_size: 50,
       cluster_type: 'MANAGED',
       nodes: [1, 3],
     }

--- a/libs/shared/console-shared/src/lib/cluster-settings/ui/cluster-resources-settings/cluster-resources-settings.spec.tsx
+++ b/libs/shared/console-shared/src/lib/cluster-settings/ui/cluster-resources-settings/cluster-resources-settings.spec.tsx
@@ -11,7 +11,7 @@ describe('ClusterResourcesSettings', () => {
   beforeEach(() => {
     defaultValues = {
       instance_type: 't2.micro',
-      disk_size: 20,
+      disk_size: 50,
       cluster_type: 'MANAGED',
       nodes: [1, 3],
     }

--- a/libs/shared/factories/src/lib/cluster-factory.mock.ts
+++ b/libs/shared/factories/src/lib/cluster-factory.mock.ts
@@ -15,7 +15,7 @@ export const clusterFactoryMock = (howMany: number, customCloudProvider?: CloudP
     cloud_provider: customCloudProvider ? customCloudProvider : chance.pickone(Object.values(CloudProviderEnum)),
     min_running_nodes: 1,
     max_running_nodes: 5,
-    disk_size: 10,
+    disk_size: 20,
     status: chance.pickone(Object.values(StateEnum)),
     is_default: false,
     version: '1.22',


### PR DESCRIPTION
# What does this PR do?

This PR changes the minimum default disk_size from 20 to 50 Gib.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
