### PR TITLE
fix: remove binary name in the args cmd example

### DIFF
--- a/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.tsx
+++ b/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.tsx
@@ -56,9 +56,7 @@ export function EntrypointCmdInputs(props: EntrypointCmdInputsProps) {
           />
         )}
       />
-      <p className="text-xs ml-4 mt-1 text-text-400">
-        Expected format: ["rails", "-h", "0.0.0.0", "-p", "8080", "string"]
-      </p>
+      <p className="text-xs ml-4 mt-1 text-text-400">Expected format: ["-h", "0.0.0.0", "-p", "8080", "string"]</p>
     </div>
   )
 }


### PR DESCRIPTION
# What does this PR do?

Remove confusion in an example, where we expect args and a binary name is set