### PR TITLE
chore: fix jest.requireActual

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.spec.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.spec.tsx
@@ -22,7 +22,7 @@ jest.mock('./init-form-values/init-form-values', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ applicationId: mockApplication.id }),
 }))
 

--- a/libs/pages/application/src/lib/feature/page-settings-domains-feature/page-settings-domains-feature.spec.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-domains-feature/page-settings-domains-feature.spec.tsx
@@ -26,7 +26,7 @@ jest.mock('@qovery/shared/ui', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ applicationId: '1' }),
 }))
 

--- a/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.spec.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-healthchecks-feature/page-settings-healthchecks-feature.spec.tsx
@@ -37,7 +37,7 @@ const healthchecks: Healthcheck = {
 }
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ applicationId: mockApplication.id }),
 }))
 

--- a/libs/pages/application/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.spec.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.spec.tsx
@@ -31,7 +31,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ applicationId: '0' }),
 }))
 

--- a/libs/pages/application/src/lib/page-application.spec.tsx
+++ b/libs/pages/application/src/lib/page-application.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageApplication from './page-application'
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3', applicationId: '4' }),
 }))
 

--- a/libs/pages/application/src/lib/ui/about/about-git/about-git.spec.tsx
+++ b/libs/pages/application/src/lib/ui/about/about-git/about-git.spec.tsx
@@ -29,7 +29,7 @@ const props: AboutGitProps = {
 }
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ applicationId: mockApplication.id }),
 }))
 

--- a/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.spec.tsx
@@ -23,7 +23,7 @@ jest.mock('./init-form-values/init-form-values', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', clusterId: mockCluster.id }),
 }))
 

--- a/libs/pages/cluster/src/lib/feature/page-settings-credentials-feature/page-settings-credentials-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-credentials-feature/page-settings-credentials-feature.spec.tsx
@@ -44,7 +44,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0', clusterId: mockCluster.id }),
 }))
 

--- a/libs/pages/cluster/src/lib/feature/page-settings-feature/page-settings-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-feature/page-settings-feature.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '__tests__/utils/setup-jest'
-import { Route, Routes } from 'react-router'
+import { Route, Routes } from 'react-router-dom'
 import PageSettingsFeature from './page-settings-feature'
 
 describe('PageSettingsFeature', () => {

--- a/libs/pages/cluster/src/lib/feature/page-settings-features-feature/page-settings-features-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-features-feature/page-settings-features-feature.spec.tsx
@@ -14,7 +14,7 @@ jest.mock('@qovery/domains/organization', () => {
 })
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ clusterId: mockCluster.id }),
 }))
 

--- a/libs/pages/cluster/src/lib/feature/page-settings-general-feature/page-settings-general-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-general-feature/page-settings-general-feature.spec.tsx
@@ -31,7 +31,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0', clusterId: mockCluster.id }),
 }))
 

--- a/libs/pages/cluster/src/lib/feature/page-settings-remote-feature/page-settings-remote-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-remote-feature/page-settings-remote-feature.spec.tsx
@@ -32,7 +32,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0', clusterId: mockCluster.id }),
 }))
 

--- a/libs/pages/cluster/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.spec.tsx
@@ -72,7 +72,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0', clusterId: mockCluster.id }),
 }))
 

--- a/libs/pages/cluster/src/lib/page-cluster.spec.tsx
+++ b/libs/pages/cluster/src/lib/page-cluster.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageCluster from './page-cluster'
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', clusterId: '2' }),
 }))
 

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/page-clusters-create-feature.spec.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/page-clusters-create-feature.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageClustersCreateFeature from './page-clusters-create-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
 }))
 

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/page-clusters-create-feature.spec.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/page-clusters-create-feature.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageClustersCreateFeature from './page-clusters-create-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router') as any),
+  ...(jest.requireActual('react-router-dom') as any),
   useParams: () => ({ organizationId: '1' }),
 }))
 

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-features-feature/step-features-feature.spec.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-features-feature/step-features-feature.spec.tsx
@@ -19,7 +19,7 @@ const mockFeatures = [
 ]
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
   useNavigate: () => mockNavigate,
 }))

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-general-feature/step-general-feature.spec.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-general-feature/step-general-feature.spec.tsx
@@ -11,7 +11,7 @@ const mockNavigate = jest.fn()
 const mockOrganization: OrganizationEntity = organizationFactoryMock(1)[0]
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
   useNavigate: () => mockNavigate,
 }))

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-remote-feature/step-remote-feature.spec.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-remote-feature/step-remote-feature.spec.tsx
@@ -8,7 +8,7 @@ const mockSetRemoteData = jest.fn()
 const mockNavigate = jest.fn()
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
   useNavigate: () => mockNavigate,
 }))

--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-summary-feature/step-summary-feature.spec.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/step-summary-feature/step-summary-feature.spec.tsx
@@ -16,7 +16,7 @@ jest.mock('react-redux', () => ({
 
 const mockNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
   useNavigate: () => mockNavigate,
 }))

--- a/libs/pages/clusters/src/lib/page-clusters.spec.tsx
+++ b/libs/pages/clusters/src/lib/page-clusters.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageClusters from './page-clusters'
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
   Link: () => <div />,
 }))

--- a/libs/pages/database/src/lib/feature/page-settings-general-feature/page-settings-general-feature.spec.tsx
+++ b/libs/pages/database/src/lib/feature/page-settings-general-feature/page-settings-general-feature.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ databaseId: '0' }),
 }))
 

--- a/libs/pages/database/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.spec.tsx
+++ b/libs/pages/database/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.spec.tsx
@@ -42,7 +42,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ databaseId: '0' }),
 }))
 

--- a/libs/pages/events/src/lib/feature/page-general-feature/page-general-feature.spec.tsx
+++ b/libs/pages/events/src/lib/feature/page-general-feature/page-general-feature.spec.tsx
@@ -7,7 +7,7 @@ import { eventsFactoryMock } from '@qovery/shared/factories'
 import PageGeneralFeature from './page-general-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0' }),
 }))
 

--- a/libs/pages/events/src/lib/page-events.spec.tsx
+++ b/libs/pages/events/src/lib/page-events.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageEvents from './page-events'
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', clusterId: '2' }),
 }))
 

--- a/libs/pages/layout/src/lib/feature/menu-account-feature/menu-account-feature.spec.tsx
+++ b/libs/pages/layout/src/lib/feature/menu-account-feature/menu-account-feature.spec.tsx
@@ -9,12 +9,12 @@ const mockUser = userSignUpFactoryMock()
 const mockOrganization: OrganizationEntity = mockOrganizations[0]
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
 }))
 
 jest.mock('react-redux', () => ({
-  ...(jest.requireActual('react-redux') as any),
+  ...jest.requireActual('react-redux'),
   selectOrganizationById: () => mockOrganization,
   selectAllOrganization: () => mockOrganizations,
   selectUserSignUp: () => mockUser,

--- a/libs/pages/layout/src/lib/ui/menu-account/menu-account.spec.tsx
+++ b/libs/pages/layout/src/lib/ui/menu-account/menu-account.spec.tsx
@@ -11,7 +11,7 @@ const mockOrganizations: OrganizationEntity[] = organizationFactoryMock(2)
 const mockUser: SignUp = userSignUpFactoryMock()
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
 }))
 

--- a/libs/pages/login/src/lib/feature/page-login/page-login.spec.tsx
+++ b/libs/pages/login/src/lib/feature/page-login/page-login.spec.tsx
@@ -2,7 +2,7 @@ import { render } from '__tests__/utils/setup-jest'
 import PageLoginFeature from './page-login'
 
 jest.mock('@elgorditosalsero/react-gtm-hook', () => ({
-  ...(jest.requireActual('@elgorditosalsero/react-gtm-hook') as any),
+  ...jest.requireActual('@elgorditosalsero/react-gtm-hook'),
   useGTMDispatch: jest.fn(),
 }))
 

--- a/libs/pages/login/src/lib/feature/page-redirect-login/page-redirect-login.spec.tsx
+++ b/libs/pages/login/src/lib/feature/page-redirect-login/page-redirect-login.spec.tsx
@@ -2,7 +2,7 @@ import { render } from '__tests__/utils/setup-jest'
 import PageRedirectLogin from './page-redirect-login'
 
 jest.mock('@elgorditosalsero/react-gtm-hook', () => ({
-  ...(jest.requireActual('@elgorditosalsero/react-gtm-hook') as any),
+  ...jest.requireActual('@elgorditosalsero/react-gtm-hook'),
   useGTMDispatch: jest.fn(),
 }))
 

--- a/libs/pages/login/src/lib/hooks/use-redirect-if-logged/use-redirect-if-logged.spec.tsx
+++ b/libs/pages/login/src/lib/hooks/use-redirect-if-logged/use-redirect-if-logged.spec.tsx
@@ -12,12 +12,12 @@ jest.mock('./utils/utils')
 
 const mockedUsedNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUsedNavigate,
 }))
 
 jest.mock('@elgorditosalsero/react-gtm-hook', () => ({
-  ...(jest.requireActual('@elgorditosalsero/react-gtm-hook') as any),
+  ...jest.requireActual('@elgorditosalsero/react-gtm-hook'),
   useGTMDispatch: jest.fn(),
 }))
 

--- a/libs/pages/login/src/lib/page-login.spec.tsx
+++ b/libs/pages/login/src/lib/page-login.spec.tsx
@@ -2,7 +2,7 @@ import { render } from '__tests__/utils/setup-jest'
 import PageLogin from './page-login'
 
 jest.mock('@elgorditosalsero/react-gtm-hook', () => ({
-  ...(jest.requireActual('@elgorditosalsero/react-gtm-hook') as any),
+  ...jest.requireActual('@elgorditosalsero/react-gtm-hook'),
   useGTMDispatch: jest.fn(),
 }))
 

--- a/libs/pages/logs/environment/src/lib/feature/pod-logs-feature/pod-logs-feature.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/pod-logs-feature/pod-logs-feature.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PodLogsFeature, { PodLogsFeatureProps } from './pod-logs-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3', serviceId: '4' }),
 }))
 

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/page-application-create-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/page-application-create-feature.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageApplicationCreateFeature from './page-application-create-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3' }),
 }))
 

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/page-application-create-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/page-application-create-feature.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageApplicationCreateFeature from './page-application-create-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router') as any),
+  ...(jest.requireActual('react-router-dom') as any),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3' }),
 }))
 

--- a/libs/pages/services/src/lib/feature/page-database-create-feature/page-database-create-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-database-create-feature/page-database-create-feature.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageDatabaseCreateFeature from './page-database-create-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3' }),
 }))
 

--- a/libs/pages/services/src/lib/feature/page-database-create-feature/step-general-feature/step-general-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-database-create-feature/step-general-feature/step-general-feature.spec.tsx
@@ -9,7 +9,7 @@ const mockSetGeneralData = jest.fn()
 const mockNavigate = jest.fn()
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3' }),
   useNavigate: () => mockNavigate,
 }))

--- a/libs/pages/services/src/lib/feature/page-database-create-feature/step-resources-feature/step-resources-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-database-create-feature/step-resources-feature/step-resources-feature.spec.tsx
@@ -27,7 +27,7 @@ jest.mock('@qovery/domains/database', () => ({
 
 const mockNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3' }),
   useNavigate: () => mockNavigate,
 }))

--- a/libs/pages/services/src/lib/feature/page-database-create-feature/step-summary-feature/step-summary-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-database-create-feature/step-summary-feature/step-summary-feature.spec.tsx
@@ -16,7 +16,7 @@ jest.mock('react-redux', () => ({
 
 const mockNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3' }),
   useNavigate: () => mockNavigate,
 }))

--- a/libs/pages/services/src/lib/feature/page-job-create-feature/page-job-create-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-job-create-feature/page-job-create-feature.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageJobCreateFeature from './page-job-create-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3' }),
 }))
 

--- a/libs/pages/services/src/lib/feature/page-job-create-feature/page-job-create-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-job-create-feature/page-job-create-feature.spec.tsx
@@ -1,9 +1,9 @@
 import { render } from '__tests__/utils/setup-jest'
-import { Route, Routes } from 'react-router'
+import { Route, Routes } from 'react-router-dom'
 import PageJobCreateFeature from './page-job-create-feature'
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router') as any),
+  ...(jest.requireActual('react-router-dom') as any),
   useParams: () => ({ organizationId: '1', projectId: '2', environmentId: '3' }),
 }))
 

--- a/libs/pages/services/src/lib/feature/page-settings-deployment-rules-feature/page-settings-deployment-rules-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-settings-deployment-rules-feature/page-settings-deployment-rules-feature.spec.tsx
@@ -19,7 +19,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ environmentId: '1' }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-feature/billing-details-feature/billing-details-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-feature/billing-details-feature/billing-details-feature.spec.tsx
@@ -9,7 +9,7 @@ import BillingDetailsFeature from './billing-details-feature'
 import SpyInstance = jest.SpyInstance
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/invoices-list-feature/invoices-list-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/invoices-list-feature/invoices-list-feature.spec.tsx
@@ -8,7 +8,7 @@ import InvoicesListFeature, { getListOfYears } from './invoices-list-feature'
 import SpyInstance = jest.SpyInstance
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/page-organization-billing-summary-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/page-organization-billing-summary-feature.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-organization-container-registries-feature/crud-modal-feature/crud-modal-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-container-registries-feature/crud-modal-feature/crud-modal-feature.spec.tsx
@@ -42,7 +42,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: mockOrganization.id }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-organization-general-feature/page-organization-general-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-general-feature/page-organization-general-feature.spec.tsx
@@ -29,7 +29,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0' }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-organization-github-repository-access-feature/page-organization-github-repository-access-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-github-repository-access-feature/page-organization-github-repository-access-feature.spec.tsx
@@ -50,7 +50,7 @@ jest.mock('@qovery/domains/organization', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
   Link: () => <div />,
 }))

--- a/libs/pages/settings/src/lib/feature/page-organization-members-feature/page-organization-members-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-members-feature/page-organization-members-feature.spec.tsx
@@ -31,7 +31,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0' }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-organization-roles-edit-feature/page-organization-roles-edit-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-roles-edit-feature/page-organization-roles-edit-feature.spec.tsx
@@ -40,7 +40,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0' }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-organization-webhooks-feature/page-organization-webhooks-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-webhooks-feature/page-organization-webhooks-feature.spec.tsx
@@ -12,7 +12,7 @@ const useEditWebhooksMockSpy = jest.spyOn(organizationDomain, 'useEditWebhook') 
 const mockWebhooks = webhookFactoryMock(3)
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '1' }),
 }))
 

--- a/libs/pages/settings/src/lib/feature/page-project-general-feature/page-project-general-feature.spec.tsx
+++ b/libs/pages/settings/src/lib/feature/page-project-general-feature/page-project-general-feature.spec.tsx
@@ -28,7 +28,7 @@ jest.mock('react-redux', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ organizationId: '0', projectId: '0' }),
 }))
 

--- a/libs/pages/settings/src/lib/page-settings.spec.tsx
+++ b/libs/pages/settings/src/lib/page-settings.spec.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import PageSettings from './page-settings'
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router'),
+  ...jest.requireActual('react-router-dom'),
   Link: 'Link',
   useParams: () => ({ organizationId: '1' }),
 }))

--- a/libs/pages/settings/src/lib/ui/page-organization-roles-edit/page-organization-roles-edit.spec.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles-edit/page-organization-roles-edit.spec.tsx
@@ -11,7 +11,7 @@ import PageOrganizationRolesEdit, { PageOrganizationRolesEditProps } from './pag
 
 const mockedUsedNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUsedNavigate,
 }))
 

--- a/libs/pages/settings/src/lib/ui/page-organization-roles/page-organization-roles.spec.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles/page-organization-roles.spec.tsx
@@ -4,7 +4,7 @@ import PageOrganizationRoles, { PageOrganizationRolesProps, isDefaultRole, roles
 
 const mockedUsedNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUsedNavigate,
 }))
 

--- a/libs/shared/auth/src/lib/use-invite-member/use-invite-member.spec.tsx
+++ b/libs/shared/auth/src/lib/use-invite-member/use-invite-member.spec.tsx
@@ -8,7 +8,7 @@ import { useInviteMember } from './use-invite-member'
 // mock useNavigate
 const mockedUseNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUseNavigate,
   useLocation: jest.fn(),
 }))

--- a/libs/shared/console-shared/src/lib/create-clone-environment-modal/feature/create-clone-environment-modal-feature.spec.tsx
+++ b/libs/shared/console-shared/src/lib/create-clone-environment-modal/feature/create-clone-environment-modal-feature.spec.tsx
@@ -20,7 +20,7 @@ jest.mock('@qovery/domains/organization', () => ({
 }))
 
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useParams: () => ({ projectId: '1', organizationId: '0' }),
 }))
 

--- a/libs/shared/console-shared/src/lib/create-project-modal/feature/create-project-modal-feature.spec.tsx
+++ b/libs/shared/console-shared/src/lib/create-project-modal/feature/create-project-modal-feature.spec.tsx
@@ -6,7 +6,7 @@ import SpyInstance = jest.SpyInstance
 
 const mockedUsedNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUsedNavigate,
 }))
 

--- a/libs/shared/console-shared/src/lib/deploy-other-commit-modal/feature/deploy-other-commit-modal-feature.spec.tsx
+++ b/libs/shared/console-shared/src/lib/deploy-other-commit-modal/feature/deploy-other-commit-modal-feature.spec.tsx
@@ -16,7 +16,7 @@ import DeployOtherCommitModalFeature, { DeployOtherCommitModalFeatureProps } fro
 import SpyInstance = jest.SpyInstance
 
 jest.mock('react-redux', () => ({
-  ...(jest.requireActual('react-redux') as any),
+  ...jest.requireActual('react-redux'),
   useDispatch: () =>
     jest.fn().mockImplementation(() =>
       Promise.resolve({
@@ -31,7 +31,7 @@ jest.mock('react-redux', () => ({
 const mockApplication = applicationFactoryMock(1)[0]
 
 jest.mock('@qovery/domains/application', () => ({
-  ...(jest.requireActual('@qovery/domains/application') as any),
+  ...jest.requireActual('@qovery/domains/application'),
   fetchApplicationCommits: () => jest.fn(),
   getCommitsGroupedByDate: () => ({
     '2021-09-01': [

--- a/libs/shared/console-shared/src/lib/deploy-other-tag-modal/feature/deploy-other-tag-modal-feature.spec.tsx
+++ b/libs/shared/console-shared/src/lib/deploy-other-tag-modal/feature/deploy-other-tag-modal-feature.spec.tsx
@@ -8,7 +8,7 @@ import DeployOtherTagModalFeature, { DeployOtherTagModalFeatureProps } from './d
 import SpyInstance = jest.SpyInstance
 
 jest.mock('react-redux', () => ({
-  ...(jest.requireActual('react-redux') as any),
+  ...jest.requireActual('react-redux'),
   useDispatch: () =>
     jest.fn().mockImplementation(() =>
       Promise.resolve({
@@ -22,7 +22,7 @@ jest.mock('react-redux', () => ({
 
 const mockApplication = applicationFactoryMock(1)[0]
 jest.mock('@qovery/domains/application', () => ({
-  ...(jest.requireActual('@qovery/domains/application') as any),
+  ...jest.requireActual('@qovery/domains/application'),
   selectApplicationById: () => mockApplication,
   postApplicationActionsDeployByTag: jest.fn(),
 }))

--- a/libs/shared/console-shared/src/lib/github-application-callback/github-application-callback-feature/github-application-callback-feature.spec.tsx
+++ b/libs/shared/console-shared/src/lib/github-application-callback/github-application-callback-feature/github-application-callback-feature.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('@qovery/domains/organization', () => ({
 
 const mockedUseNavigate = jest.fn()
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUseNavigate,
   useLocation: jest.fn(),
 }))


### PR DESCRIPTION
# What does this PR do?

- remove `as any`
- replace `react-router` usage by `react-router-dom`