### PR TITLE
fix(page-settings-healthchecks): update to avoid not available save btn 

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.spec.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.spec.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render } from '__tests__/utils/setup-jest'
+import userEvent from '@testing-library/user-event'
+import { act, fireEvent, render, screen } from '__tests__/utils/setup-jest'
 import { Healthcheck } from 'qovery-typescript-axios'
 import * as storeApplication from '@qovery/domains/application'
 import { applicationFactoryMock } from '@qovery/shared/factories'
@@ -80,20 +81,17 @@ describe('PageSettingsHealthchecksFeature', () => {
         }),
     }))
 
-    const { getByTestId, getByText } = render(<PageSettingsHealthchecksFeature />)
+    render(<PageSettingsHealthchecksFeature />)
 
     await act(() => {
-      const input = getByTestId('input-readiness-probe-service')
+      const input = screen.getByTestId('input-readiness-probe-service')
       fireEvent.input(input, { target: { value: 'my-service' } })
     })
 
-    const btnSave = getByText('Save')
-
+    const btnSave = screen.getByRole('button', { name: /save/i })
     expect(btnSave).not.toBeDisabled()
 
-    await act(() => {
-      btnSave.click()
-    })
+    await userEvent.click(btnSave)
 
     expect(editApplicationSpy.mock.calls[0][0].applicationId).toBe(mockApplication.id)
     expect(editApplicationSpy.mock.calls[0][0].data)

--- a/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.spec.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.spec.tsx
@@ -80,17 +80,19 @@ describe('PageSettingsHealthchecksFeature', () => {
         }),
     }))
 
-    const { getByTestId } = render(<PageSettingsHealthchecksFeature />)
+    const { getByTestId, getByText } = render(<PageSettingsHealthchecksFeature />)
 
     await act(() => {
       const input = getByTestId('input-readiness-probe-service')
       fireEvent.input(input, { target: { value: 'my-service' } })
     })
 
-    expect(getByTestId('submit-button')).not.toBeDisabled()
+    const btnSave = getByText('Save')
+
+    expect(btnSave).not.toBeDisabled()
 
     await act(() => {
-      getByTestId('submit-button').click()
+      btnSave.click()
     })
 
     expect(editApplicationSpy.mock.calls[0][0].applicationId).toBe(mockApplication.id)

--- a/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.tsx
@@ -8,7 +8,7 @@ import { editApplication, getApplicationsState, postApplicationActionsRedeploy }
 import { useFetchEnvironment } from '@qovery/domains/environment'
 import { defaultLivenessProbe, defaultReadinessProbe, probeFormatted } from '@qovery/shared/console-shared'
 import { ProbeTypeEnum, getServiceType, isJob } from '@qovery/shared/enums'
-import { ApplicationEntity, HealthcheckData, LoadingStatus } from '@qovery/shared/interfaces'
+import { ApplicationEntity, HealthcheckData } from '@qovery/shared/interfaces'
 import { APPLICATION_SETTINGS_RESOURCES_URL, APPLICATION_SETTINGS_URL, APPLICATION_URL } from '@qovery/shared/routes'
 import { AppDispatch, RootState } from '@qovery/store'
 import PageSettingsHealthchecks from '../../ui/page-settings-healthchecks/page-settings-healthchecks'
@@ -52,7 +52,7 @@ export function PageSettingsHealthchecksFeature() {
     }
   }
 
-  const [loading, setLoading] = useState<LoadingStatus>('not loaded')
+  const [loading, setLoading] = useState<boolean>(false)
 
   const methods = useForm({
     mode: 'onChange',
@@ -78,7 +78,7 @@ export function PageSettingsHealthchecksFeature() {
 
   const onSubmit = methods.handleSubmit((data) => {
     if (application) {
-      setLoading('loading')
+      setLoading(true)
       const cloneApplication = handleSubmit(data, application)
 
       dispatch(
@@ -91,7 +91,7 @@ export function PageSettingsHealthchecksFeature() {
       )
         .unwrap()
         .catch((error) => console.error(error))
-        .finally(() => setLoading('loaded'))
+        .finally(() => setLoading(false))
     }
   })
 
@@ -149,8 +149,6 @@ export function PageSettingsHealthchecksFeature() {
           environmentId,
           applicationId
         )}${APPLICATION_SETTINGS_URL}${APPLICATION_SETTINGS_RESOURCES_URL}`}
-        defaultTypeReadiness={defaultTypeReadiness as ProbeTypeEnum}
-        defaultTypeLiveness={defaultTypeLiveness as ProbeTypeEnum}
         onSubmit={onSubmit}
         loading={loading}
         environmentMode={environment?.mode}

--- a/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.tsx
@@ -52,7 +52,7 @@ export function PageSettingsHealthchecksFeature() {
     }
   }
 
-  const [loading, setLoading] = useState<boolean>(false)
+  const [loading, setLoading] = useState(false)
 
   const methods = useForm({
     mode: 'onChange',

--- a/libs/pages/application/src/lib/ui/page-settings-healthchecks/page-settings-healthchecks.spec.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-healthchecks/page-settings-healthchecks.spec.tsx
@@ -1,7 +1,6 @@
 import { render } from '__tests__/utils/setup-jest'
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
 import { defaultLivenessProbe, defaultReadinessProbe } from '@qovery/shared/console-shared'
-import { ProbeTypeEnum } from '@qovery/shared/enums'
 import PageSettingsHealthchecks from './page-settings-healthchecks'
 
 describe('PageSettingsHealthchecks', () => {
@@ -10,11 +9,9 @@ describe('PageSettingsHealthchecks', () => {
       wrapWithReactHookForm(
         <PageSettingsHealthchecks
           onSubmit={jest.fn()}
-          defaultTypeLiveness={ProbeTypeEnum.TCP}
-          defaultTypeReadiness={ProbeTypeEnum.HTTP}
           linkResourcesSetting="/"
           isJob={false}
-          loading={'loaded'}
+          loading={false}
           ports={[]}
         />,
         {

--- a/libs/pages/application/src/lib/ui/page-settings-healthchecks/page-settings-healthchecks.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-healthchecks/page-settings-healthchecks.tsx
@@ -1,14 +1,10 @@
 import { EnvironmentModeEnum, ServicePort } from 'qovery-typescript-axios'
 import { useFormContext } from 'react-hook-form'
 import { ApplicationSettingsHealthchecks } from '@qovery/shared/console-shared'
-import { ProbeTypeEnum } from '@qovery/shared/enums'
-import { LoadingStatus } from '@qovery/shared/interfaces'
-import { BannerBox, BannerBoxEnum, HelpSection, Link, StickyActionFormToaster } from '@qovery/shared/ui'
+import { BannerBox, BannerBoxEnum, Button, ButtonSize, ButtonStyle, HelpSection, Link } from '@qovery/shared/ui'
 
 export interface PageSettingsHealthchecksProps {
-  loading: LoadingStatus
-  defaultTypeReadiness: ProbeTypeEnum
-  defaultTypeLiveness: ProbeTypeEnum
+  loading: boolean
   linkResourcesSetting: string
   isJob: boolean
   jobPort?: number | null
@@ -25,8 +21,6 @@ export function PageSettingsHealthchecks({
   isJob,
   jobPort,
   linkResourcesSetting,
-  defaultTypeReadiness,
-  defaultTypeLiveness,
   minRunningInstances,
   environmentMode,
 }: PageSettingsHealthchecksProps) {
@@ -67,16 +61,20 @@ export function PageSettingsHealthchecks({
             <ApplicationSettingsHealthchecks
               isJob={isJob}
               jobPort={jobPort}
-              defaultTypeReadiness={defaultTypeReadiness}
-              defaultTypeLiveness={defaultTypeLiveness}
               ports={ports?.map((port) => port.internal_port)}
             />
-            <StickyActionFormToaster
-              visible={formState.isDirty}
-              onSubmit={onSubmit}
-              disabledValidation={!formState.isValid}
-              loading={loading === 'loading'}
-            />
+            <div className="flex justify-end">
+              <Button
+                className="mb-6 btn--no-min-w"
+                disabled={!formState.isValid}
+                size={ButtonSize.LARGE}
+                style={ButtonStyle.BASIC}
+                loading={loading}
+                type="submit"
+              >
+                Save
+              </Button>
+            </div>
           </div>
         </form>
       </div>

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.spec.tsx
@@ -27,17 +27,22 @@ describe('PageApplicationCreateHealthchecksFeature', () => {
                   port: 3000,
                 },
               },
+              initial_delay_seconds: 1,
+              period_seconds: 1,
+              timeout_seconds: 1,
+              failure_threshold: 1,
+              success_threshold: 1,
             },
             readiness_probe: {
               type: {
                 none: null,
               },
+              initial_delay_seconds: 1,
+              period_seconds: 1,
+              timeout_seconds: 1,
+              failure_threshold: 1,
+              success_threshold: 1,
             },
-            initial_delay_seconds: 1,
-            period_seconds: 1,
-            timeout_seconds: 1,
-            failure_threshold: 1,
-            success_threshold: 1,
           },
         },
         ports: [
@@ -61,7 +66,7 @@ describe('PageApplicationCreateHealthchecksFeature', () => {
   })
 
   it('should submit the data to the context', async () => {
-    const { baseElement } = render(
+    const { debug, baseElement } = render(
       <ApplicationContainerCreateContext.Provider value={context}>
         <StepHealthchecksFeature />
       </ApplicationContainerCreateContext.Provider>
@@ -69,6 +74,8 @@ describe('PageApplicationCreateHealthchecksFeature', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     await act(() => {})
+
+    debug(baseElement, 100000)
 
     const button = getByTestId(baseElement, 'button-submit')
     expect(button).not.toBeDisabled()

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.spec.tsx
@@ -66,7 +66,7 @@ describe('PageApplicationCreateHealthchecksFeature', () => {
   })
 
   it('should submit the data to the context', async () => {
-    const { debug, baseElement } = render(
+    const { baseElement } = render(
       <ApplicationContainerCreateContext.Provider value={context}>
         <StepHealthchecksFeature />
       </ApplicationContainerCreateContext.Provider>
@@ -74,8 +74,6 @@ describe('PageApplicationCreateHealthchecksFeature', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     await act(() => {})
-
-    debug(baseElement, 100000)
 
     const button = getByTestId(baseElement, 'button-submit')
     expect(button).not.toBeDisabled()

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.tsx
@@ -62,9 +62,9 @@ export function StepHealthchecksFeature() {
     defaultValues: {
       readiness_probe: {
         ...{
-          current_type: ProbeTypeEnum.TCP,
+          current_type: portData?.healthchecks?.typeReadiness || ProbeTypeEnum.TCP,
           type: {
-            [ProbeTypeEnum.TCP.toLowerCase()]: {
+            [portData?.healthchecks?.typeReadiness || ProbeTypeEnum.TCP.toLowerCase()]: {
               port: portData?.ports && portData?.ports.length > 0 ? portData?.ports[0].application_port : 0,
             },
           },
@@ -73,9 +73,9 @@ export function StepHealthchecksFeature() {
       },
       liveness_probe: {
         ...{
-          current_type: ProbeTypeEnum.TCP,
+          current_type: portData?.healthchecks?.typeLiveness || ProbeTypeEnum.TCP,
           type: {
-            [ProbeTypeEnum.TCP.toLowerCase()]: {
+            [portData?.healthchecks?.typeLiveness || ProbeTypeEnum.TCP]: {
               port: portData?.ports && portData?.ports.length > 0 ? portData?.ports[0].application_port : 0,
             },
           },

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/step-healthchecks-feature/step-healthchecks-feature.tsx
@@ -126,13 +126,7 @@ export function StepHealthchecksFeature() {
   return (
     <FunnelFlowBody helpSection={funnelCardHelp}>
       <FormProvider {...methods}>
-        <StepHealthchecks
-          ports={portData?.ports}
-          onBack={onBack}
-          onSubmit={onSubmit}
-          defaultTypeReadiness={(portData?.healthchecks?.typeReadiness as ProbeTypeEnum) || ProbeTypeEnum.TCP}
-          defaultTypeLiveness={(portData?.healthchecks?.typeLiveness as ProbeTypeEnum) || ProbeTypeEnum.TCP}
-        />
+        <StepHealthchecks ports={portData?.ports} onBack={onBack} onSubmit={onSubmit} />
       </FormProvider>
     </FunnelFlowBody>
   )

--- a/libs/pages/services/src/lib/ui/page-application-create/step-healthchecks/step-healthchecks.tsx
+++ b/libs/pages/services/src/lib/ui/page-application-create/step-healthchecks/step-healthchecks.tsx
@@ -1,25 +1,16 @@
 import { FormEventHandler } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ApplicationSettingsHealthchecks } from '@qovery/shared/console-shared'
-import { ProbeTypeEnum } from '@qovery/shared/enums'
 import { PortData } from '@qovery/shared/interfaces'
 import { Button, ButtonSize, ButtonStyle } from '@qovery/shared/ui'
 
 export interface StepHealthchecksProps {
   onBack: () => void
   onSubmit: FormEventHandler<HTMLFormElement>
-  defaultTypeReadiness: ProbeTypeEnum
-  defaultTypeLiveness: ProbeTypeEnum
   ports?: PortData[]
 }
 
-export function StepHealthchecks({
-  ports,
-  onSubmit,
-  onBack,
-  defaultTypeReadiness,
-  defaultTypeLiveness,
-}: StepHealthchecksProps) {
+export function StepHealthchecks({ ports, onSubmit, onBack }: StepHealthchecksProps) {
   const { formState } = useFormContext()
 
   return (
@@ -36,11 +27,7 @@ export function StepHealthchecks({
       </div>
 
       <form onSubmit={onSubmit}>
-        <ApplicationSettingsHealthchecks
-          defaultTypeReadiness={defaultTypeReadiness}
-          defaultTypeLiveness={defaultTypeLiveness}
-          ports={ports?.map((port: PortData) => port.application_port || 0)}
-        />
+        <ApplicationSettingsHealthchecks ports={ports?.map((port: PortData) => port.application_port || 0)} />
 
         <div className="flex justify-between mt-10">
           <Button

--- a/libs/shared/console-shared/src/lib/application-settings/ui/application-settings-healthchecks/application-settings-healthchecks.tsx
+++ b/libs/shared/console-shared/src/lib/application-settings/ui/application-settings-healthchecks/application-settings-healthchecks.tsx
@@ -35,8 +35,8 @@ export interface ApplicationSettingsHealthchecksProps {
 export function ApplicationSettingsHealthchecks({ ports, jobPort, isJob }: ApplicationSettingsHealthchecksProps) {
   const { control, watch } = useFormContext()
 
-  const typeReadiness = watch('readiness_probe.current_type')
-  const typeLiveness = watch('liveness_probe.current_type')
+  const typeReadiness = watch('readiness_probe.current_type') || ProbeTypeEnum.NONE
+  const typeLiveness = watch('liveness_probe.current_type') || ProbeTypeEnum.NONE
 
   const tableHead: TableEditionRow[] = [
     {

--- a/libs/shared/console-shared/src/lib/application-settings/ui/application-settings-healthchecks/application-settings-healthchecks.tsx
+++ b/libs/shared/console-shared/src/lib/application-settings/ui/application-settings-healthchecks/application-settings-healthchecks.tsx
@@ -180,9 +180,7 @@ export function ApplicationSettingsHealthchecks({ ports, jobPort, isJob }: Appli
                     dataTestId="input-liveness-probe-port"
                     name={field.name}
                     defaultValue={field.value || ''}
-                    onChange={(value) => {
-                      field.onChange(value)
-                    }}
+                    onChange={field.onChange}
                     items={
                       ports
                         ? ports.map((value) => ({
@@ -222,9 +220,7 @@ export function ApplicationSettingsHealthchecks({ ports, jobPort, isJob }: Appli
                     dataTestId="input-readiness-probe-port"
                     name={field.name}
                     defaultValue={field.value || ''}
-                    onChange={(value) => {
-                      field.onChange(value)
-                    }}
+                    onChange={field.onChange}
                     items={
                       ports
                         ? ports.map((value) => ({

--- a/libs/shared/console-shared/src/lib/application-settings/ui/application-settings-healthchecks/application-settings-healthchecks.tsx
+++ b/libs/shared/console-shared/src/lib/application-settings/ui/application-settings-healthchecks/application-settings-healthchecks.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { ProbeTypeEnum } from '@qovery/shared/enums'
 import {
@@ -31,29 +30,13 @@ export interface ApplicationSettingsHealthchecksProps {
   ports?: number[]
   isJob?: boolean
   jobPort?: number | null
-  defaultTypeReadiness: ProbeTypeEnum
-  defaultTypeLiveness: ProbeTypeEnum
 }
 
-export function ApplicationSettingsHealthchecks({
-  ports,
-  jobPort,
-  defaultTypeReadiness,
-  defaultTypeLiveness,
-  isJob,
-}: ApplicationSettingsHealthchecksProps) {
-  const { control, trigger } = useFormContext()
+export function ApplicationSettingsHealthchecks({ ports, jobPort, isJob }: ApplicationSettingsHealthchecksProps) {
+  const { control, watch } = useFormContext()
 
-  const [typeReadiness, setTypeReadiness] = useState<ProbeTypeEnum>(defaultTypeReadiness)
-  const [typeLiveness, setTypeLiveness] = useState<ProbeTypeEnum>(defaultTypeLiveness)
-
-  useEffect(() => {
-    setTypeReadiness(defaultTypeReadiness)
-  }, [defaultTypeReadiness])
-
-  useEffect(() => {
-    setTypeLiveness(defaultTypeLiveness)
-  }, [defaultTypeLiveness])
+  const typeReadiness = watch('readiness_probe.current_type')
+  const typeLiveness = watch('liveness_probe.current_type')
 
   const tableHead: TableEditionRow[] = [
     {
@@ -120,11 +103,7 @@ export function ApplicationSettingsHealthchecks({
                   dataTestId="input-liveness-probe-current-type"
                   name={field.name}
                   defaultValue={field.value || ''}
-                  onChange={(value) => {
-                    field.onChange(value)
-                    setTypeLiveness(value as ProbeTypeEnum)
-                    trigger().then()
-                  }}
+                  onChange={field.onChange}
                   items={Object.values(ProbeTypeEnum).map((value) => ({
                     label: value,
                     value: value,
@@ -147,11 +126,7 @@ export function ApplicationSettingsHealthchecks({
                   dataTestId="input-readiness-probe-current-type"
                   name={field.name}
                   defaultValue={field.value || ''}
-                  onChange={(value) => {
-                    field.onChange(value)
-                    setTypeReadiness(value as ProbeTypeEnum)
-                    trigger().then()
-                  }}
+                  onChange={field.onChange}
                   items={Object.values(ProbeTypeEnum).map((value) => ({
                     label: value,
                     value: value,
@@ -207,7 +182,6 @@ export function ApplicationSettingsHealthchecks({
                     defaultValue={field.value || ''}
                     onChange={(value) => {
                       field.onChange(value)
-                      trigger().then()
                     }}
                     items={
                       ports
@@ -250,7 +224,6 @@ export function ApplicationSettingsHealthchecks({
                     defaultValue={field.value || ''}
                     onChange={(value) => {
                       field.onChange(value)
-                      trigger().then()
                     }}
                     items={
                       ports

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-tooltip": "^1.0.4",
     "@reduxjs/toolkit": "1.9.3",
     "@szhsin/react-menu": "^3.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "ansi-to-react": "^6.1.6",
     "autoprefixer": "10.4.13",
     "axios": "^0.27.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5341,6 +5341,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/user-event@npm:^14.4.3":
+  version: 14.4.3
+  resolution: "@testing-library/user-event@npm:14.4.3"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 852c48ea6db1c9471b18276617c84fec4320771e466cd58339a732ca3fd73ad35e5a43ae14f51af51a8d0a150dcf60fcaab049ef367871207bea8f92c4b8195e
+  languageName: node
+  linkType: hard
+
 "@tootallnate/once@npm:2":
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
@@ -17278,6 +17287,7 @@ __metadata:
     "@szhsin/react-menu": ^3.0.0
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": 14.0.0
+    "@testing-library/user-event": ^14.4.3
     "@trivago/prettier-plugin-sort-imports": ^3.3.0
     "@types/chance": ^1.1.3
     "@types/jest": 29.4.4


### PR DESCRIPTION
# What does this PR do?

[> Link to the JIRA ticket
](https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-737)

- Fix Healthchecks page settings with real save button
- Clean, remove useless type state for Liveness and Readiness (we use the state of react-hook-form)

![Capture d’écran 2023-07-25 à 17 34 28 (1)](https://github.com/Qovery/console/assets/533928/ec6bf1e9-02ab-47ef-a365-5124dee7cd3b)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
