### PR TITLE
chore(environments-queries): update environment by id query

### DIFF
--- a/libs/domains/environment/src/index.ts
+++ b/libs/domains/environment/src/index.ts
@@ -1,3 +1,3 @@
-export * from './lib/slices/environments.slice'
+export * from './lib/slices/environments.queries'
 export * from './lib/slices/environment.actions'
 export * from './lib/slices/deployment-stage'

--- a/libs/pages/application/src/lib/feature/page-settings-danger-zone-feature/page-settings-danger-zone-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-danger-zone-feature/page-settings-danger-zone-feature.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
 import { deleteApplicationAction, selectApplicationById } from '@qovery/domains/application'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { getServiceType } from '@qovery/shared/enums'
 import { ApplicationEntity } from '@qovery/shared/interfaces'
 import { SERVICES_GENERAL_URL, SERVICES_URL } from '@qovery/shared/routes'
@@ -12,8 +12,7 @@ export function PageSettingsDangerZoneFeature() {
   const { organizationId = '', projectId = '', environmentId = '', applicationId = '' } = useParams()
   const dispatch = useDispatch<AppDispatch>()
   const navigate = useNavigate()
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const application = useSelector<RootState, ApplicationEntity | undefined>((state) =>
     selectApplicationById(state, applicationId)

--- a/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.tsx
@@ -5,6 +5,7 @@ import { FieldValues, FormProvider, useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { editApplication, getApplicationsState, postApplicationActionsRedeploy } from '@qovery/domains/application'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { defaultLivenessProbe, defaultReadinessProbe, probeFormatted } from '@qovery/shared/console-shared'
 import { ProbeTypeEnum, getServiceType, isJob } from '@qovery/shared/enums'
 import { ApplicationEntity, HealthcheckData, LoadingStatus } from '@qovery/shared/interfaces'
@@ -36,6 +37,8 @@ export function PageSettingsHealthchecksFeature() {
   const { organizationId = '', projectId = '', environmentId = '', applicationId = '' } = useParams()
 
   const dispatch = useDispatch<AppDispatch>()
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
+
   const application = useSelector<RootState, ApplicationEntity | undefined>(
     (state) => getApplicationsState(state).entities[applicationId],
     equal
@@ -150,6 +153,7 @@ export function PageSettingsHealthchecksFeature() {
         defaultTypeLiveness={defaultTypeLiveness as ProbeTypeEnum}
         onSubmit={onSubmit}
         loading={loading}
+        environmentMode={environment?.mode}
       />
     </FormProvider>
   )

--- a/libs/pages/application/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.tsx
@@ -3,7 +3,7 @@ import { FieldValues, FormProvider, useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { editApplication, postApplicationActionsRedeploy, selectApplicationById } from '@qovery/domains/application'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { getServiceType, isJob } from '@qovery/shared/enums'
 import { ApplicationEntity } from '@qovery/shared/interfaces'
 import { AppDispatch, RootState } from '@qovery/store'
@@ -38,8 +38,7 @@ export function PageSettingsResourcesFeature() {
       JSON.stringify(a?.instances) === JSON.stringify(b?.instances)
   )
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const methods = useForm({
     mode: 'onChange',
@@ -95,6 +94,7 @@ export function PageSettingsResourcesFeature() {
         application={application}
         displayWarningCpu={displayWarningCpu}
         clusterId={environment?.cluster_id}
+        environmentMode={environment?.mode}
       />
     </FormProvider>
   )

--- a/libs/pages/application/src/lib/page-application.tsx
+++ b/libs/pages/application/src/lib/page-application.tsx
@@ -10,7 +10,7 @@ import {
   fetchApplicationStatus,
   selectApplicationById,
 } from '@qovery/domains/application'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { getServiceType, isApplication, isGitJob } from '@qovery/shared/enums'
 import { ApplicationEntity, LoadingStatus } from '@qovery/shared/interfaces'
 import { APPLICATION_GENERAL_URL, APPLICATION_URL } from '@qovery/shared/routes'
@@ -21,8 +21,7 @@ import Container from './ui/container/container'
 
 export function PageApplication() {
   const { applicationId = '', environmentId = '', organizationId = '', projectId = '' } = useParams()
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const application = useSelector<RootState, ApplicationEntity | undefined>(
     (state) => selectApplicationById(state, applicationId),

--- a/libs/pages/application/src/lib/ui/page-settings-healthchecks/page-settings-healthchecks.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-healthchecks/page-settings-healthchecks.tsx
@@ -1,7 +1,5 @@
 import { EnvironmentModeEnum, ServicePort } from 'qovery-typescript-axios'
 import { useFormContext } from 'react-hook-form'
-import { useParams } from 'react-router-dom'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
 import { ApplicationSettingsHealthchecks } from '@qovery/shared/console-shared'
 import { ProbeTypeEnum } from '@qovery/shared/enums'
 import { LoadingStatus } from '@qovery/shared/interfaces'
@@ -17,6 +15,7 @@ export interface PageSettingsHealthchecksProps {
   ports?: ServicePort[]
   onSubmit?: () => void
   maxRunningInstances?: number
+  environmentMode?: EnvironmentModeEnum
 }
 
 export function PageSettingsHealthchecks({
@@ -29,16 +28,14 @@ export function PageSettingsHealthchecks({
   defaultTypeReadiness,
   defaultTypeLiveness,
   maxRunningInstances,
+  environmentMode,
 }: PageSettingsHealthchecksProps) {
   const { formState } = useFormContext()
-  const { projectId = '', environmentId = '' } = useParams()
-  const { data: environments = [] } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId ?? '', environments)
 
   return (
     <div className="flex flex-col justify-between w-full text-ssm">
       <div className="p-8 max-w-content-with-navigation-left">
-        {environment?.mode === EnvironmentModeEnum.PRODUCTION && maxRunningInstances === 1 && (
+        {environmentMode === EnvironmentModeEnum.PRODUCTION && maxRunningInstances === 1 && (
           <BannerBox
             className="mb-2"
             message={

--- a/libs/pages/application/src/lib/ui/page-settings-resources/page-settings-resources.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-resources/page-settings-resources.tsx
@@ -1,3 +1,4 @@
+import { EnvironmentModeEnum } from 'qovery-typescript-axios'
 import { FormEventHandler } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ApplicationSettingsResources } from '@qovery/shared/console-shared'
@@ -8,12 +9,13 @@ export interface PageSettingsResourcesProps {
   onSubmit: FormEventHandler<HTMLFormElement>
   displayWarningCpu: boolean
   application?: ApplicationEntity
+  environmentMode?: EnvironmentModeEnum
   loading?: boolean
   clusterId?: string
 }
 
 export function PageSettingsResources(props: PageSettingsResourcesProps) {
-  const { onSubmit, loading, application, clusterId, displayWarningCpu } = props
+  const { onSubmit, loading, application, clusterId, displayWarningCpu, environmentMode } = props
   const { formState } = useFormContext()
 
   if (!application) return null
@@ -30,6 +32,7 @@ export function PageSettingsResources(props: PageSettingsResourcesProps) {
             displayWarningCpu={displayWarningCpu}
             application={application}
             clusterId={clusterId}
+            environmentMode={environmentMode}
           />
           <div className="flex justify-end">
             <Button

--- a/libs/pages/database/src/lib/feature/page-settings-danger-zone-feature/page-settings-danger-zone-feature.tsx
+++ b/libs/pages/database/src/lib/feature/page-settings-danger-zone-feature/page-settings-danger-zone-feature.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
 import { deleteDatabaseAction, selectDatabaseById } from '@qovery/domains/database'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { DatabaseEntity } from '@qovery/shared/interfaces'
 import { SERVICES_GENERAL_URL, SERVICES_URL } from '@qovery/shared/routes'
 import { AppDispatch, RootState } from '@qovery/store'
@@ -11,8 +11,7 @@ export function PageSettingsDangerZoneFeature() {
   const { organizationId = '', projectId = '', environmentId = '', databaseId = '' } = useParams()
   const dispatch = useDispatch<AppDispatch>()
   const navigate = useNavigate()
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
   const database = useSelector<RootState, DatabaseEntity | undefined>((state) => selectDatabaseById(state, databaseId))
 
   const deleteApplication = () => {

--- a/libs/pages/database/src/lib/feature/page-settings-general-feature/page-settings-general-feature.tsx
+++ b/libs/pages/database/src/lib/feature/page-settings-general-feature/page-settings-general-feature.tsx
@@ -5,7 +5,7 @@ import { FieldValues, FormProvider, useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { editDatabase, postDatabaseActionsRedeploy, selectDatabaseById } from '@qovery/domains/database'
-import { getEnvironmentById, useFetchDatabaseConfiguration, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchDatabaseConfiguration, useFetchEnvironment } from '@qovery/domains/environment'
 import { selectClusterById } from '@qovery/domains/organization'
 import { ClusterEntity, DatabaseEntity } from '@qovery/shared/interfaces'
 import { AppDispatch, RootState } from '@qovery/store'
@@ -29,8 +29,8 @@ export function PageSettingsGeneralFeature() {
     (state) => selectDatabaseById(state, databaseId),
     equal
   )
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
+
   const cluster = useSelector<RootState, ClusterEntity | undefined>((state: RootState) =>
     selectClusterById(state, environment?.cluster_id || '')
   )

--- a/libs/pages/database/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.tsx
+++ b/libs/pages/database/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.tsx
@@ -3,7 +3,7 @@ import { FieldValues, FormProvider, useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { editDatabase, postDatabaseActionsRedeploy, selectDatabaseById } from '@qovery/domains/database'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { DatabaseEntity } from '@qovery/shared/interfaces'
 import { AppDispatch, RootState } from '@qovery/store'
 import PageSettingsResources from '../../ui/page-settings-resources/page-settings-resources'
@@ -26,8 +26,7 @@ export function PageSettingsResourcesFeature() {
   const dispatch = useDispatch<AppDispatch>()
 
   const database = useSelector<RootState, DatabaseEntity | undefined>((state) => selectDatabaseById(state, databaseId))
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const methods = useForm({
     mode: 'onChange',

--- a/libs/pages/database/src/lib/page-database.tsx
+++ b/libs/pages/database/src/lib/page-database.tsx
@@ -10,7 +10,7 @@ import {
   fetchDatabasesStatus,
   selectDatabaseById,
 } from '@qovery/domains/database'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { DatabaseEntity, LoadingStatus } from '@qovery/shared/interfaces'
 import { useDocumentTitle } from '@qovery/shared/utils'
 import { AppDispatch, RootState } from '@qovery/store'
@@ -19,8 +19,7 @@ import Container from './ui/container/container'
 
 export function PageDatabase() {
   const { databaseId = '', environmentId = '', projectId = '' } = useParams()
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const database = useSelector<RootState, DatabaseEntity | undefined>(
     (state) => selectDatabaseById(state, databaseId),

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -6,7 +6,7 @@ import { Route, Routes, useLocation, useParams } from 'react-router-dom'
 import useWebSocket from 'react-use-websocket'
 import { fetchApplicationsStatus, selectApplicationsEntitiesByEnvId } from '@qovery/domains/application'
 import { fetchDatabasesStatus, selectDatabasesEntitiesByEnvId } from '@qovery/domains/database'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { useAuth } from '@qovery/shared/auth'
 import { ApplicationEntity, DatabaseEntity, LoadingStatus } from '@qovery/shared/interfaces'
 import { DEPLOYMENT_LOGS_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
@@ -22,10 +22,8 @@ export function PageEnvironmentLogs() {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
 
   const dispatch = useDispatch<AppDispatch>()
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
-  const { data: environments } = useFetchEnvironments(projectId)
-
-  const environment = getEnvironmentById(environmentId, environments)
   const location = useLocation()
 
   useDocumentTitle(`Environment logs ${environment ? `- ${environment?.name}` : '- Loading...'}`)

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/step-resources-feature/step-resources-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/step-resources-feature/step-resources-feature.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { selectClusterById } from '@qovery/domains/organization'
 import { ApplicationResourcesData, ClusterEntity } from '@qovery/shared/interfaces'
 import {
@@ -25,8 +25,7 @@ export function StepResourcesFeature() {
   const navigate = useNavigate()
   const [maxInstances, setMaxInstance] = useState(50)
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const cluster = useSelector<RootState, ClusterEntity | undefined>((state) =>
     selectClusterById(state, environment?.cluster_id || '')
@@ -93,7 +92,12 @@ export function StepResourcesFeature() {
   return (
     <FunnelFlowBody helpSection={funnelCardHelp}>
       <FormProvider {...methods}>
-        <StepResources maximumInstances={maxInstances} onBack={onBack} onSubmit={onSubmit} />
+        <StepResources
+          maximumInstances={maxInstances}
+          onBack={onBack}
+          onSubmit={onSubmit}
+          environmentMode={environment?.mode}
+        />
       </FormProvider>
     </FunnelFlowBody>
   )

--- a/libs/pages/services/src/lib/feature/page-database-create-feature/step-general-feature/step-general-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-database-create-feature/step-general-feature/step-general-feature.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
-import { getEnvironmentById, useFetchDatabaseConfiguration, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchDatabaseConfiguration, useFetchEnvironment } from '@qovery/domains/environment'
 import { selectClusterById } from '@qovery/domains/organization'
 import { ClusterEntity, Value } from '@qovery/shared/interfaces'
 import {
@@ -77,8 +77,7 @@ export function StepGeneralFeature() {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
   const navigate = useNavigate()
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const cluster = useSelector<RootState, ClusterEntity | undefined>((state: RootState) =>
     selectClusterById(state, environment?.cluster_id || '')

--- a/libs/pages/services/src/lib/feature/page-deployments-feature/page-deployments-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-deployments-feature/page-deployments-feature.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
-import { getEnvironmentById, useEnvironmentDeploymentHistory, useFetchEnvironments } from '@qovery/domains/environment'
+import { useEnvironmentDeploymentHistory, useFetchEnvironment } from '@qovery/domains/environment'
 import { deploymentMock } from '@qovery/shared/factories'
 import { DeploymentService } from '@qovery/shared/interfaces'
 import { BaseLink } from '@qovery/shared/ui'
@@ -10,8 +10,7 @@ import PageDeployments from '../../ui/page-deployments/page-deployments'
 export function PageDeploymentsFeature() {
   const { projectId = '', environmentId = '' } = useParams()
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
   const {
     refetch,
     isLoading: loadingStatusDeployments,

--- a/libs/pages/services/src/lib/feature/page-general-feature/page-general-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-general-feature/page-general-feature.tsx
@@ -7,7 +7,7 @@ import {
   selectApplicationsEntitiesByEnvId,
 } from '@qovery/domains/application'
 import { fetchDatabasesStatus, getDatabasesState, selectDatabasesEntitiesByEnvId } from '@qovery/domains/database'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { applicationFactoryMock } from '@qovery/shared/factories'
 import { ApplicationEntity, DatabaseEntity, LoadingStatus } from '@qovery/shared/interfaces'
 import { BaseLink } from '@qovery/shared/ui'
@@ -28,8 +28,7 @@ export function PageGeneralFeature() {
     selectDatabasesEntitiesByEnvId(state, environmentId)
   )
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const applicationsLoadingStatus = useSelector<RootState, LoadingStatus>(
     (state) => getApplicationsState(state).loadingStatus

--- a/libs/pages/services/src/lib/feature/page-job-create-feature/step-resources-feature/step-resources-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-job-create-feature/step-resources-feature/step-resources-feature.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useNavigate, useParams } from 'react-router-dom'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { ServiceTypeEnum } from '@qovery/shared/enums'
 import { ApplicationResourcesData } from '@qovery/shared/interfaces'
 import {
@@ -19,6 +20,7 @@ export function StepResourcesFeature() {
   const { setCurrentStep, resourcesData, setResourcesData, generalData, jobURL, jobType } =
     useJobContainerCreateContext()
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -73,7 +75,7 @@ export function StepResourcesFeature() {
   return (
     <FunnelFlowBody helpSection={funnelCardHelp}>
       <FormProvider {...methods}>
-        <StepResources onBack={onBack} onSubmit={onSubmit} />
+        <StepResources onBack={onBack} onSubmit={onSubmit} environmentMode={environment?.mode} />
       </FormProvider>
     </FunnelFlowBody>
   )

--- a/libs/pages/services/src/lib/feature/page-settings-danger-zone-feature/page-settings-danger-zone-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-settings-danger-zone-feature/page-settings-danger-zone-feature.tsx
@@ -1,11 +1,6 @@
 import { StateEnum } from 'qovery-typescript-axios'
 import { useNavigate, useParams } from 'react-router-dom'
-import {
-  getEnvironmentById,
-  getEnvironmentStatusById,
-  useDeleteEnvironment,
-  useFetchEnvironments,
-} from '@qovery/domains/environment'
+import { getEnvironmentStatusById, useDeleteEnvironment, useFetchEnvironment } from '@qovery/domains/environment'
 import { ENVIRONMENTS_GENERAL_URL, ENVIRONMENTS_URL } from '@qovery/shared/routes'
 import PageSettingsDangerZone from '../../ui/page-settings-danger-zone/page-settings-danger-zone'
 
@@ -13,8 +8,7 @@ export function PageSettingsDangerZoneFeature() {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
   const navigate = useNavigate()
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
   const status = getEnvironmentStatusById(environmentId)
   const deleteEnvironment = useDeleteEnvironment(
     projectId,

--- a/libs/pages/services/src/lib/feature/page-settings-deployment-pipeline-feature/page-settings-deployment-pipeline-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-settings-deployment-pipeline-feature/page-settings-deployment-pipeline-feature.tsx
@@ -6,11 +6,10 @@ import { useParams } from 'react-router-dom'
 import { selectApplicationsEntitiesByEnvId } from '@qovery/domains/application'
 import { selectDatabasesEntitiesByEnvId } from '@qovery/domains/database'
 import {
-  getEnvironmentById,
   useAddServiceToDeploymentStage,
   useDeleteEnvironmentDeploymentStage,
   useFetchDeploymentStageList,
-  useFetchEnvironments,
+  useFetchEnvironment,
 } from '@qovery/domains/environment'
 import { Icon, IconAwesomeEnum, useModal, useModalConfirmation } from '@qovery/shared/ui'
 import { RootState } from '@qovery/store'
@@ -26,8 +25,7 @@ export interface StageRequest {
 export function PageSettingsDeploymentPipelineFeature() {
   const { projectId = '', environmentId = '' } = useParams()
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const applications = useSelector(
     (state: RootState) => selectApplicationsEntitiesByEnvId(state, environmentId),

--- a/libs/pages/services/src/lib/feature/page-settings-general-feature/page-settings-general-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-settings-general-feature/page-settings-general-feature.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
-import { getEnvironmentById, useEditEnvironment, useFetchEnvironments } from '@qovery/domains/environment'
+import { useEditEnvironment, useFetchEnvironment } from '@qovery/domains/environment'
 import { fetchClusters, selectClustersEntitiesByOrganizationId } from '@qovery/domains/organization'
 import { useDocumentTitle } from '@qovery/shared/utils'
 import { AppDispatch, RootState } from '@qovery/store'
@@ -21,8 +21,7 @@ export function PageSettingsGeneralFeature() {
     selectClustersEntitiesByOrganizationId(state, organizationId)
   )
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
   const editEnvironment = useEditEnvironment(projectId, () => setLoading(false))
 
   const [loading, setLoading] = useState(false)

--- a/libs/pages/services/src/lib/page-services.tsx
+++ b/libs/pages/services/src/lib/page-services.tsx
@@ -2,10 +2,9 @@ import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom'
 import {
-  getEnvironmentById,
   getEnvironmentStatusById,
   useEnvironmentRunningStatus,
-  useFetchEnvironments,
+  useFetchEnvironment,
   useFetchEnvironmentsStatus,
 } from '@qovery/domains/environment'
 import { APPLICATION_GENERAL_URL, SERVICES_GENERAL_URL, SERVICES_URL } from '@qovery/shared/routes'
@@ -20,8 +19,7 @@ export function PageServices() {
   const location = useLocation()
   const navigate = useNavigate()
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
   const environmentsStatus = useFetchEnvironmentsStatus(projectId)
   const environmentRunningStatus = useEnvironmentRunningStatus(environmentId)
 

--- a/libs/pages/services/src/lib/ui/page-application-create/step-resources/step-resources.tsx
+++ b/libs/pages/services/src/lib/ui/page-application-create/step-resources/step-resources.tsx
@@ -1,3 +1,4 @@
+import { EnvironmentModeEnum } from 'qovery-typescript-axios'
 import { FormEventHandler } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ApplicationSettingsResources } from '@qovery/shared/console-shared'
@@ -8,9 +9,10 @@ export interface StepResourcesProps {
   onBack: () => void
   onSubmit: FormEventHandler<HTMLFormElement>
   maximumInstances?: number
+  environmentMode?: EnvironmentModeEnum
 }
 
-export function StepResources({ maximumInstances, onSubmit, onBack }: StepResourcesProps) {
+export function StepResources({ maximumInstances, onSubmit, onBack, environmentMode }: StepResourcesProps) {
   const { formState } = useFormContext<ApplicationResourcesData>()
 
   return (
@@ -20,7 +22,11 @@ export function StepResources({ maximumInstances, onSubmit, onBack }: StepResour
       </div>
 
       <form onSubmit={onSubmit}>
-        <ApplicationSettingsResources maxInstances={maximumInstances} displayWarningCpu={false} />
+        <ApplicationSettingsResources
+          maxInstances={maximumInstances}
+          displayWarningCpu={false}
+          environmentMode={environmentMode}
+        />
 
         <div className="flex justify-between">
           <Button

--- a/libs/pages/services/src/lib/ui/page-job-create/step-resources/step-resources.tsx
+++ b/libs/pages/services/src/lib/ui/page-job-create/step-resources/step-resources.tsx
@@ -1,3 +1,4 @@
+import { EnvironmentModeEnum } from 'qovery-typescript-axios'
 import { FormEventHandler } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ApplicationSettingsResources } from '@qovery/shared/console-shared'
@@ -7,9 +8,10 @@ import { Button, ButtonSize, ButtonStyle } from '@qovery/shared/ui'
 export interface StepResourcesProps {
   onBack: () => void
   onSubmit: FormEventHandler<HTMLFormElement>
+  environmentMode?: EnvironmentModeEnum
 }
 
-export function StepResources({ onBack, onSubmit }: StepResourcesProps) {
+export function StepResources({ onBack, environmentMode, onSubmit }: StepResourcesProps) {
   const { formState } = useFormContext<ApplicationResourcesData>()
 
   return (
@@ -20,7 +22,7 @@ export function StepResources({ onBack, onSubmit }: StepResourcesProps) {
       </div>
 
       <form onSubmit={onSubmit}>
-        <ApplicationSettingsResources displayWarningCpu={false} />
+        <ApplicationSettingsResources displayWarningCpu={false} environmentMode={environmentMode} />
 
         <div className="flex justify-between">
           <Button

--- a/libs/shared/console-shared/src/lib/application-settings/ui/application-settings-resources/application-settings-resources.tsx
+++ b/libs/shared/console-shared/src/lib/application-settings/ui/application-settings-resources/application-settings-resources.tsx
@@ -1,7 +1,6 @@
 import { EnvironmentModeEnum } from 'qovery-typescript-axios'
 import { Controller, useFormContext } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
 import { isJob } from '@qovery/shared/enums'
 import { ApplicationEntity } from '@qovery/shared/interfaces'
 import { CLUSTER_SETTINGS_RESOURCES_URL, CLUSTER_SETTINGS_URL, CLUSTER_URL } from '@qovery/shared/routes'
@@ -13,14 +12,13 @@ export interface ApplicationSettingsResourcesProps {
   minInstances?: number
   maxInstances?: number
   clusterId?: string
+  environmentMode?: EnvironmentModeEnum
 }
 
 export function ApplicationSettingsResources(props: ApplicationSettingsResourcesProps) {
-  const { displayWarningCpu, application, minInstances = 1, maxInstances = 50, clusterId = '' } = props
+  const { displayWarningCpu, application, minInstances = 1, maxInstances = 50, clusterId = '', environmentMode } = props
   const { control, watch } = useFormContext()
-  const { organizationId = '', projectId = '', environmentId = '' } = useParams()
-  const { data: environments = [] } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId ?? '', environments)
+  const { organizationId = '' } = useParams()
 
   let maxMemoryBySize = application?.maximum_memory
 
@@ -128,21 +126,19 @@ export function ApplicationSettingsResources(props: ApplicationSettingsResources
             Application auto-scaling is based on real-time CPU consumption. When your app goes above 60% (default) of
             CPU consumption for 5 minutes, your app will be auto-scaled and more instances will be added.
           </p>
-          {environment?.mode === EnvironmentModeEnum.PRODUCTION &&
-            watchInstances[0] === 1 &&
-            watchInstances[1] === 1 && (
-              <BannerBox
-                className="mt-3"
-                message={
-                  <span>
-                    We strongly discourage running your production environment with only one instance. This setup might
-                    create service downtime in case of cluster upgrades. Set a minimum of 2 instances for your service
-                    to ensure high availability.
-                  </span>
-                }
-                type={BannerBoxEnum.WARNING}
-              />
-            )}
+          {environmentMode === EnvironmentModeEnum.PRODUCTION && watchInstances[0] === 1 && watchInstances[1] === 1 && (
+            <BannerBox
+              className="mt-3"
+              message={
+                <span>
+                  We strongly discourage running your production environment with only one instance. This setup might
+                  create service downtime in case of cluster upgrades. Set a minimum of 2 instances for your service to
+                  ensure high availability.
+                </span>
+              }
+              type={BannerBoxEnum.WARNING}
+            />
+          )}
         </BlockContent>
       )}
     </div>

--- a/libs/shared/console-shared/src/lib/database-settings-resources/feature/settings-resources-instance-types-feature/setting-resources-instance-types-feature.tsx
+++ b/libs/shared/console-shared/src/lib/database-settings-resources/feature/settings-resources-instance-types-feature/setting-resources-instance-types-feature.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { useFetchDatabaseInstanceTypes } from '@qovery/domains/database'
-import { getEnvironmentById, useFetchEnvironments } from '@qovery/domains/environment'
+import { useFetchEnvironment } from '@qovery/domains/environment'
 import { selectClusterById } from '@qovery/domains/organization'
 import { ClusterEntity } from '@qovery/shared/interfaces'
 import { RootState } from '@qovery/store'
@@ -20,8 +20,7 @@ export function SettingsResourcesInstanceTypesFeature({
 }: SettingsResourcesInstanceTypesFeatureProps) {
   const { projectId = '', environmentId = '' } = useParams()
 
-  const { data: environments } = useFetchEnvironments(projectId, true)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
   const cluster = useSelector<RootState, ClusterEntity | undefined>((state: RootState) =>
     selectClusterById(state, environment?.cluster_id || '')
   )

--- a/libs/shared/console-shared/src/lib/update-all-modal/feature/update-all-modal-feature.tsx
+++ b/libs/shared/console-shared/src/lib/update-all-modal/feature/update-all-modal-feature.tsx
@@ -7,7 +7,7 @@ import {
   fetchApplications,
   selectApplicationsEntitiesByEnvId,
 } from '@qovery/domains/application'
-import { getEnvironmentById, useActionDeployAllEnvironment, useFetchEnvironments } from '@qovery/domains/environment'
+import { useActionDeployAllEnvironment, useFetchEnvironment } from '@qovery/domains/environment'
 import { getServiceType, isApplication, isGitJob, isJob } from '@qovery/shared/enums'
 import { ApplicationEntity, LoadingStatus } from '@qovery/shared/interfaces'
 import { useModal } from '@qovery/shared/ui'
@@ -22,8 +22,7 @@ export interface UpdateAllModalFeatureProps {
 export function UpdateAllModalFeature(props: UpdateAllModalFeatureProps) {
   const { environmentId, projectId } = props
 
-  const { data: environments } = useFetchEnvironments(projectId)
-  const environment = getEnvironmentById(environmentId, environments)
+  const { data: environment } = useFetchEnvironment(projectId, environmentId)
 
   const { closeModal } = useModal()
   const dispatch: AppDispatch = useDispatch()


### PR DESCRIPTION
# What does this PR do?

- Update environmentById query with select 
- Rename file environments.slice.ts => environment.queries.ts
- Fix Healtchecks query on UI file for environment mode
- Need to do for environmentStatusById
- I didn't separate the fetch `environmentsApi.listEnvironment` with an external function (like getEnvironments), don't know if it's really necessary on our case because we use an external package and not a simple fetch or other

```
export const useFetchEnvironments = <TData = Environment[]>(
  projectId: string,
  select?: (data: Environment[]) => TData
) => {
  const queryClient = useQueryClient()

  return useQuery(
    ['project', projectId, 'environments'],
    async () => {
      const response = await environmentsApi.listEnvironment(projectId)
      return response.data.results as Environment[]
    },
    {
      onSuccess: () => {
        // refetch environmentsStatus requests
        queryClient.invalidateQueries(['environmentsStatus', projectId])
      },
      onError: (err) => toastError(err as Error),
      enabled: projectId !== '',
      select,
    }
  )
}

export const useFetchEnvironment = (projectId: string, environmentId: string) =>
  useFetchEnvironments(projectId, (environments) =>
    environments.find((environment) => environment.id === environmentId)
  )
```

---

## PR Checklist

- [x] This PR introduces breaking change(s) and has been labeled as such
- [x] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
