### PR TITLE
refactor: remove useless polyfills

### DIFF
--- a/apps/console/project.json
+++ b/apps/console/project.json
@@ -14,7 +14,6 @@
         "index": "apps/console/src/index.html",
         "baseHref": "/",
         "main": "apps/console/src/main.tsx",
-        "polyfills": "apps/console/src/polyfills.ts",
         "tsConfig": "apps/console/tsconfig.app.json",
         "assets": [
           "apps/console/src/favicon.ico",

--- a/apps/console/src/polyfills.ts
+++ b/apps/console/src/polyfills.ts
@@ -1,7 +1,0 @@
-/**
- * Polyfill stable language features. These imports will be optimized by `@babel/preset-env`.
- *
- * See: https://github.com/zloirock/core-js#babel
- */
-import 'core-js/stable'
-import 'regenerator-runtime/runtime'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "ansi-to-react": "^6.1.6",
     "autoprefixer": "10.4.13",
     "axios": "^0.27.2",
-    "core-js": "^3.6.5",
     "cronstrue": "^2.21.0",
     "date-fns": "^2.29.3",
     "date-fns-tz": "^1.3.7",
@@ -53,7 +52,6 @@
     "react-syntax-highlighter": "^15.5.0",
     "react-use-intercom": "^1.5.2",
     "react-use-websocket": "^4.2.0",
-    "regenerator-runtime": "0.13.7",
     "styled-components": "^5.3.8",
     "tailwindcss": "3.2.7",
     "tslib": "^2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8831,7 +8831,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.25.4, core-js@npm:^3.29.0, core-js@npm:^3.6.5":
+"core-js@npm:^3.25.4, core-js@npm:^3.29.0":
   version: 3.31.0
   resolution: "core-js@npm:3.31.0"
   checksum: f7cf9b3010f7ca99c026d95b61743baca1a85512742ed2b67e8f65a72ac4f4fe0b90b00057783e886bdd39d3a295f42f845d33e7cba3973ed263df978343ab79
@@ -17298,7 +17298,6 @@ __metadata:
     babel-jest: 29.4.3
     babel-loader: ^8.1.0
     chance: ^1.1.8
-    core-js: ^3.6.5
     cronstrue: ^2.21.0
     css-loader: ^6.4.0
     cypress: ^9.1.0
@@ -17346,7 +17345,6 @@ __metadata:
     react-syntax-highlighter: ^15.5.0
     react-use-intercom: ^1.5.2
     react-use-websocket: ^4.2.0
-    regenerator-runtime: 0.13.7
     semantic-release: ^19.0.5
     storybook-tailwind-dark-mode: ^1.0.22
     style-loader: ^3.3.0
@@ -18171,13 +18169,6 @@ __metadata:
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
   checksum: 3317a09b2f802da8db09aa276e469b57a6c0dd818347e05b8862959c6193408242f150db5de83c12c3fa99091ad95fb42a6db2c3329bfaa12a0ea4cbbeb30cb0
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:0.13.7":
-  version: 0.13.7
-  resolution: "regenerator-runtime@npm:0.13.7"
-  checksum: 52b66e6669152c0b1bccd95c8e11aabbfe67bb97bdf00e223bdf723b0f0052d4da5c02001d4c4bef576bdc5bcdc38a20496d1b5363b65c950c8434ed5071d9e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://qovery.atlassian.net/browse/FRT-755

Manually include regenerator-runtime and core-js as polyfill isn't necessary anymore.
This is not part of a freshly generated nx workspace (eg. `npx create-nx-workspace@latest --preset=react-monorepo --bundler=webpack`) and this is done by babel plugins

```
ctjhoa@SKYNET ~/qovery/console (git)-[staging] % rg polyfill
yarn.lock
41:    abortcontroller-polyfill: ^1.7.3
46:    promise-polyfill: ^8.2.3
225:"@babel/helper-define-polyfill-provider@npm:^0.3.3":
227:  resolution: "@babel/helper-define-polyfill-provider@npm:0.3.3"
1300:    babel-plugin-polyfill-corejs2: ^0.3.3
1301:    babel-plugin-polyfill-corejs3: ^0.6.0
1302:    babel-plugin-polyfill-regenerator: ^0.4.1
1477:    babel-plugin-polyfill-corejs2: ^0.3.3
1478:    babel-plugin-polyfill-corejs3: ^0.6.0
1479:    babel-plugin-polyfill-regenerator: ^0.4.1
2532:    headers-polyfill: ^3.1.0
6672:"abortcontroller-polyfill@npm:^1.7.3":
6674:  resolution: "abortcontroller-polyfill@npm:1.7.5"
7538:"babel-plugin-polyfill-corejs2@npm:^0.3.3":
7540:  resolution: "babel-plugin-polyfill-corejs2@npm:0.3.3"
7543:    "@babel/helper-define-polyfill-provider": ^0.3.3
7551:"babel-plugin-polyfill-corejs3@npm:^0.6.0":
7553:  resolution: "babel-plugin-polyfill-corejs3@npm:0.6.0"
7555:    "@babel/helper-define-polyfill-provider": ^0.3.3
7563:"babel-plugin-polyfill-regenerator@npm:^0.4.1":
7565:  resolution: "babel-plugin-polyfill-regenerator@npm:0.4.1"
7567:    "@babel/helper-define-polyfill-provider": ^0.3.3
11941:"headers-polyfill@npm:^3.1.0":
11943:  resolution: "headers-polyfill@npm:3.1.2"
15132:    headers-polyfill: ^3.1.0
17136:"promise-polyfill@npm:^8.2.3":
17138:  resolution: "promise-polyfill@npm:8.3.0"
```