### PR TITLE
feat(tooltip): add truncate by default

### DIFF
--- a/libs/pages/application/src/lib/ui/about/about-container/about-container.tsx
+++ b/libs/pages/application/src/lib/ui/about/about-container/about-container.tsx
@@ -43,7 +43,7 @@ export function AboutContainer(props: AboutContainerProps) {
         Registry:{' '}
         <Skeleton height={36} width={100} show={!props.currentRegistry}>
           <Button external link={props.currentRegistry?.url} style={ButtonStyle.STROKED} iconLeft={IconEnum.CONTAINER}>
-            {props.currentRegistry?.name}
+            <Truncate truncateLimit={18} text={props.currentRegistry?.name || ''} />
           </Button>
         </Skeleton>
       </div>

--- a/libs/pages/application/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
@@ -62,7 +62,7 @@ export function PageSettingsAdvanced(props: PageSettingsAdvancedProps) {
           cells: [
             {
               content: (
-                <Tooltip content={key}>
+                <Tooltip classNameTrigger="truncate" content={key}>
                   <div>{key}</div>
                 </Tooltip>
               ),

--- a/libs/pages/cluster/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
@@ -60,7 +60,7 @@ export function PageSettingsAdvanced(props: PageSettingsAdvancedProps) {
           cells: [
             {
               content: (
-                <Tooltip content={key}>
+                <Tooltip classNameTrigger="truncate" content={key}>
                   <div>{key}</div>
                 </Tooltip>
               ),

--- a/libs/pages/events/src/lib/ui/row-event/row-event.spec.tsx
+++ b/libs/pages/events/src/lib/ui/row-event/row-event.spec.tsx
@@ -1,5 +1,4 @@
-import { act, getAllByTestId, getByTestId, getByText, queryByTestId } from '@testing-library/react'
-import { render } from '__tests__/utils/setup-jest'
+import { act, getAllByTestId, getByTestId, getByText, queryByTestId, render } from '__tests__/utils/setup-jest'
 import { OrganizationEventResponse } from 'qovery-typescript-axios'
 import { eventsFactoryMock } from '@qovery/shared/factories'
 import { dateYearMonthDayHourMinuteSecond, upperCaseFirstLetter } from '@qovery/shared/utils'

--- a/libs/shared/ui/src/lib/components/tooltip/tooltip.tsx
+++ b/libs/shared/ui/src/lib/components/tooltip/tooltip.tsx
@@ -10,6 +10,7 @@ export interface TooltipProps {
   side?: 'top' | 'right' | 'bottom' | 'left'
   align?: 'center' | 'start' | 'end'
   delayDuration?: number
+  classNameTrigger?: string
 }
 
 export function Tooltip(props: TooltipProps) {
@@ -22,6 +23,7 @@ export function Tooltip(props: TooltipProps) {
     side = 'top',
     align = 'center',
     delayDuration = 200,
+    classNameTrigger = '',
   } = props
 
   return (
@@ -32,7 +34,7 @@ export function Tooltip(props: TooltipProps) {
         onOpenChange={onOpenChange}
         delayDuration={delayDuration}
       >
-        <TooltipPrimitive.Trigger asChild className="truncate">
+        <TooltipPrimitive.Trigger asChild className={classNameTrigger}>
           {children}
         </TooltipPrimitive.Trigger>
         <TooltipPrimitive.Content

--- a/libs/shared/ui/src/lib/components/tooltip/tooltip.tsx
+++ b/libs/shared/ui/src/lib/components/tooltip/tooltip.tsx
@@ -32,7 +32,9 @@ export function Tooltip(props: TooltipProps) {
         onOpenChange={onOpenChange}
         delayDuration={delayDuration}
       >
-        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Trigger asChild className="truncate">
+          {children}
+        </TooltipPrimitive.Trigger>
         <TooltipPrimitive.Content
           className="bg-element-dark-400 text-text-100 dark:bg-element-light-lighter-200 dark:text-text-700 rounded-sm px-2 py-1 text-xs font-medium z-[100]"
           side={side}


### PR DESCRIPTION
# What does this PR do?

- Add truncate by default for all tooltip

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
