### PR TITLE
feat(modal-confirmation-delete): change confirm deletion modal

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-domains-feature/page-settings-domains-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-domains-feature/page-settings-domains-feature.tsx
@@ -60,7 +60,6 @@ export function PageSettingsDomainsFeature() {
         openModalConfirmation({
           title: 'Delete custom domain',
           isDelete: true,
-          description: 'Are you sure you want to delete this custom domain?',
           name: customDomain.domain,
           action: () => {
             if (application) {

--- a/libs/pages/application/src/lib/feature/page-settings-ports-feature/page-settings-ports-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-ports-feature/page-settings-ports-feature.tsx
@@ -100,8 +100,7 @@ export function PageSettingsPortsFeature() {
         openModalConfirmation({
           title: 'Delete Port',
           isDelete: true,
-          description: 'Are you sure you want to delete this port?',
-          name: application?.name,
+          name: `Port: ${(port as PortData).application_port || (port as ServicePort).internal_port}`,
           action: () => {
             if (application) {
               const cloneApplication = deletePort(application, (port as ServicePort).id)

--- a/libs/pages/application/src/lib/feature/page-settings-storage-feature/page-settings-storage-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-storage-feature/page-settings-storage-feature.tsx
@@ -46,8 +46,7 @@ export function PageSettingsStorageFeature() {
       onRemove={(storage: ServiceStorageStorage) => {
         openModalConfirmation({
           title: 'Delete storage',
-          description: 'To confirm the deletion of this storage, please type the name of the application',
-          name: application?.name,
+          name: storage.mount_point,
           isDelete: true,
           action: async () => {
             if (!application) return

--- a/libs/pages/application/src/lib/feature/table-row-environment-variable-feature/table-row-environment-variable-feature.tsx
+++ b/libs/pages/application/src/lib/feature/table-row-environment-variable-feature/table-row-environment-variable-feature.tsx
@@ -182,7 +182,6 @@ export function TableRowEnvironmentVariableFeature(props: TableRowEnvironmentVar
           onClick: () => {
             openModalConfirmation({
               title: 'Delete variable',
-              description: 'To confirm the deletion of your variable, please type the name of the variable:',
               name: variable?.key,
               isDelete: true,
               action: () => {

--- a/libs/pages/application/src/lib/ui/page-settings-danger-zone/page-settings-danger-zone.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-danger-zone/page-settings-danger-zone.tsx
@@ -20,7 +20,6 @@ export function PageSettingsDangerZone(props: PageSettingsDangerZoneProps) {
           modalConfirmation={{
             mode: environmentMode,
             title: 'Delete application',
-            description: 'To confirm the deletion of your application, please type the name of the application:',
             name: application?.name,
           }}
         />

--- a/libs/pages/cluster/src/lib/feature/page-settings-network-feature/page-settings-network-feature.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-network-feature/page-settings-network-feature.tsx
@@ -81,7 +81,6 @@ export function PageSettingsNetworkFeature() {
         openModalConfirmation({
           title: 'Delete Network',
           isDelete: true,
-          description: 'Are you sure you want to delete this network?',
           name: route.target,
           action: () => {
             if (cluster?.routingTable?.items && cluster?.routingTable?.items?.length > 0) {

--- a/libs/pages/cluster/src/lib/ui/page-settings-danger-zone/page-settings-danger-zone.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-danger-zone/page-settings-danger-zone.tsx
@@ -19,7 +19,6 @@ export function PageSettingsDangerZone(props: PageSettingsDangerZoneProps) {
           modalConfirmation={{
             mode: EnvironmentModeEnum.PRODUCTION,
             title: 'Uninstall cluster',
-            description: 'To confirm the deletion of your cluster, please type the name of the cluster:',
             name: cluster?.name,
           }}
         />

--- a/libs/pages/database/src/lib/ui/page-settings-danger-zone/page-settings-danger-zone.tsx
+++ b/libs/pages/database/src/lib/ui/page-settings-danger-zone/page-settings-danger-zone.tsx
@@ -20,7 +20,6 @@ export function PageSettingsDangerZone(props: PageSettingsDangerZoneProps) {
           modalConfirmation={{
             mode: environmentMode,
             title: 'Delete database',
-            description: 'To confirm the deletion of your database, please type the name of the database:',
             name: database?.name,
           }}
         />

--- a/libs/pages/services/src/lib/feature/page-settings-deployment-pipeline-feature/page-settings-deployment-pipeline-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-settings-deployment-pipeline-feature/page-settings-deployment-pipeline-feature.tsx
@@ -95,7 +95,6 @@ export function PageSettingsDeploymentPipelineFeature() {
             openModalConfirmation({
               title: 'Delete this stage',
               isDelete: true,
-              description: 'Are you sure you want to delete this stage?',
               name: stage.name,
               action: () => deleteEnvironmentDeploymentStage.mutate({ stageId: stage.id }),
             }),

--- a/libs/pages/services/src/lib/ui/page-settings-danger-zone/page-settings-danger-zone.tsx
+++ b/libs/pages/services/src/lib/ui/page-settings-danger-zone/page-settings-danger-zone.tsx
@@ -27,7 +27,6 @@ export function PageSettingsDangerZone(props: PageSettingsDangerZoneProps) {
           modalConfirmation={{
             mode: environment?.mode,
             title: 'Delete environment',
-            description: 'To confirm the deletion of your environment, please type the name of the environment:',
             name: environment?.name,
           }}
         />

--- a/libs/pages/settings/src/lib/feature/page-organization-api-feature/page-organization-api-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-api-feature/page-organization-api-feature.tsx
@@ -39,7 +39,6 @@ export function PageOrganizationApiFeature() {
         openModalConfirmation({
           title: 'Delete API token',
           isDelete: true,
-          description: 'Are you sure you want to delete this token?',
           name: token?.name,
           action: () => {
             dispatch(

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-feature/page-organization-billing-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-feature/page-organization-billing-feature.tsx
@@ -46,7 +46,6 @@ export function PageOrganizationBillingFeature() {
   const onDeleteCreditCard = (creditCard: CreditCard) => {
     openModalConfirmation({
       title: 'Delete credit card',
-      description: 'Write the last digits of your credit card to delete it.',
       name: creditCard.last_digit,
       isDelete: true,
       placeholder: 'Enter the last digits',

--- a/libs/pages/settings/src/lib/feature/page-organization-container-registries-feature/page-organization-container-registries-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-container-registries-feature/page-organization-container-registries-feature.tsx
@@ -48,7 +48,6 @@ export function PageOrganizationContainerRegistriesFeature() {
         openModalConfirmation({
           title: 'Delete container registry',
           isDelete: true,
-          description: 'Are you sure you want to delete this container registry?',
           name: registry?.name,
           action: () => {
             dispatch(

--- a/libs/pages/settings/src/lib/feature/page-organization-roles-edit-feature/page-organization-roles-edit-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-roles-edit-feature/page-organization-roles-edit-feature.tsx
@@ -223,7 +223,6 @@ export function PageOrganizationRolesEditFeature() {
           openModalConfirmation({
             title: 'Delete custom role',
             isDelete: true,
-            description: 'Are you sure you want to delete this custom role?',
             name: customRole?.name,
             action: () => {
               dispatch(

--- a/libs/pages/settings/src/lib/feature/page-organization-webhooks-feature/page-organization-webhooks-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-webhooks-feature/page-organization-webhooks-feature.tsx
@@ -31,7 +31,6 @@ export function PageOrganizationWebhooksFeature() {
     openModalConfirmation({
       title: 'Delete webhook',
       isDelete: true,
-      description: 'To confirm the deletion of your webhook, please type the target url of the webhook:',
       name: webhook.target_url || '',
       action: () => {
         deleteWebhooks.mutate({ webhookId: webhook.id })

--- a/libs/pages/settings/src/lib/ui/page-organization-danger-zone/page-organization-danger-zone.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-danger-zone/page-organization-danger-zone.tsx
@@ -39,7 +39,6 @@ export function PageOrganizationDangerZone(props: PageOrganizationDangerZoneProp
           modalConfirmation={{
             mode: EnvironmentModeEnum.PRODUCTION,
             title: 'Delete organization',
-            description: 'To confirm the deletion of your organization, please type the name of the organization:',
             name: organization?.name,
           }}
         />

--- a/libs/pages/settings/src/lib/ui/page-organization-members/row-member/row-member.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-members/row-member/row-member.tsx
@@ -136,7 +136,6 @@ export function RowMember(props: RowMemberProps) {
                 openModalConfirmation({
                   title: 'Confirm to remove this member',
                   isDelete: true,
-                  description: 'Are you sure you want to delete this member?',
                   name: (member as Member).name,
                   action: () => deleteMember && deleteMember(member.id),
                 })
@@ -181,7 +180,6 @@ export function RowMember(props: RowMemberProps) {
                 openModalConfirmation({
                   title: 'Confirm to remove this invite',
                   isDelete: true,
-                  description: 'Are you sure you want to delete this member?',
                   name: (member as InviteMember).email,
                   action: () => deleteInviteMember && deleteInviteMember(member.id),
                 })

--- a/libs/pages/settings/src/lib/ui/page-project-danger-zone/page-project-danger-zone.tsx
+++ b/libs/pages/settings/src/lib/ui/page-project-danger-zone/page-project-danger-zone.tsx
@@ -34,7 +34,6 @@ export function PageProjectDangerZone(props: PageProjectDangerZoneProps) {
           modalConfirmation={{
             mode: EnvironmentModeEnum.PRODUCTION,
             title: 'Delete project',
-            description: 'To confirm the deletion of your project, please type the name of the organization:',
             name: project?.name,
           }}
         />

--- a/libs/shared/console-shared/src/lib/buttons-actions/ui/application-buttons-actions/application-buttons-actions.tsx
+++ b/libs/shared/console-shared/src/lib/buttons-actions/ui/application-buttons-actions/application-buttons-actions.tsx
@@ -72,7 +72,6 @@ export function ApplicationButtonsActions(props: ApplicationButtonsActionsProps)
   const removeService = (id: string, name?: string, force = false) => {
     openModalConfirmation({
       title: `Delete application`,
-      description: `To confirm the deletion of your application, please type the name of the application:`,
       name: name,
       isDelete: true,
       action: () => {

--- a/libs/shared/console-shared/src/lib/buttons-actions/ui/cluster-buttons-actions/cluster-buttons-actions.tsx
+++ b/libs/shared/console-shared/src/lib/buttons-actions/ui/cluster-buttons-actions/cluster-buttons-actions.tsx
@@ -43,7 +43,6 @@ export function ClusterButtonsActions(props: ClusterButtonsActionsProps) {
   const removeCluster = (id: string, name?: string) => {
     openModalConfirmation({
       title: `Uninstall cluster`,
-      description: `To confirm the deletion of your cluster, please type the name of the cluster:`,
       name: name,
       isDelete: true,
       action: () => dispatch(deleteClusterAction({ organizationId, clusterId: id })),

--- a/libs/shared/console-shared/src/lib/buttons-actions/ui/database-buttons-actions/database-buttons-actions.tsx
+++ b/libs/shared/console-shared/src/lib/buttons-actions/ui/database-buttons-actions/database-buttons-actions.tsx
@@ -63,7 +63,6 @@ export function DatabaseButtonsActions(props: DatabaseButtonsActionsProps) {
   const removeDatabase = (id: string, name?: string, force = false) => {
     openModalConfirmation({
       title: `Delete database`,
-      description: `To confirm the deletion of your database, please type the name of the database:`,
       name: name,
       isDelete: true,
       action: () => {

--- a/libs/shared/console-shared/src/lib/environment-buttons-actions/ui/environment-buttons-actions.tsx
+++ b/libs/shared/console-shared/src/lib/environment-buttons-actions/ui/environment-buttons-actions.tsx
@@ -198,8 +198,7 @@ export function EnvironmentButtonsActions(props: EnvironmentButtonsActionsProps)
 
   const removeEnvironment = async () => {
     openModalConfirmation({
-      title: 'Delete environment',
-      description: 'To confirm the deletion of your environment, please type the name of the environment:',
+      title: `Delete environment`,
       name: environment?.name,
       isDelete: true,
       action: () => deleteEnvironment.mutate(),

--- a/libs/shared/ui/src/lib/components/block-content-delete/block-content-delete.tsx
+++ b/libs/shared/ui/src/lib/components/block-content-delete/block-content-delete.tsx
@@ -6,7 +6,6 @@ export interface BlockContentDeleteProps {
   title: string
   modalConfirmation: {
     title: string
-    description: string
     name?: string
     mode?: string
   }
@@ -58,7 +57,6 @@ export function BlockContentDelete(props: BlockContentDeleteProps) {
               openModalConfirmation({
                 mode: modalConfirmation.mode,
                 title: modalConfirmation.title,
-                description: modalConfirmation.description,
                 name: modalConfirmation.name,
                 action: () => callback && callback(),
                 isDelete: true,

--- a/libs/shared/ui/src/lib/components/modals/modal-confirmation/__snapshots__/modal-confirmation.spec.tsx.snap
+++ b/libs/shared/ui/src/lib/components/modals/modal-confirmation/__snapshots__/modal-confirmation.spec.tsx.snap
@@ -1,0 +1,209 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalConfirmation should match confirm mode with description 1`] = `
+<div>
+  <div
+    class="p-6"
+  >
+    <h2
+      class="h4 text-text-600 mb-2 max-w-sm"
+    >
+      my title
+    </h2>
+    <div
+      class="text-text-400 text-sm mb-6"
+    >
+      my description
+      <span
+        class="link inline cursor-pointer text-accent2-500 text-sm ml-1 truncate max-w-[250px]"
+        data-state="closed"
+        data-testid="copy-cta"
+      >
+        staging
+         
+        <span
+          class="icon-solid-copy shrink-0 "
+          role="img"
+        />
+      </span>
+    </div>
+    <form>
+      <div
+        class="mb-6 "
+        data-testid="input-small-wrapper"
+      >
+        <div
+          class="input input--small flex-grow   "
+          data-testid="input"
+        >
+          <label
+            class="hidden"
+          />
+          <input
+            class="absolute text-sm top-0 left-0 h-full w-full text-text-600 placeholder:text-text-400 rounded px-2 "
+            data-testid="input-value"
+            name="name"
+            placeholder="Enter the current name"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="flex gap-3 justify-end"
+      >
+        <button
+          class="btn btn--regular btn--stroked btn--no-min-w "
+          data-testid=""
+          type="button"
+        >
+          <span>
+            Cancel
+          </span>
+        </button>
+        <button
+          class="btn btn--regular btn--basic btn--no-min-w "
+          data-testid=""
+          type="submit"
+        >
+          <span>
+            Confirm
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`ModalConfirmation should match delete mode with description 1`] = `
+<div>
+  <div
+    class="p-6"
+  >
+    <h2
+      class="h4 text-text-600 mb-2 max-w-sm"
+    >
+      my title
+    </h2>
+    <div
+      class="text-text-400 text-sm mb-6"
+    >
+      my description
+    </div>
+    <form>
+      <div
+        class="mb-6 "
+        data-testid="input-small-wrapper"
+      >
+        <div
+          class="input input--small flex-grow   "
+          data-testid="input"
+        >
+          <label
+            class="hidden"
+          />
+          <input
+            class="absolute text-sm top-0 left-0 h-full w-full text-text-600 placeholder:text-text-400 rounded px-2 "
+            data-testid="input-value"
+            name="name"
+            placeholder="Enter "delete""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="flex gap-3 justify-end"
+      >
+        <button
+          class="btn btn--regular btn--stroked btn--no-min-w "
+          data-testid=""
+          type="button"
+        >
+          <span>
+            Cancel
+          </span>
+        </button>
+        <button
+          class="btn btn--regular btn--error btn--no-min-w "
+          data-testid=""
+          type="submit"
+        >
+          <span>
+            Confirm
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`ModalConfirmation should match delete mode without description 1`] = `
+<div>
+  <div
+    class="p-6"
+  >
+    <h2
+      class="h4 text-text-600 mb-2 max-w-sm"
+    >
+      my title
+    </h2>
+    <div
+      class="text-text-400 text-sm mb-6"
+    >
+      To confirm the deletion of 
+      <strong>
+        staging
+      </strong>
+      , please type "delete"
+    </div>
+    <form>
+      <div
+        class="mb-6 "
+        data-testid="input-small-wrapper"
+      >
+        <div
+          class="input input--small flex-grow   "
+          data-testid="input"
+        >
+          <label
+            class="hidden"
+          />
+          <input
+            class="absolute text-sm top-0 left-0 h-full w-full text-text-600 placeholder:text-text-400 rounded px-2 "
+            data-testid="input-value"
+            name="name"
+            placeholder="Enter "delete""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="flex gap-3 justify-end"
+      >
+        <button
+          class="btn btn--regular btn--stroked btn--no-min-w "
+          data-testid=""
+          type="button"
+        >
+          <span>
+            Cancel
+          </span>
+        </button>
+        <button
+          class="btn btn--regular btn--error btn--no-min-w "
+          data-testid=""
+          type="submit"
+        >
+          <span>
+            Confirm
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;

--- a/libs/shared/ui/src/lib/components/modals/modal-confirmation/modal-confirmation.spec.tsx
+++ b/libs/shared/ui/src/lib/components/modals/modal-confirmation/modal-confirmation.spec.tsx
@@ -1,6 +1,5 @@
-import { render } from '__tests__/utils/setup-jest'
 import { fireEvent, screen } from '@testing-library/react'
-
+import { render } from '__tests__/utils/setup-jest'
 import ModalConfirmation, { ModalConfirmationProps } from './modal-confirmation'
 
 describe('ModalConfirmation', () => {
@@ -35,5 +34,28 @@ describe('ModalConfirmation', () => {
     fireEvent.click(copy)
 
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith('production')
+  })
+
+  it('should match delete mode without description', () => {
+    props.description = undefined
+    props.isDelete = true
+
+    const { container } = render(<ModalConfirmation {...props} />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should match delete mode with description', () => {
+    props.isDelete = true
+
+    const { container } = render(<ModalConfirmation {...props} />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should match confirm mode with description', () => {
+    const { container } = render(<ModalConfirmation {...props} />)
+
+    expect(container).toMatchSnapshot()
   })
 })

--- a/libs/shared/ui/src/lib/components/modals/modal-confirmation/modal-confirmation.stories.tsx
+++ b/libs/shared/ui/src/lib/components/modals/modal-confirmation/modal-confirmation.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react'
-import Modal from '../../modal/modal'
 import { Button } from '../../buttons/button/button'
+import Modal from '../../modal/modal'
 import { ModalConfirmation, ModalConfirmationProps } from '../modal-confirmation/modal-confirmation'
 
 export default {
@@ -16,6 +16,7 @@ const Template: Story<ModalConfirmationProps> = (args) => (
         description={args.description}
         name={args.name}
         placeholder={args.placeholder}
+        isDelete={args.isDelete}
         callback={() => {
           console.log('callback')
         }}
@@ -28,7 +29,15 @@ export const Primary = Template.bind({})
 
 Primary.args = {
   title: 'Cancel environment deployment',
-  description: 'Please confirm by enter the name of you environment:',
+  description: 'Please confirm by entering the name of your environment:',
   name: 'staging',
   placeholder: 'Enter the environment name',
+}
+
+export const Delete = Template.bind({})
+
+Delete.args = {
+  title: 'Delete environment',
+  name: 'staging',
+  isDelete: true,
 }

--- a/libs/shared/ui/src/lib/components/modals/modal-confirmation/modal-confirmation.tsx
+++ b/libs/shared/ui/src/lib/components/modals/modal-confirmation/modal-confirmation.tsx
@@ -8,13 +8,14 @@ import { Tooltip } from '../../tooltip/tooltip'
 
 export interface ModalConfirmationProps {
   title: string
-  description: string
-  name: string | undefined
+  description?: string
+  name?: string
   callback: () => void
   warning?: string
   setOpen?: (open: boolean) => void
   placeholder?: string
   ctaButton?: string
+  isDelete?: boolean
 }
 
 export function ModalConfirmation(props: ModalConfirmationProps) {
@@ -25,7 +26,8 @@ export function ModalConfirmation(props: ModalConfirmationProps) {
     callback,
     setOpen,
     warning,
-    placeholder = 'Enter the current name',
+    isDelete = false,
+    placeholder = isDelete ? 'Enter "delete"' : 'Enter the current name',
     ctaButton = 'Confirm',
   } = props
 
@@ -54,24 +56,38 @@ export function ModalConfirmation(props: ModalConfirmationProps) {
         />
       )}
       <div className="text-text-400 text-sm mb-6">
-        {description}
-        <Tooltip content="Copy">
-          <span
-            data-testid="copy-cta"
-            onClick={copyToClipboard}
-            className="link inline cursor-pointer text-accent2-500 text-sm ml-1 truncate max-w-[250px]"
-          >
-            {name} <Icon name="icon-solid-copy" />
-          </span>
-        </Tooltip>
+        {isDelete ? (
+          description ? (
+            description
+          ) : (
+            <>
+              To confirm the deletion of <strong>{name}</strong>, please type "delete"
+            </>
+          )
+        ) : (
+          <>
+            {description}
+            <Tooltip content="Copy">
+              <span
+                data-testid="copy-cta"
+                onClick={copyToClipboard}
+                className="link inline cursor-pointer text-accent2-500 text-sm ml-1 truncate max-w-[250px]"
+              >
+                {name} <Icon name="icon-solid-copy" />
+              </span>
+            </Tooltip>
+          </>
+        )}
       </div>
       <form onSubmit={onSubmit}>
         <Controller
           name="name"
           control={control}
           rules={{
-            required: 'Please enter a name.',
-            validate: (value) => value === name || 'Please enter the right name.',
+            required: isDelete ? 'Please enter "delete".' : 'Please enter a name.',
+            validate: (value) =>
+              (isDelete ? value === 'delete' : value === name) ||
+              (isDelete ? 'Please confirm by entering "delete".' : 'Please enter the right name.'),
           }}
           defaultValue=""
           render={({ field, fieldState: { error } }) => (
@@ -89,7 +105,7 @@ export function ModalConfirmation(props: ModalConfirmationProps) {
           <Button className="btn--no-min-w" style={ButtonStyle.STROKED} onClick={() => setOpen && setOpen(false)}>
             Cancel
           </Button>
-          <Button className="btn--no-min-w" type="submit">
+          <Button className="btn--no-min-w" style={isDelete ? ButtonStyle.ERROR : ButtonStyle.BASIC} type="submit">
             {ctaButton}
           </Button>
         </div>

--- a/libs/shared/ui/src/lib/components/modals/modal-confirmation/use-modal-confirmation/use-modal-confirmation.tsx
+++ b/libs/shared/ui/src/lib/components/modals/modal-confirmation/use-modal-confirmation/use-modal-confirmation.tsx
@@ -5,7 +5,7 @@ import { ModalConfirmation } from '../modal-confirmation'
 
 export interface UseModalConfirmationProps {
   title: string
-  description: string
+  description?: string
   action: () => void
   name?: string
   mode?: EnvironmentModeEnum | string | undefined
@@ -33,6 +33,7 @@ export function useModalConfirmation() {
             warning={modalConfirmation.warning}
             callback={modalConfirmation.action}
             placeholder={modalConfirmation.placeholder}
+            isDelete={modalConfirmation?.isDelete}
           />
         ),
       })


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/browse/FRT-736

Change the behavior of the confirm deletion modal.
- You must now type "delete" (instead of the name of the resource)
- The CTA button is now red when it's a deletion

![2023-07-18-180248_1837x544_scrot](https://github.com/Qovery/console/assets/1716173/cd8b1eb7-1ae0-4f34-8aa5-f44afe49475f)

**Impacts**
- Delete Storage
- Delete Custom Domains
- Delete API tokens
- Delete Custom Roles
- Delete Network
- Delete Pipeline stage
- Delete Organization Member
- Delete Organization Invite
- Delete Container registry
- Delete Webhook
- Delete Credit card
- Delete Network Port
- Delete Project
- Delete Service
- Delete Cluster
- Delete Application
- Delete Database



---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
