### PR TITLE
feat: added tooltips to display full date on updated_at info

### DIFF
--- a/libs/pages/application/src/lib/ui/about/about-update/about-update.tsx
+++ b/libs/pages/application/src/lib/ui/about/about-update/about-update.tsx
@@ -16,9 +16,9 @@ export function AboutUpdate(props: AboutUpdateProps) {
       )}
       {props.application?.updated_at && (
         <div>
-          Last edit:{' '}
+          Last edit:
           <Tooltip content={dateFullFormat(props.application.updated_at)}>
-            <span>{timeAgo(new Date(props.application.updated_at))} ago</span>
+            <span>{timeAgo(new Date(props.application.updated_at))}</span>
           </Tooltip>
         </div>
       )}

--- a/libs/pages/application/src/lib/ui/about/about-update/about-update.tsx
+++ b/libs/pages/application/src/lib/ui/about/about-update/about-update.tsx
@@ -1,4 +1,5 @@
 import { ApplicationEntity } from '@qovery/shared/interfaces'
+import { Tooltip } from '@qovery/shared/ui'
 import { dateFullFormat, timeAgo } from '@qovery/shared/utils'
 
 export interface AboutUpdateProps {
@@ -15,7 +16,10 @@ export function AboutUpdate(props: AboutUpdateProps) {
       )}
       {props.application?.updated_at && (
         <div>
-          Last edit: <span>{timeAgo(new Date(props.application.updated_at))}</span>
+          Last edit:{' '}
+          <Tooltip content={dateFullFormat(props.application.updated_at)}>
+            <span>{timeAgo(new Date(props.application.updated_at))} ago</span>
+          </Tooltip>
         </div>
       )}
     </div>

--- a/libs/pages/environments/src/lib/ui/table-row-environments/table-row-environments.tsx
+++ b/libs/pages/environments/src/lib/ui/table-row-environments/table-row-environments.tsx
@@ -13,7 +13,7 @@ import {
   TagMode,
   Tooltip,
 } from '@qovery/shared/ui'
-import { dateYearMonthDayHourMinuteSecond, timeAgo } from '@qovery/shared/utils'
+import { dateFullFormat, timeAgo } from '@qovery/shared/utils'
 
 export interface TableRowEnvironmentsProps {
   data: Environment
@@ -74,7 +74,7 @@ export function TableRowEnvironments(props: TableRowEnvironmentsProps) {
               <p className="flex items-center leading-7 text-text-400 text-sm">
                 <StatusLabel status={status && status.state} />
                 {status?.last_deployment_date && (
-                  <Tooltip content={dateYearMonthDayHourMinuteSecond(new Date(status.last_deployment_date))}>
+                  <Tooltip content={dateFullFormat(status.last_deployment_date)}>
                     <span className="text-xs text-text-300 mx-3 font-medium">
                       {timeAgo(new Date(status.last_deployment_date))} ago
                     </span>

--- a/libs/pages/environments/src/lib/ui/table-row-environments/table-row-environments.tsx
+++ b/libs/pages/environments/src/lib/ui/table-row-environments/table-row-environments.tsx
@@ -13,7 +13,7 @@ import {
   TagMode,
   Tooltip,
 } from '@qovery/shared/ui'
-import { timeAgo } from '@qovery/shared/utils'
+import { dateYearMonthDayHourMinuteSecond, timeAgo } from '@qovery/shared/utils'
 
 export interface TableRowEnvironmentsProps {
   data: Environment
@@ -74,9 +74,11 @@ export function TableRowEnvironments(props: TableRowEnvironmentsProps) {
               <p className="flex items-center leading-7 text-text-400 text-sm">
                 <StatusLabel status={status && status.state} />
                 {status?.last_deployment_date && (
-                  <span className="text-xs text-text-300 mx-3 font-medium">
-                    {timeAgo(new Date(status.last_deployment_date))} ago
-                  </span>
+                  <Tooltip content={dateYearMonthDayHourMinuteSecond(new Date(status.last_deployment_date))}>
+                    <span className="text-xs text-text-300 mx-3 font-medium">
+                      {timeAgo(new Date(status.last_deployment_date))} ago
+                    </span>
+                  </Tooltip>
                 )}
               </p>
               <EnvironmentButtonsActions environment={data} status={status} hasServices={true} />

--- a/libs/pages/services/src/lib/ui/table-row-services/table-row-services.tsx
+++ b/libs/pages/services/src/lib/ui/table-row-services/table-row-services.tsx
@@ -28,7 +28,7 @@ import {
   TagCommit,
   Tooltip,
 } from '@qovery/shared/ui'
-import { timeAgo, upperCaseFirstLetter } from '@qovery/shared/utils'
+import { dateYearMonthDayHourMinuteSecond, timeAgo, upperCaseFirstLetter } from '@qovery/shared/utils'
 
 export interface TableRowServicesProps<T> {
   data: ApplicationEntity | DatabaseEntity
@@ -92,9 +92,11 @@ export function TableRowServices<T>(props: TableRowServicesProps<T>) {
               <p className="flex items-center gap-3 leading-7 text-text-400 text-sm">
                 {data.status && data.status.state && <StatusLabel status={data.status && data.status.state} />}
                 {data.status?.last_deployment_date && (
-                  <span className="text-xs text-text-300 font-medium">
-                    {timeAgo(new Date(data.status.last_deployment_date))} ago
-                  </span>
+                  <Tooltip content={dateYearMonthDayHourMinuteSecond(new Date(data.status.last_deployment_date))}>
+                    <span className="text-xs text-text-300 font-medium">
+                      {timeAgo(new Date(data.status.last_deployment_date))} ago
+                    </span>
+                  </Tooltip>
                 )}
               </p>
               {data.name && (

--- a/libs/pages/services/src/lib/ui/table-row-services/table-row-services.tsx
+++ b/libs/pages/services/src/lib/ui/table-row-services/table-row-services.tsx
@@ -28,7 +28,7 @@ import {
   TagCommit,
   Tooltip,
 } from '@qovery/shared/ui'
-import { dateYearMonthDayHourMinuteSecond, timeAgo, upperCaseFirstLetter } from '@qovery/shared/utils'
+import { dateFullFormat, timeAgo, upperCaseFirstLetter } from '@qovery/shared/utils'
 
 export interface TableRowServicesProps<T> {
   data: ApplicationEntity | DatabaseEntity
@@ -92,7 +92,7 @@ export function TableRowServices<T>(props: TableRowServicesProps<T>) {
               <p className="flex items-center gap-3 leading-7 text-text-400 text-sm">
                 {data.status && data.status.state && <StatusLabel status={data.status && data.status.state} />}
                 {data.status?.last_deployment_date && (
-                  <Tooltip content={dateYearMonthDayHourMinuteSecond(new Date(data.status.last_deployment_date))}>
+                  <Tooltip content={dateFullFormat(data.status.last_deployment_date)}>
                     <span className="text-xs text-text-300 font-medium">
                       {timeAgo(new Date(data.status.last_deployment_date))} ago
                     </span>


### PR DESCRIPTION
# What does this PR do?

I have added tooltips on the updated at info available in:
- the service list
- the environment list
- the service overview

what is missing for now:
- tooltip on the deployment tab

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
