### PR TITLE
fix(port): add default healtchecks

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-ports-feature/crud-modal-feature/crud-modal-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-ports-feature/crud-modal-feature/crud-modal-feature.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react'
 import { FieldValues, FormProvider, useForm } from 'react-hook-form'
 import { useDispatch } from 'react-redux'
 import { editApplication, postApplicationActionsRedeploy } from '@qovery/domains/application'
-import { CrudModal } from '@qovery/shared/console-shared'
-import { getServiceType } from '@qovery/shared/enums'
+import { CrudModal, defaultLivenessProbe } from '@qovery/shared/console-shared'
+import { ProbeTypeEnum, getServiceType } from '@qovery/shared/enums'
 import { ApplicationEntity } from '@qovery/shared/interfaces'
 import { useModal } from '@qovery/shared/ui'
 import { AppDispatch } from '@qovery/store'
@@ -38,6 +38,20 @@ export const handleSubmit = (data: FieldValues, application: ApplicationEntity, 
     }) as ServicePort[]
   } else {
     cloneApplication.ports = [...ports, port] as ServicePort[]
+  }
+
+  if (ports.length === 0) {
+    cloneApplication.healthchecks = {
+      liveness_probe: {
+        type: {
+          [ProbeTypeEnum.TCP.toLowerCase()]: {
+            port: port.internal_port,
+            host: null,
+          },
+        },
+        ...defaultLivenessProbe,
+      },
+    }
   }
 
   return cloneApplication

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.tsx
@@ -95,8 +95,8 @@ export function StepHealthchecksFeature() {
   }, [methods, portData?.healthchecks])
 
   const onSubmit = methods.handleSubmit((data) => {
-    const typeLiveness = data.liveness_probe.current_type
-    const typeReadiness = data.readiness_probe.current_type
+    const typeLiveness = data.liveness_probe ? data.liveness_probe.current_type : ProbeTypeEnum.NONE
+    const typeReadiness = data.readiness_probe ? data.readiness_probe.current_type : ProbeTypeEnum.NONE
 
     setPortData({
       ports: portData?.ports || [],
@@ -104,8 +104,14 @@ export function StepHealthchecksFeature() {
         typeLiveness: typeLiveness as string,
         typeReadiness: typeReadiness as string,
         item: {
-          liveness_probe: probeFormatted(data.liveness_probe, portData?.ports?.[0].application_port) as ProbeExtended,
-          readiness_probe: probeFormatted(data.readiness_probe, portData?.ports?.[0].application_port) as ProbeExtended,
+          liveness_probe:
+            data.liveness_probe && typeLiveness !== ProbeTypeEnum.NONE
+              ? (probeFormatted(data.liveness_probe, portData?.ports?.[0].application_port) as ProbeExtended)
+              : undefined,
+          readiness_probe:
+            data.readiness_probe && typeReadiness !== ProbeTypeEnum.NONE
+              ? (probeFormatted(data.readiness_probe, portData?.ports?.[0].application_port) as ProbeExtended)
+              : undefined,
         },
       },
     })

--- a/libs/shared/interfaces/src/lib/common/flow-port-data.interface.ts
+++ b/libs/shared/interfaces/src/lib/common/flow-port-data.interface.ts
@@ -11,8 +11,8 @@ export type ProbeExtended = Probe & {
 }
 
 export interface HealthcheckData {
-  readiness_probe: ProbeExtended
-  liveness_probe: ProbeExtended
+  readiness_probe?: ProbeExtended
+  liveness_probe?: ProbeExtended
 }
 
 export interface FlowPortData {


### PR DESCRIPTION
# What does this PR do?

- Add default TCP healtchecks when we create a new port

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
