### PR TITLE
fix(deployment-logs): display delete logs

### DIFF
--- a/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
@@ -78,9 +78,13 @@ export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
     updateServiceId(serviceId)
   }, [updateServiceId, serviceId])
 
+  // deployment logs by serviceId and stageId
+  // display when name is delete or stageId is empty
   const logsByServiceId = logs.filter(
     (currentData: EnvironmentLogs) =>
-      (currentData.details.stage?.id === stageId || !currentData.details.stage?.id) &&
+      (currentData.details.stage?.id === stageId ||
+        !currentData.details.stage?.id ||
+        currentData.details.stage.name === 'delete') &&
       (currentData.details.transmitter?.type === 'Environment' || currentData.details.transmitter?.id === serviceId)
   )
 


### PR DESCRIPTION
# What does this PR do?

- Display logs when we deleting service

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
