### PR TITLE
chore: enable nginx compression

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,37 @@ server {
   # hide for storybook
   # add_header X-Frame-Options "DENY" always;
 
+  # https://blog.containerize.com/how-to-optimize-your-website-using-gzip-compression-in-nginx/
+  gzip on;
+  gzip_disable "msie6";
+
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_http_version 1.1;
+  gzip_min_length 256;
+  gzip_types
+    application/atom+xml
+    application/geo+json
+    application/javascript
+    application/x-javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rdf+xml
+    application/rss+xml
+    application/xhtml+xml
+    application/xml
+    font/eot
+    font/otf
+    font/ttf
+    image/svg+xml
+    text/css
+    text/javascript
+    text/plain
+    text/xml;
+
   location / {
     root /usr/share/nginx/html/;
     include /etc/nginx/mime.types;


### PR DESCRIPTION
# What does this PR do?

GZIP compression wasn' t enabled.
![2023-07-21-113537_2256x725_scrot](https://github.com/Qovery/console/assets/1716173/3b0f037b-0541-4aa1-960a-da5cb20f52ae)

We need compression to optimize web app loading.

After:
![2023-07-21-120159_2256x713_scrot](https://github.com/Qovery/console/assets/1716173/5dfa03dd-b3d9-4ca4-821f-946728e9384e)
