### PR TITLE
fix(layout): fetching cluster status

### DIFF
--- a/libs/pages/layout/src/lib/feature/layout/layout.tsx
+++ b/libs/pages/layout/src/lib/feature/layout/layout.tsx
@@ -6,6 +6,7 @@ import { fetchApplications } from '@qovery/domains/application'
 import { fetchDatabases } from '@qovery/domains/database'
 import {
   fetchClusters,
+  fetchClustersStatus,
   fetchOrganization,
   fetchOrganizationById,
   selectClustersEntitiesByOrganizationId,
@@ -73,6 +74,7 @@ export function Layout(props: LayoutProps) {
     if (organizationId) {
       dispatch(fetchProjects({ organizationId }))
       dispatch(fetchClusters({ organizationId }))
+      dispatch(fetchClustersStatus({ organizationId }))
     }
   }, [dispatch, organizationId])
 


### PR DESCRIPTION
# What does this PR do?

- [Interrupt](https://qovery.slack.com/archives/C038JMN9GUE/p1688990829035699) 
- Add cluster status fetch on the first load
- Allow to hide the cluster banner everywhere if `is_deployed` flag is true 

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
