### PR TITLE
fix(services): allow object for advanced settings

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.ts
+++ b/libs/pages/application/src/lib/feature/page-settings-advanced-feature/init-form-values/init-form-values.ts
@@ -13,12 +13,15 @@ export function initFormValues(
     if (isApplication(serviceType) || isContainer(serviceType)) {
       const currentSettings = (application as GitApplicationEntity)?.advanced_settings?.current_settings
       if (currentSettings) {
-        values[key] = currentSettings[key as keyof ApplicationAdvancedSettings]?.toString() || ''
+        const value = currentSettings[key as keyof ApplicationAdvancedSettings]
+        values[key] = (typeof value === 'object' ? JSON.stringify(value) : value?.toString()) || ''
+        console.log(values[key])
       }
     } else if (isJob(serviceType)) {
       const currentSettings = application?.advanced_settings?.current_settings
       if (currentSettings) {
-        values[key] = currentSettings[key as keyof JobAdvancedSettings]?.toString() || ''
+        const value = currentSettings[key as keyof JobAdvancedSettings]
+        values[key] = (typeof value === 'object' ? JSON.stringify(value) : value?.toString()) || ''
       }
     }
   })

--- a/libs/pages/application/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-advanced-feature/page-settings-advanced-feature.tsx
@@ -97,9 +97,16 @@ export function PageSettingsAdvancedFeature() {
     // we can't do ApplicationAdvanceSettings[key] === 'string' or 'number'
     // so if field is empty string replace by value found in defaultSettings (because default value is well typed)
     Object.keys(dataFormatted).forEach((key) => {
-      if (dataFormatted[key] === '') {
-        dataFormatted[key] = defaultSettings ? defaultSettings[key as keyof AdvancedSettings] : ''
+      // check if we can convert this string to object
+      try {
+        JSON.parse(dataFormatted[key])
+      } catch (e) {
+        if (dataFormatted[key] === '') {
+          dataFormatted[key] = defaultSettings ? defaultSettings[key as keyof AdvancedSettings] : ''
+        }
+        return
       }
+      dataFormatted[key] = JSON.parse(dataFormatted[key])
     })
 
     if (application) {

--- a/libs/pages/application/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-advanced/page-settings-advanced.tsx
@@ -69,36 +69,38 @@ export function PageSettingsAdvanced(props: PageSettingsAdvancedProps) {
               className: 'font-medium vis',
             },
             {
-              content: (
-                <>
-                  <Tooltip
-                    content={
-                      (props.defaultAdvancedSettings &&
-                        props.defaultAdvancedSettings[
-                          key as keyof (ApplicationAdvancedSettings | JobAdvancedSettings)
-                        ]?.toString()) ||
-                      ''
-                    }
-                  >
-                    <div className="inline whitespace-nowrap overflow-hidden text-ellipsis">
-                      {props.defaultAdvancedSettings &&
-                        props.defaultAdvancedSettings[
-                          key as keyof (ApplicationAdvancedSettings | JobAdvancedSettings)
-                        ]?.toString()}
-                    </div>
-                  </Tooltip>
-                  <CopyToClipboard
-                    className="ml-2 text-text-300 invisible group-hover:visible"
-                    content={
-                      (props.defaultAdvancedSettings &&
-                        props.defaultAdvancedSettings[
-                          key as keyof (ApplicationAdvancedSettings | JobAdvancedSettings)
-                        ]?.toString()) ||
-                      ''
-                    }
-                  />
-                </>
-              ),
+              content: () => {
+                const value =
+                  props.defaultAdvancedSettings &&
+                  props.defaultAdvancedSettings[key as keyof (ApplicationAdvancedSettings | JobAdvancedSettings)]
+                const displayValue = (typeof value === 'object' ? JSON.stringify(value) : value?.toString()) || ''
+
+                return (
+                  <>
+                    <Tooltip
+                      content={
+                        (props.defaultAdvancedSettings &&
+                          props.defaultAdvancedSettings[
+                            key as keyof (ApplicationAdvancedSettings | JobAdvancedSettings)
+                          ]?.toString()) ||
+                        ''
+                      }
+                    >
+                      <div className="inline whitespace-nowrap overflow-hidden text-ellipsis">{displayValue}</div>
+                    </Tooltip>
+                    <CopyToClipboard
+                      className="ml-2 text-text-300 invisible group-hover:visible"
+                      content={
+                        (props.defaultAdvancedSettings &&
+                          props.defaultAdvancedSettings[
+                            key as keyof (ApplicationAdvancedSettings | JobAdvancedSettings)
+                          ]?.toString()) ||
+                        ''
+                      }
+                    />
+                  </>
+                )
+              },
               className: 'group',
             },
             {


### PR DESCRIPTION
# What does this PR do?

- Allow "object" for services advanced settings (add similar logic with Cluster advanced settings)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
