### PR TITLE
feat(environment-logs): add deployment history

### DIFF
--- a/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.spec.tsx
@@ -52,18 +52,13 @@ describe('DeploymentLogsFeature', () => {
       },
     ],
     statusStages: services,
-    pauseStatusLogs: false,
-    loadingStatus: 'loaded',
-    setPauseStatusLogs: jest.fn(),
   }
 
   it('should render successfully', () => {
-    console.warn = jest.fn()
-
     const { baseElement } = render(
       <Routes location="/organization/1/project/2/environment/3/logs/">
         <Route
-          path="/organization/1/project/2/environment/3/logs/4/deployment"
+          path="/organization/1/project/2/environment/3/logs/4/deployment-logs"
           element={<DeploymentLogsFeature {...props} />}
         />
       </Routes>

--- a/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
@@ -1,9 +1,11 @@
-import { DeploymentStageWithServicesStatuses, EnvironmentLogs, Status } from 'qovery-typescript-axios'
-import { useContext, useEffect } from 'react'
+import { DeploymentStageWithServicesStatuses, Environment, EnvironmentLogs, Status } from 'qovery-typescript-axios'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
+import useWebSocket from 'react-use-websocket'
 import { selectApplicationById } from '@qovery/domains/application'
 import { selectDatabaseById } from '@qovery/domains/database'
+import { useAuth } from '@qovery/shared/auth'
 import { ApplicationEntity, DatabaseEntity, LoadingStatus } from '@qovery/shared/interfaces'
 import { useDocumentTitle } from '@qovery/shared/utils'
 import { RootState } from '@qovery/state/store'
@@ -11,10 +13,7 @@ import DeploymentLogs from '../../ui/deployment-logs/deployment-logs'
 import { ServiceStageIdsContext } from '../service-stage-ids-context/service-stage-ids-context'
 
 export interface DeploymentLogsFeatureProps {
-  logs: EnvironmentLogs[]
-  pauseStatusLogs: boolean
-  loadingStatus: LoadingStatus
-  setPauseStatusLogs: (pause: boolean) => void
+  environment: Environment
   statusStages?: DeploymentStageWithServicesStatuses[]
 }
 
@@ -58,8 +57,8 @@ export function getServiceStatuesById(services?: DeploymentStageWithServicesStat
 }
 
 export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
-  const { logs, loadingStatus, pauseStatusLogs, setPauseStatusLogs, statusStages } = props
-  const { serviceId = '' } = useParams()
+  const { environment, statusStages } = props
+  const { organizationId = '', projectId = '', environmentId = '', serviceId = '', versionId = '' } = useParams()
   const { stageId, updateServiceId } = useContext(ServiceStageIdsContext)
 
   const application = useSelector<RootState, ApplicationEntity | undefined>((state) =>
@@ -67,11 +66,74 @@ export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
   )
   const database = useSelector<RootState, DatabaseEntity | undefined>((state) => selectDatabaseById(state, serviceId))
 
+  const [logs, setLogs] = useState<EnvironmentLogs[]>([])
+  const [loadingStatusDeploymentLogs, setLoadingStatusDeploymentLogs] = useState<LoadingStatus>('not loaded')
+  const [messageChunks, setMessageChunks] = useState<EnvironmentLogs[][]>([])
+  const [debounceTime, setDebounceTime] = useState(1000)
+  const [pauseStatusLogs, setPauseStatusLogs] = useState<boolean>(false)
+
   useDocumentTitle(
-    `Deployment logs ${loadingStatus === 'loaded' ? `- ${application?.name || database?.name}` : '- Loading...'}`
+    `Deployment logs ${
+      loadingStatusDeploymentLogs === 'loaded' ? `- ${application?.name || database?.name}` : '- Loading...'
+    }`
   )
 
-  const hideDeploymentLogsBoolean = !(getServiceStatuesById(statusStages, serviceId) as Status)?.is_part_last_deployment
+  const { getAccessTokenSilently } = useAuth()
+  const chunkSize = 500
+
+  const deploymentLogsUrl: () => Promise<string> = useCallback(async () => {
+    // reset current Logs
+    setLogs([])
+
+    const url = `wss://ws.qovery.com/deployment/logs?organization=${organizationId}&cluster=${environment?.cluster_id}&project=${projectId}&environment=${environmentId}&version=${versionId}`
+    const token = await getAccessTokenSilently()
+
+    return new Promise((resolve) => {
+      environment?.cluster_id && resolve(url + `&bearer_token=${token}`)
+    })
+  }, [organizationId, environment?.cluster_id, projectId, environmentId, versionId, getAccessTokenSilently])
+
+  useWebSocket(deploymentLogsUrl, {
+    onMessage: (message) => {
+      setLoadingStatusDeploymentLogs('loaded')
+
+      const newLog = JSON.parse(message?.data)
+
+      setMessageChunks((prevChunks) => {
+        const lastChunk = prevChunks[prevChunks.length - 1] || []
+        if (lastChunk.length < chunkSize) {
+          return [...prevChunks.slice(0, -1), [...lastChunk, ...newLog]]
+        } else {
+          return [...prevChunks, [...newLog]]
+        }
+      })
+    },
+  })
+
+  useEffect(() => {
+    if (messageChunks.length === 0 || pauseStatusLogs) return
+
+    const timerId = setTimeout(() => {
+      if (!pauseStatusLogs) {
+        setMessageChunks((prevChunks) => prevChunks.slice(1))
+        setLogs((prevLogs) => {
+          const combinedLogs = [...prevLogs, ...messageChunks[0]]
+          return [...new Map(combinedLogs.map((item) => [item['timestamp'], item])).values()]
+        })
+
+        if (logs.length > 1000) {
+          setDebounceTime(100)
+        }
+      }
+    }, debounceTime)
+
+    return () => {
+      clearTimeout(timerId)
+    }
+  }, [messageChunks, pauseStatusLogs])
+
+  // const hideDeploymentLogsBoolean = !(getServiceStatuesById(statusStages, serviceId) as Status)?.is_part_last_deployment
+  const hideDeploymentLogsBoolean = false
 
   // reset deployment logs by serviceId
   useEffect(() => {
@@ -97,7 +159,7 @@ export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
 
   return (
     <DeploymentLogs
-      loadingStatus={loadingStatus}
+      loadingStatus={loadingStatusDeploymentLogs}
       // filter by same transmitter id and environment type
       logs={logsByServiceId}
       errors={errors}

--- a/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
@@ -1,4 +1,4 @@
-import { DeploymentStageWithServicesStatuses, Environment, EnvironmentLogs, Status } from 'qovery-typescript-axios'
+import { DeploymentStageWithServicesStatuses, Environment, EnvironmentLogs } from 'qovery-typescript-axios'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
@@ -57,9 +57,9 @@ export function getServiceStatuesById(services?: DeploymentStageWithServicesStat
 }
 
 export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
-  const { environment, statusStages } = props
+  const { environment } = props
   const { organizationId = '', projectId = '', environmentId = '', serviceId = '', versionId = '' } = useParams()
-  const { stageId, updateServiceId } = useContext(ServiceStageIdsContext)
+  const { stageId, updateServiceId, updateVersionId } = useContext(ServiceStageIdsContext)
 
   const application = useSelector<RootState, ApplicationEntity | undefined>((state) =>
     selectApplicationById(state, serviceId)
@@ -135,10 +135,11 @@ export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
   // const hideDeploymentLogsBoolean = !(getServiceStatuesById(statusStages, serviceId) as Status)?.is_part_last_deployment
   const hideDeploymentLogsBoolean = false
 
-  // reset deployment logs by serviceId
+  // reset deployment logs by serviceId and versionId
   useEffect(() => {
     updateServiceId(serviceId)
-  }, [updateServiceId, serviceId])
+    updateVersionId(versionId)
+  }, [updateServiceId, serviceId, updateVersionId, versionId])
 
   // deployment logs by serviceId and stageId
   // display when name is delete or stageId is empty
@@ -166,7 +167,7 @@ export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
       pauseStatusLogs={pauseStatusLogs}
       setPauseStatusLogs={setPauseStatusLogs}
       serviceRunningStatus={application?.running_status || database?.running_status}
-      serviceDeploymentStatus={(getServiceStatuesById(statusStages, serviceId) as Status)?.service_deployment_status}
+      // serviceDeploymentStatus={(getServiceStatuesById(statusStages, serviceId) as Status)?.service_deployment_status}
       hideDeploymentLogs={hideDeploymentLogsBoolean}
     />
   )

--- a/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
@@ -59,7 +59,7 @@ export function getServiceStatuesById(services?: DeploymentStageWithServicesStat
 
 export function DeploymentLogsFeature({ environment, statusStages }: DeploymentLogsFeatureProps) {
   const { organizationId = '', projectId = '', environmentId = '', serviceId = '', versionId = '' } = useParams()
-  const { stageId, updateServiceId, updateVersionId } = useContext(ServiceStageIdsContext)
+  const { stageId } = useContext(ServiceStageIdsContext)
 
   const application = useSelector<RootState, ApplicationEntity | undefined>((state) =>
     selectApplicationById(state, serviceId)
@@ -134,12 +134,6 @@ export function DeploymentLogsFeature({ environment, statusStages }: DeploymentL
   }, [messageChunks, pauseStatusLogs])
 
   const hideDeploymentLogsBoolean = !(getServiceStatuesById(statusStages, serviceId) as Status)?.is_part_last_deployment
-
-  // reset deployment logs by serviceId and versionId
-  useEffect(() => {
-    updateServiceId(serviceId)
-    updateVersionId(versionId)
-  }, [updateServiceId, serviceId, updateVersionId, versionId])
 
   // deployment logs by serviceId and stageId
   // display when name is delete or stageId is empty

--- a/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
@@ -1,4 +1,4 @@
-import { DeploymentStageWithServicesStatuses, Environment, EnvironmentLogs } from 'qovery-typescript-axios'
+import { DeploymentStageWithServicesStatuses, Environment, EnvironmentLogs, Status } from 'qovery-typescript-axios'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
@@ -56,8 +56,7 @@ export function getServiceStatuesById(services?: DeploymentStageWithServicesStat
   return null
 }
 
-export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
-  const { environment } = props
+export function DeploymentLogsFeature({ environment, statusStages }: DeploymentLogsFeatureProps) {
   const { organizationId = '', projectId = '', environmentId = '', serviceId = '', versionId = '' } = useParams()
   const { stageId, updateServiceId, updateVersionId } = useContext(ServiceStageIdsContext)
 
@@ -167,7 +166,7 @@ export function DeploymentLogsFeature(props: DeploymentLogsFeatureProps) {
       pauseStatusLogs={pauseStatusLogs}
       setPauseStatusLogs={setPauseStatusLogs}
       serviceRunningStatus={application?.running_status || database?.running_status}
-      // serviceDeploymentStatus={(getServiceStatuesById(statusStages, serviceId) as Status)?.service_deployment_status}
+      serviceDeploymentStatus={(getServiceStatuesById(statusStages, serviceId) as Status)?.service_deployment_status}
       hideDeploymentLogs={hideDeploymentLogsBoolean}
     />
   )

--- a/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/deployment-logs-feature/deployment-logs-feature.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom'
 import useWebSocket from 'react-use-websocket'
 import { selectApplicationById } from '@qovery/domains/application'
 import { selectDatabaseById } from '@qovery/domains/database'
+import { useEnvironmentDeploymentHistory } from '@qovery/domains/environment'
 import { useAuth } from '@qovery/shared/auth'
 import { ApplicationEntity, DatabaseEntity, LoadingStatus } from '@qovery/shared/interfaces'
 import { useDocumentTitle } from '@qovery/shared/utils'
@@ -64,6 +65,7 @@ export function DeploymentLogsFeature({ environment, statusStages }: DeploymentL
     selectApplicationById(state, serviceId)
   )
   const database = useSelector<RootState, DatabaseEntity | undefined>((state) => selectDatabaseById(state, serviceId))
+  const { data: dataDeploymentHistory } = useEnvironmentDeploymentHistory(projectId, environmentId)
 
   const [logs, setLogs] = useState<EnvironmentLogs[]>([])
   const [loadingStatusDeploymentLogs, setLoadingStatusDeploymentLogs] = useState<LoadingStatus>('not loaded')
@@ -131,8 +133,7 @@ export function DeploymentLogsFeature({ environment, statusStages }: DeploymentL
     }
   }, [messageChunks, pauseStatusLogs])
 
-  // const hideDeploymentLogsBoolean = !(getServiceStatuesById(statusStages, serviceId) as Status)?.is_part_last_deployment
-  const hideDeploymentLogsBoolean = false
+  const hideDeploymentLogsBoolean = !(getServiceStatuesById(statusStages, serviceId) as Status)?.is_part_last_deployment
 
   // reset deployment logs by serviceId and versionId
   useEffect(() => {
@@ -167,7 +168,9 @@ export function DeploymentLogsFeature({ environment, statusStages }: DeploymentL
       setPauseStatusLogs={setPauseStatusLogs}
       serviceRunningStatus={application?.running_status || database?.running_status}
       serviceDeploymentStatus={(getServiceStatuesById(statusStages, serviceId) as Status)?.service_deployment_status}
+      serviceName={application?.name || database?.name}
       hideDeploymentLogs={hideDeploymentLogsBoolean}
+      dataDeploymentHistory={dataDeploymentHistory}
     />
   )
 }

--- a/libs/pages/logs/environment/src/lib/feature/pod-logs-feature/pod-logs-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/pod-logs-feature/pod-logs-feature.tsx
@@ -1,5 +1,5 @@
 import { Log } from 'qovery-typescript-axios'
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import useWebSocket from 'react-use-websocket'
@@ -10,7 +10,6 @@ import { ApplicationEntity, DatabaseEntity, LoadingStatus } from '@qovery/shared
 import { useDocumentTitle } from '@qovery/shared/utils'
 import { RootState } from '@qovery/state/store'
 import PodLogs from '../../ui/pod-logs/pod-logs'
-import { ServiceStageIdsContext } from '../service-stage-ids-context/service-stage-ids-context'
 
 export interface PodLogsFeatureProps {
   clusterId: string
@@ -19,7 +18,6 @@ export interface PodLogsFeatureProps {
 export function PodLogsFeature(props: PodLogsFeatureProps) {
   const { clusterId } = props
   const { organizationId = '', projectId = '', environmentId = '', serviceId = '' } = useParams()
-  const { updateServiceId } = useContext(ServiceStageIdsContext)
 
   const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>('not loaded')
   const [messageChunks, setMessageChunks] = useState<Log[][]>([])
@@ -116,11 +114,6 @@ export function PodLogsFeature(props: PodLogsFeatureProps) {
       clearTimeout(timerId)
     }
   }, [messageNGINXChunks, pauseStatusLogs, debounceTime])
-
-  // update serviceId
-  useEffect(() => {
-    updateServiceId(serviceId)
-  }, [updateServiceId, serviceId])
 
   // reset pod logs
   useEffect(() => {

--- a/libs/pages/logs/environment/src/lib/feature/service-stage-ids-context/service-stage-ids-context.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/service-stage-ids-context/service-stage-ids-context.spec.tsx
@@ -3,37 +3,6 @@ import { useContext } from 'react'
 import { ServiceStageIdsContext, ServiceStageIdsProvider } from './service-stage-ids-context'
 
 describe('ServiceStageIdsContext', () => {
-  it('should provide the initial service state', () => {
-    const TestComponent = () => {
-      const { serviceId, updateServiceId } = useContext(ServiceStageIdsContext)
-      return (
-        <div>
-          <p data-testid="service">{serviceId}</p>
-          <button data-testid="set-service" onClick={() => updateServiceId('id')}>
-            Set Service
-          </button>
-        </div>
-      )
-    }
-
-    const { getByTestId } = render(
-      <ServiceStageIdsProvider>
-        <TestComponent />
-      </ServiceStageIdsProvider>
-    )
-
-    const service = getByTestId('service')
-    const setServiceButton = getByTestId('set-service')
-
-    act(() => {
-      setServiceButton.click()
-    })
-
-    waitFor(() => {
-      expect(service.textContent).toBe('id')
-    })
-  })
-
   it('should provide the initial stage state', () => {
     const TestComponent = () => {
       const { stageId, updateStageId } = useContext(ServiceStageIdsContext)

--- a/libs/pages/logs/environment/src/lib/feature/service-stage-ids-context/service-stage-ids-context.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/service-stage-ids-context/service-stage-ids-context.tsx
@@ -3,20 +3,25 @@ import { ReactNode, createContext, useContext, useState } from 'react'
 interface ServiceStageIdsContextValues {
   serviceId: string
   stageId: string
+  versionId: string
   updateServiceId: (serviceId: string) => void
   updateStageId: (stageId: string) => void
+  updateVersionId: (versionId: string) => void
 }
 
 export const ServiceStageIdsContext = createContext<ServiceStageIdsContextValues>({
   serviceId: '',
   stageId: '',
+  versionId: '',
   updateServiceId: () => {},
   updateStageId: () => {},
+  updateVersionId: () => {},
 })
 
 export const ServiceStageIdsProvider = ({ children }: { children: ReactNode }) => {
   const [serviceId, setServiceId] = useState<string>('')
   const [stageId, setStageId] = useState<string>('')
+  const [versionId, setVersionId] = useState<string>('')
 
   const updateServiceId = (newServiceId: string) => {
     setServiceId(newServiceId)
@@ -26,8 +31,14 @@ export const ServiceStageIdsProvider = ({ children }: { children: ReactNode }) =
     setStageId(newStageId)
   }
 
+  const updateVersionId = (newVersionId: string) => {
+    setVersionId(newVersionId)
+  }
+
   return (
-    <ServiceStageIdsContext.Provider value={{ serviceId, stageId, updateServiceId, updateStageId }}>
+    <ServiceStageIdsContext.Provider
+      value={{ serviceId, stageId, versionId, updateServiceId, updateStageId, updateVersionId }}
+    >
       {children}
     </ServiceStageIdsContext.Provider>
   )

--- a/libs/pages/logs/environment/src/lib/feature/service-stage-ids-context/service-stage-ids-context.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/service-stage-ids-context/service-stage-ids-context.tsx
@@ -1,46 +1,24 @@
 import { ReactNode, createContext, useContext, useState } from 'react'
 
 interface ServiceStageIdsContextValues {
-  serviceId: string
   stageId: string
-  versionId: string
-  updateServiceId: (serviceId: string) => void
   updateStageId: (stageId: string) => void
-  updateVersionId: (versionId: string) => void
 }
 
 export const ServiceStageIdsContext = createContext<ServiceStageIdsContextValues>({
-  serviceId: '',
   stageId: '',
-  versionId: '',
-  updateServiceId: () => {},
   updateStageId: () => {},
-  updateVersionId: () => {},
 })
 
 export const ServiceStageIdsProvider = ({ children }: { children: ReactNode }) => {
-  const [serviceId, setServiceId] = useState<string>('')
   const [stageId, setStageId] = useState<string>('')
-  const [versionId, setVersionId] = useState<string>('')
-
-  const updateServiceId = (newServiceId: string) => {
-    setServiceId(newServiceId)
-  }
 
   const updateStageId = (newStageId: string) => {
     setStageId(newStageId)
   }
 
-  const updateVersionId = (newVersionId: string) => {
-    setVersionId(newVersionId)
-  }
-
   return (
-    <ServiceStageIdsContext.Provider
-      value={{ serviceId, stageId, versionId, updateServiceId, updateStageId, updateVersionId }}
-    >
-      {children}
-    </ServiceStageIdsContext.Provider>
+    <ServiceStageIdsContext.Provider value={{ stageId, updateStageId }}>{children}</ServiceStageIdsContext.Provider>
   )
 }
 

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react'
+import SidebarHistoryFeature from './sidebar-history-feature'
+
+describe('SidebarHistoryFeature', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<SidebarHistoryFeature />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.spec.tsx
@@ -1,9 +1,14 @@
-import { render } from '@testing-library/react'
-import SidebarHistoryFeature from './sidebar-history-feature'
+import { render } from '__tests__/utils/setup-jest'
+import SidebarHistoryFeature, { SidebarHistoryFeatureProps } from './sidebar-history-feature'
 
 describe('SidebarHistoryFeature', () => {
+  const props: SidebarHistoryFeatureProps = {
+    versionId: '1',
+    serviceId: '2',
+  }
+
   it('should render successfully', () => {
-    const { baseElement } = render(<SidebarHistoryFeature />)
+    const { baseElement } = render(<SidebarHistoryFeature {...props} />)
     expect(baseElement).toBeTruthy()
   })
 })

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
@@ -1,10 +1,13 @@
+import { useContext } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useEnvironmentDeploymentHistory } from '@qovery/domains/environment'
 import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
+import { ServiceStageIdsContext } from '../service-stage-ids-context/service-stage-ids-context'
 
 export function SidebarHistoryFeature() {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
   const { data } = useEnvironmentDeploymentHistory(projectId, environmentId)
+  const { versionId } = useContext(ServiceStageIdsContext)
 
   const navigate = useNavigate()
 
@@ -14,12 +17,14 @@ export function SidebarHistoryFeature() {
     <div className="flex justify-center border-b border-element-light-darker-100 px-4 py-3">
       <div>
         <div className="text-text-100 text-xs font-medium">Deployment - 1/10</div>
-        <div className="text-text-100 text-xs">
+        <div>
           {data?.map((item, index) => (
             <div
               key={item.id}
-              className="py-2"
-              onClick={() => navigate(pathLogs + DEPLOYMENT_LOGS_VERSION_URL(environmentId, item.id))}
+              className={`py-2 text-xs ${item.id === versionId ? 'text-brand-400' : 'text-text-100'}`}
+              onClick={() => {
+                navigate(pathLogs + DEPLOYMENT_LOGS_VERSION_URL(environmentId, item.id))
+              }}
             >
               {index + 1}/{data.length} {item.id}
             </div>

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
@@ -13,24 +13,30 @@ export function SidebarHistoryFeature() {
   const { data } = useEnvironmentDeploymentHistory(projectId, environmentId)
   const { serviceId, versionId, updateVersionId } = useContext(ServiceStageIdsContext)
   const navigate = useNavigate()
-
   const applications = useSelector((state: RootState) => selectApplicationsEntitiesByEnvId(state, environmentId))
 
   const pathLogs = ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId)
 
   useEffect(() => {
-    if (!versionId && serviceId !== '') {
+    if (!versionId) {
       const firstVersionId = data?.[0]?.id || ''
+      // adding the first versionId if not defined
       updateVersionId(firstVersionId)
-      navigate(pathLogs + DEPLOYMENT_LOGS_VERSION_URL(serviceId, firstVersionId))
+      // navigate to deployment logs view
+      if (serviceId) {
+        navigate(
+          ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+            DEPLOYMENT_LOGS_VERSION_URL(serviceId, firstVersionId)
+        )
+      }
     }
-  }, [navigate, serviceId, versionId, updateVersionId, data, pathLogs])
+  }, [organizationId, projectId, environmentId, serviceId, versionId, navigate, updateVersionId, data])
 
   if (!data) return
 
-  return (
-    <SidebarHistory data={data} versionId={versionId} serviceId={serviceId || applications[0].id} pathLogs={pathLogs} />
-  )
+  const defaultServiceId = serviceId || applications[0]?.id || ''
+
+  return <SidebarHistory data={data} versionId={versionId} serviceId={defaultServiceId} pathLogs={pathLogs} />
 }
 
 export default SidebarHistoryFeature

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
@@ -1,7 +1,10 @@
 import { useContext, useEffect } from 'react'
+import { useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
+import { selectApplicationsEntitiesByEnvId } from '@qovery/domains/application'
 import { useEnvironmentDeploymentHistory } from '@qovery/domains/environment'
 import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
+import { RootState } from '@qovery/store'
 import SidebarHistory from '../../ui/sidebar-history/sidebar-history'
 import { ServiceStageIdsContext } from '../service-stage-ids-context/service-stage-ids-context'
 
@@ -10,6 +13,8 @@ export function SidebarHistoryFeature() {
   const { data } = useEnvironmentDeploymentHistory(projectId, environmentId)
   const { serviceId, versionId, updateVersionId } = useContext(ServiceStageIdsContext)
   const navigate = useNavigate()
+
+  const applications = useSelector((state: RootState) => selectApplicationsEntitiesByEnvId(state, environmentId))
 
   const pathLogs = ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId)
 
@@ -23,7 +28,9 @@ export function SidebarHistoryFeature() {
 
   if (!data) return
 
-  return <SidebarHistory data={data} versionId={versionId} serviceId={serviceId} pathLogs={pathLogs} />
+  return (
+    <SidebarHistory data={data} versionId={versionId} serviceId={serviceId || applications[0].id} pathLogs={pathLogs} />
+  )
 }
 
 export default SidebarHistoryFeature

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
@@ -1,9 +1,8 @@
-import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 import { selectApplicationsEntitiesByEnvId } from '@qovery/domains/application'
 import { useEnvironmentDeploymentHistory } from '@qovery/domains/environment'
-import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
+import { ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
 import { RootState } from '@qovery/store'
 import SidebarHistory from '../../ui/sidebar-history/sidebar-history'
 
@@ -15,28 +14,15 @@ export interface SidebarHistoryFeatureProps {
 export function SidebarHistoryFeature({ versionId, serviceId }: SidebarHistoryFeatureProps) {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
   const { data } = useEnvironmentDeploymentHistory(projectId, environmentId)
-  const navigate = useNavigate()
   const applications = useSelector((state: RootState) => selectApplicationsEntitiesByEnvId(state, environmentId))
 
   const { pathname } = useLocation()
   const pathLogs = ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId)
   const serviceLogsPath = pathname.includes(SERVICE_LOGS_URL(serviceId))
 
-  useEffect(() => {
-    if (!versionId && !serviceLogsPath) {
-      const firstVersionId = data?.[0]?.id || ''
-      if (serviceId) {
-        navigate(
-          ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-            DEPLOYMENT_LOGS_VERSION_URL(serviceId, firstVersionId)
-        )
-      }
-    }
-  }, [organizationId, projectId, environmentId, serviceId, versionId, navigate, data, serviceLogsPath])
-
   const defaultServiceId = serviceId || applications[0]?.id
 
-  if (!data || !defaultServiceId) return
+  if (!data || !defaultServiceId || serviceLogsPath) return
 
   return <SidebarHistory data={data} versionId={versionId} serviceId={defaultServiceId} pathLogs={pathLogs} />
 }

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useEnvironmentDeploymentHistory } from '@qovery/domains/environment'
 import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
@@ -7,23 +7,32 @@ import { ServiceStageIdsContext } from '../service-stage-ids-context/service-sta
 export function SidebarHistoryFeature() {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
   const { data } = useEnvironmentDeploymentHistory(projectId, environmentId)
-  const { versionId } = useContext(ServiceStageIdsContext)
-
+  const { serviceId, versionId, updateVersionId } = useContext(ServiceStageIdsContext)
   const navigate = useNavigate()
 
   const pathLogs = ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId)
 
+  useEffect(() => {
+    if (!versionId && serviceId !== '') {
+      const firstVersionId = data?.[0]?.id || ''
+      updateVersionId(firstVersionId)
+      navigate(pathLogs + DEPLOYMENT_LOGS_VERSION_URL(serviceId, firstVersionId))
+    }
+  }, [navigate, serviceId, versionId, updateVersionId, data, pathLogs])
+
+  const currentIndex = (data?.findIndex((item) => item.id === versionId) || 0) + 1
+
   return (
     <div className="flex justify-center border-b border-element-light-darker-100 px-4 py-3">
       <div>
-        <div className="text-text-100 text-xs font-medium">Deployment - 1/10</div>
+        <div className="text-text-100 text-xs font-medium">Deployment - {currentIndex}/10</div>
         <div>
           {data?.map((item, index) => (
             <div
               key={item.id}
               className={`py-2 text-xs ${item.id === versionId ? 'text-brand-400' : 'text-text-100'}`}
               onClick={() => {
-                navigate(pathLogs + DEPLOYMENT_LOGS_VERSION_URL(environmentId, item.id))
+                navigate(pathLogs + DEPLOYMENT_LOGS_VERSION_URL(serviceId, item.id))
               }}
             >
               {index + 1}/{data.length} {item.id}

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
@@ -1,0 +1,33 @@
+import { useNavigate, useParams } from 'react-router-dom'
+import { useEnvironmentDeploymentHistory } from '@qovery/domains/environment'
+import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
+
+export function SidebarHistoryFeature() {
+  const { organizationId = '', projectId = '', environmentId = '' } = useParams()
+  const { data } = useEnvironmentDeploymentHistory(projectId, environmentId)
+
+  const navigate = useNavigate()
+
+  const pathLogs = ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId)
+
+  return (
+    <div className="flex justify-center border-b border-element-light-darker-100 px-4 py-3">
+      <div>
+        <div className="text-text-100 text-xs font-medium">Deployment - 1/10</div>
+        <div className="text-text-100 text-xs">
+          {data?.map((item, index) => (
+            <div
+              key={item.id}
+              className="py-2"
+              onClick={() => navigate(pathLogs + DEPLOYMENT_LOGS_VERSION_URL(environmentId, item.id))}
+            >
+              {index + 1}/{data.length} {item.id}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SidebarHistoryFeature

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
@@ -3,7 +3,7 @@ import { useLocation, useParams } from 'react-router-dom'
 import { selectApplicationsEntitiesByEnvId } from '@qovery/domains/application'
 import { useEnvironmentDeploymentHistory } from '@qovery/domains/environment'
 import { ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
-import { RootState } from '@qovery/store'
+import { RootState } from '@qovery/state/store'
 import SidebarHistory from '../../ui/sidebar-history/sidebar-history'
 
 export interface SidebarHistoryFeatureProps {

--- a/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
+++ b/libs/pages/logs/environment/src/lib/feature/sidebar-history-feature/sidebar-history-feature.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useEnvironmentDeploymentHistory } from '@qovery/domains/environment'
 import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
+import SidebarHistory from '../../ui/sidebar-history/sidebar-history'
 import { ServiceStageIdsContext } from '../service-stage-ids-context/service-stage-ids-context'
 
 export function SidebarHistoryFeature() {
@@ -20,28 +21,9 @@ export function SidebarHistoryFeature() {
     }
   }, [navigate, serviceId, versionId, updateVersionId, data, pathLogs])
 
-  const currentIndex = (data?.findIndex((item) => item.id === versionId) || 0) + 1
+  if (!data) return
 
-  return (
-    <div className="flex justify-center border-b border-element-light-darker-100 px-4 py-3">
-      <div>
-        <div className="text-text-100 text-xs font-medium">Deployment - {currentIndex}/10</div>
-        <div>
-          {data?.map((item, index) => (
-            <div
-              key={item.id}
-              className={`py-2 text-xs ${item.id === versionId ? 'text-brand-400' : 'text-text-100'}`}
-              onClick={() => {
-                navigate(pathLogs + DEPLOYMENT_LOGS_VERSION_URL(serviceId, item.id))
-              }}
-            >
-              {index + 1}/{data.length} {item.id}
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  )
+  return <SidebarHistory data={data} versionId={versionId} serviceId={serviceId} pathLogs={pathLogs} />
 }
 
 export default SidebarHistoryFeature

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -1,5 +1,5 @@
 import equal from 'fast-deep-equal'
-import { DeploymentStageWithServicesStatuses, EnvironmentLogs, EnvironmentStatus } from 'qovery-typescript-axios'
+import { DeploymentStageWithServicesStatuses, EnvironmentStatus } from 'qovery-typescript-axios'
 import { useCallback, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Route, Routes, useLocation, useParams } from 'react-router-dom'
@@ -8,8 +8,13 @@ import { fetchApplicationsStatus, selectApplicationsEntitiesByEnvId } from '@qov
 import { fetchDatabasesStatus, selectDatabasesEntitiesByEnvId } from '@qovery/domains/database'
 import { useFetchEnvironment } from '@qovery/domains/environment'
 import { useAuth } from '@qovery/shared/auth'
-import { ApplicationEntity, DatabaseEntity, LoadingStatus } from '@qovery/shared/interfaces'
-import { DEPLOYMENT_LOGS_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
+import { ApplicationEntity, DatabaseEntity } from '@qovery/shared/interfaces'
+import {
+  DEPLOYMENT_LOGS_URL,
+  DEPLOYMENT_LOGS_VERSION_URL,
+  ENVIRONMENT_LOGS_URL,
+  SERVICE_LOGS_URL,
+} from '@qovery/shared/routes'
 import { Icon, IconAwesomeEnum } from '@qovery/shared/ui'
 import { useDocumentTitle } from '@qovery/shared/utils'
 import { AppDispatch, RootState } from '@qovery/state/store'
@@ -66,60 +71,7 @@ export function PageEnvironmentLogs() {
     },
   })
 
-  const [messageChunks, setMessageChunks] = useState<EnvironmentLogs[][]>([])
-  const chunkSize = 500
-  const [debounceTime, setDebounceTime] = useState(1000)
-  const [logs, setLogs] = useState<EnvironmentLogs[]>([])
-  const [pauseStatusLogs, setPauseStatusLogs] = useState<boolean>(false)
-  const [loadingStatusDeploymentLogs, setLoadingStatusDeploymentLogs] = useState<LoadingStatus>('not loaded')
-
-  const deploymentLogsUrl: () => Promise<string> = useCallback(async () => {
-    const url = `wss://ws.qovery.com/deployment/logs?organization=${organizationId}&cluster=${environment?.cluster_id}&project=${projectId}&environment=${environmentId}`
-    const token = await getAccessTokenSilently()
-
-    return new Promise((resolve) => {
-      resolve(url + `&bearer_token=${token}`)
-    })
-  }, [organizationId, environment?.cluster_id, projectId, environmentId, getAccessTokenSilently])
-
-  useWebSocket(deploymentLogsUrl, {
-    onMessage: (message) => {
-      setLoadingStatusDeploymentLogs('loaded')
-
-      const newLog = JSON.parse(message?.data)
-
-      setMessageChunks((prevChunks) => {
-        const lastChunk = prevChunks[prevChunks.length - 1] || []
-        if (lastChunk.length < chunkSize) {
-          return [...prevChunks.slice(0, -1), [...lastChunk, ...newLog]]
-        } else {
-          return [...prevChunks, [...newLog]]
-        }
-      })
-    },
-  })
-
-  useEffect(() => {
-    if (messageChunks.length === 0 || pauseStatusLogs) return
-
-    const timerId = setTimeout(() => {
-      if (!pauseStatusLogs) {
-        setMessageChunks((prevChunks) => prevChunks.slice(1))
-        setLogs((prevLogs) => {
-          const combinedLogs = [...prevLogs, ...messageChunks[0]]
-          return [...new Map(combinedLogs.map((item) => [item['timestamp'], item])).values()]
-        })
-
-        if (logs.length > 1000) {
-          setDebounceTime(100)
-        }
-      }
-    }, debounceTime)
-
-    return () => {
-      clearTimeout(timerId)
-    }
-  }, [messageChunks, pauseStatusLogs])
+  if (!environment) return
 
   return (
     <div className="flex h-full">
@@ -132,15 +84,11 @@ export function PageEnvironmentLogs() {
         <Routes>
           <Route
             path={DEPLOYMENT_LOGS_URL()}
-            element={
-              <DeploymentLogsFeature
-                logs={logs}
-                pauseStatusLogs={pauseStatusLogs}
-                setPauseStatusLogs={setPauseStatusLogs}
-                loadingStatus={loadingStatusDeploymentLogs}
-                statusStages={statusStages}
-              />
-            }
+            element={<DeploymentLogsFeature environment={environment} statusStages={statusStages} />}
+          />
+          <Route
+            path={DEPLOYMENT_LOGS_VERSION_URL()}
+            element={<DeploymentLogsFeature environment={environment} statusStages={statusStages} />}
           />
           <Route path={SERVICE_LOGS_URL()} element={<PodLogsFeature clusterId={environment?.cluster_id || ''} />} />
         </Routes>
@@ -154,7 +102,7 @@ export function PageEnvironmentLogs() {
               Please select a service on the left menu to access its deployment logs or live logs.
               <p>
                 You can access the deployment logs only for the services recently deployed (
-                <a className="text-brand-400">in purple</a>).
+                <span className="text-brand-400">in purple</span>).
               </p>
             </div>
           </div>

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -9,7 +9,7 @@ import { fetchDatabasesStatus, selectDatabasesEntitiesByEnvId } from '@qovery/do
 import { useFetchEnvironment } from '@qovery/domains/environment'
 import { useAuth } from '@qovery/shared/auth'
 import { ApplicationEntity, DatabaseEntity } from '@qovery/shared/interfaces'
-import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
+import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_VERSION_URL } from '@qovery/shared/routes'
 import { Icon, IconAwesomeEnum } from '@qovery/shared/ui'
 import { useDocumentTitle } from '@qovery/shared/utils'
 import { AppDispatch, RootState } from '@qovery/state/store'
@@ -85,7 +85,7 @@ export function PageEnvironmentLogs() {
             path={DEPLOYMENT_LOGS_VERSION_URL()}
             element={<DeploymentLogsFeature environment={environment} statusStages={statusStages} />}
           />
-          <Route path={SERVICE_LOGS_URL()} element={<PodLogsFeature clusterId={environment?.cluster_id} />} />
+          <Route path={SERVICE_LOGS_VERSION_URL()} element={<PodLogsFeature clusterId={environment?.cluster_id} />} />
         </Routes>
       </ServiceStageIdsProvider>
       {(location.pathname === `${ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId)}/` ||

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -9,12 +9,7 @@ import { fetchDatabasesStatus, selectDatabasesEntitiesByEnvId } from '@qovery/do
 import { useFetchEnvironment } from '@qovery/domains/environment'
 import { useAuth } from '@qovery/shared/auth'
 import { ApplicationEntity, DatabaseEntity } from '@qovery/shared/interfaces'
-import {
-  DEPLOYMENT_LOGS_URL,
-  DEPLOYMENT_LOGS_VERSION_URL,
-  ENVIRONMENT_LOGS_URL,
-  SERVICE_LOGS_URL,
-} from '@qovery/shared/routes'
+import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
 import { Icon, IconAwesomeEnum } from '@qovery/shared/ui'
 import { useDocumentTitle } from '@qovery/shared/utils'
 import { AppDispatch, RootState } from '@qovery/state/store'
@@ -82,10 +77,10 @@ export function PageEnvironmentLogs() {
           environmentStatus={environmentStatus}
         />
         <Routes>
-          <Route
+          {/* <Route
             path={DEPLOYMENT_LOGS_URL()}
             element={<DeploymentLogsFeature environment={environment} statusStages={statusStages} />}
-          />
+          /> */}
           <Route
             path={DEPLOYMENT_LOGS_VERSION_URL()}
             element={<DeploymentLogsFeature environment={environment} statusStages={statusStages} />}

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -90,7 +90,7 @@ export function PageEnvironmentLogs() {
             path={DEPLOYMENT_LOGS_VERSION_URL()}
             element={<DeploymentLogsFeature environment={environment} statusStages={statusStages} />}
           />
-          <Route path={SERVICE_LOGS_URL()} element={<PodLogsFeature clusterId={environment?.cluster_id || ''} />} />
+          <Route path={SERVICE_LOGS_URL()} element={<PodLogsFeature clusterId={environment?.cluster_id} />} />
         </Routes>
       </ServiceStageIdsProvider>
       {(location.pathname === `${ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId)}/` ||

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -74,13 +74,15 @@ export function PageEnvironmentLogs() {
   const { getAccessTokenSilently } = useAuth()
 
   const deploymentStatusUrl: () => Promise<string> = useCallback(async () => {
-    const url = `wss://ws.qovery.com/deployment/status?organization=${organizationId}&cluster=${environment?.cluster_id}&project=${projectId}&environment=${environmentId}`
+    const url = `wss://ws.qovery.com/deployment/status?organization=${organizationId}&cluster=${
+      environment?.cluster_id
+    }&project=${projectId}&environment=${environmentId}${versionId ? `&version=${versionId}` : ''}`
     const token = await getAccessTokenSilently()
 
     return new Promise((resolve) => {
       environment?.cluster_id && resolve(url + `&bearer_token=${token}`)
     })
-  }, [organizationId, environment?.cluster_id, projectId, environmentId, getAccessTokenSilently])
+  }, [organizationId, environment?.cluster_id, projectId, environmentId, getAccessTokenSilently, versionId])
 
   useWebSocket(deploymentStatusUrl, {
     onMessage: (message) => {

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -64,7 +64,7 @@ export function PageEnvironmentLogs() {
     const fetchServicesStatusByInterval = setInterval(() => {
       if (applications.length > 0) dispatch(fetchApplicationsStatus({ environmentId }))
       if (databases.length > 0) dispatch(fetchDatabasesStatus({ environmentId }))
-    }, 2000)
+    }, 10000)
     return () => clearInterval(fetchServicesStatusByInterval)
   }, [dispatch, environmentId, applications.length, databases.length])
 

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -77,10 +77,6 @@ export function PageEnvironmentLogs() {
           environmentStatus={environmentStatus}
         />
         <Routes>
-          {/* <Route
-            path={DEPLOYMENT_LOGS_URL()}
-            element={<DeploymentLogsFeature environment={environment} statusStages={statusStages} />}
-          /> */}
           <Route
             path={DEPLOYMENT_LOGS_VERSION_URL()}
             element={<DeploymentLogsFeature environment={environment} statusStages={statusStages} />}

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.spec.tsx
@@ -83,9 +83,7 @@ describe('DeploymentLogs', () => {
       },
     ]
 
-    const { debug } = render(<DeploymentLogs {...props} />)
-
-    debug()
+    render(<DeploymentLogs {...props} />)
 
     screen.getByText(
       (content, element) => element?.textContent === 'my-app service was not deployed within this deployment execution.'

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.spec.tsx
@@ -41,13 +41,13 @@ describe('DeploymentLogs', () => {
   it('should render successfully', () => {
     const { getByText, baseElement } = render(<DeploymentLogs {...props} />)
     expect(baseElement).toBeTruthy()
-    expect(getByText('Log 1')).toBeInTheDocument()
+    getByText('Log 1')
   })
 
   it('should renders placeholder message when logs are hidden', () => {
     props.hideDeploymentLogs = true
     const { getByText } = render(<DeploymentLogs {...props} />)
 
-    expect(getByText('This service has never been deployed and thus no logs are available.')).toBeInTheDocument()
+    getByText('This service was deployed more than 30 days and thus no deployment logs are available.')
   })
 })

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -41,8 +41,8 @@ export function DeploymentLogs({
   )
 
   const displayPlaceholder = (serviceDeploymentStatus?: ServiceDeploymentStatusEnum) => {
-    switch (serviceDeploymentStatus) {
-      case ServiceDeploymentStatusEnum.NEVER_DEPLOYED:
+    if (hideDeploymentLogs) {
+      if (serviceDeploymentStatus === ServiceDeploymentStatusEnum.NEVER_DEPLOYED) {
         return (
           <div>
             <p className="mb-1">
@@ -53,7 +53,9 @@ export function DeploymentLogs({
             </p>
           </div>
         )
-      case ServiceDeploymentStatusEnum.OUT_OF_DATE:
+      } else if (logs.length === 0 && loadingStatus !== 'not loaded' && !serviceDeploymentStatus) {
+        return <LoaderSpinner className="w-6 h-6" theme="dark" />
+      } else {
         return (
           <div className="flex items-center flex-col">
             <div>
@@ -93,16 +95,17 @@ export function DeploymentLogs({
             </div>
           </div>
         )
-      default:
-        return <LoaderSpinner className="w-6 h-6" theme="dark" />
+      }
     }
+
+    return <LoaderSpinner className="w-6 h-6" theme="dark" />
   }
 
   return (
     <LayoutLogs
       data={{
         items: hideDeploymentLogs ? [] : logs,
-        loadingStatus: hideDeploymentLogs ? 'loaded' : loadingStatus,
+        loadingStatus,
       }}
       placeholderDescription={displayPlaceholder(serviceDeploymentStatus)}
       pauseLogs={pauseStatusLogs}

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -1,10 +1,10 @@
-import { EnvironmentLogs, ServiceDeploymentStatusEnum } from 'qovery-typescript-axios'
+import { DeploymentHistoryEnvironment, EnvironmentLogs, ServiceDeploymentStatusEnum } from 'qovery-typescript-axios'
 import { useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { ErrorLogsProps, LayoutLogs } from '@qovery/shared/console-shared'
 import { LoadingStatus, ServiceRunningStatus } from '@qovery/shared/interfaces'
-import { ENVIRONMENT_LOGS_URL, SERVICE_LOGS_VERSION_URL } from '@qovery/shared/routes'
-import { Link } from '@qovery/shared/ui'
+import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
+import { dateFullFormat } from '@qovery/shared/utils'
 import RowDeployment from '../row-deployment/row-deployment'
 
 export interface DeploymentLogsProps {
@@ -16,21 +16,23 @@ export interface DeploymentLogsProps {
   hideDeploymentLogs?: boolean
   serviceRunningStatus?: ServiceRunningStatus
   serviceDeploymentStatus?: ServiceDeploymentStatusEnum
+  serviceName?: string
+  dataDeploymentHistory?: DeploymentHistoryEnvironment[]
 }
 
-export function DeploymentLogs(props: DeploymentLogsProps) {
-  const {
-    logs,
-    errors,
-    hideDeploymentLogs,
-    pauseStatusLogs,
-    setPauseStatusLogs,
-    serviceRunningStatus,
-    serviceDeploymentStatus,
-    loadingStatus,
-  } = props
-
-  const { organizationId = '', projectId = '', environmentId = '', serviceId = '', versionId = '' } = useParams()
+export function DeploymentLogs({
+  logs,
+  errors,
+  hideDeploymentLogs,
+  pauseStatusLogs,
+  setPauseStatusLogs,
+  serviceRunningStatus,
+  serviceDeploymentStatus,
+  loadingStatus,
+  serviceName,
+  dataDeploymentHistory,
+}: DeploymentLogsProps) {
+  const { organizationId = '', projectId = '', environmentId = '', serviceId = '' } = useParams()
 
   const memoRow = useMemo(
     () => logs?.map((log: EnvironmentLogs, index: number) => <RowDeployment key={index} index={index} data={log} />),
@@ -40,28 +42,47 @@ export function DeploymentLogs(props: DeploymentLogsProps) {
   const displayPlaceholder = (serviceDeploymentStatus?: ServiceDeploymentStatusEnum) => {
     switch (serviceDeploymentStatus) {
       case ServiceDeploymentStatusEnum.NEVER_DEPLOYED:
-        return 'This service has never been deployed and thus no logs are available.'
+        return (
+          <div>
+            <p className="mb-1">
+              No logs on this execution for <span className="text-brand-400">{serviceName}</span>.
+            </p>
+            <p className="text-text-300 font-normal text-sm">
+              This service has never been deployed and thus no Deployment logs are available.
+            </p>
+          </div>
+        )
       default:
         return (
           <div>
-            No Deployment Logs available for this service.
-            <p>
-              Deployment Logs are available only for services deployed during the last deployment execution (
-              <span className="text-brand-400">in purple</span> within the list on the left).
+            <p className="mb-10">
+              <span className="text-brand-400">{serviceName}</span> service was not deployed within this deployment
+              execution.
             </p>
-            <p>
-              You can still access the application logs from the{' '}
-              <Link
-                className="link text-accent2-500 mr-1"
-                size="text-base"
-                link={
-                  ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-                  SERVICE_LOGS_VERSION_URL(serviceId, versionId)
-                }
-                linkLabel="Live logs"
-              />
-              tab.
-            </p>
+            <div className="bg-element-light-darker-500 border border-element-light-darker-100 rounded-lg overflow-hidden">
+              <div className="py-3 bg-element-light-darker-300 border-b border-element-light-darker-100">
+                Last deployment logs
+              </div>
+              <div className="overflow-scroll h-96 p-2">
+                {dataDeploymentHistory?.map((deploymentHistory: DeploymentHistoryEnvironment) => (
+                  <div key={deploymentHistory.id} className="pb-2 last:pb-0">
+                    <Link
+                      className="flex justify-between transition bg-element-light-darker-200 hover:bg-element-light-darker-300 w-full p-3 rounded"
+                      to={
+                        ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+                        DEPLOYMENT_LOGS_VERSION_URL(serviceId, deploymentHistory.id)
+                      }
+                    >
+                      <span className="text-brand-300 text-ssm">{deploymentHistory.id}</span>
+                      <span className="text-text-300 text-ssm">{dateFullFormat(deploymentHistory.created_at)}</span>
+                    </Link>
+                  </div>
+                ))}
+              </div>
+              <div className="flex items-center justify-center bg-element-light-darker-300 h-9 border-t border-element-light-darker-100">
+                <p className="text-text-400 text-xs font-normal">You have reached the deployment history limit</p>
+              </div>
+            </div>
           </div>
         )
     }

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from 'react-router-dom'
 import { ErrorLogsProps, LayoutLogs } from '@qovery/shared/console-shared'
 import { LoadingStatus, ServiceRunningStatus } from '@qovery/shared/interfaces'
 import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
+import { LoaderSpinner } from '@qovery/shared/ui'
 import { dateFullFormat } from '@qovery/shared/utils'
 import RowDeployment from '../row-deployment/row-deployment'
 
@@ -52,9 +53,9 @@ export function DeploymentLogs({
             </p>
           </div>
         )
-      default:
+      case ServiceDeploymentStatusEnum.OUT_OF_DATE:
         return (
-          <div className="flex justify-center flex-col">
+          <div className="flex items-center flex-col">
             <div>
               <p className="mb-1">
                 <span className="text-brand-400">{serviceName}</span> service was not deployed within this deployment
@@ -92,6 +93,8 @@ export function DeploymentLogs({
             </div>
           </div>
         )
+      default:
+        return <LoaderSpinner className="w-6 h-6" theme="dark" />
     }
   }
 

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -37,8 +37,6 @@ export function DeploymentLogs(props: DeploymentLogsProps) {
     [logs]
   )
 
-  console.log('serviceDeploymentStatus: ', serviceDeploymentStatus)
-
   const displayPlaceholder = (serviceDeploymentStatus?: ServiceDeploymentStatusEnum) => {
     switch (serviceDeploymentStatus) {
       case ServiceDeploymentStatusEnum.NEVER_DEPLOYED:

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -40,9 +40,16 @@ export function DeploymentLogs({
     [logs]
   )
 
+  const deploymentsByServiceId = mergeDeploymentServices(dataDeploymentHistory).filter(
+    (deploymentHistory) => deploymentHistory.id === serviceId
+  )
+
   const displayPlaceholder = (serviceDeploymentStatus?: ServiceDeploymentStatusEnum) => {
     if (hideDeploymentLogs) {
-      if (serviceDeploymentStatus === ServiceDeploymentStatusEnum.NEVER_DEPLOYED) {
+      if (
+        serviceDeploymentStatus === ServiceDeploymentStatusEnum.NEVER_DEPLOYED ||
+        deploymentsByServiceId.length === 0
+      ) {
         return (
           <div>
             <p className="mb-1">
@@ -72,33 +79,25 @@ export function DeploymentLogs({
                 Last deployment logs
               </div>
               <div className="overflow-y-auto max-h-96 p-2">
-                {mergeDeploymentServices(dataDeploymentHistory)?.map(
-                  (deploymentHistory: DeploymentService) =>
-                    deploymentHistory.id === serviceId && (
-                      <div
-                        key={`${deploymentHistory.id}-${deploymentHistory.id}`}
-                        className="flex items-center pb-2 last:pb-0"
-                      >
-                        <Link
-                          className={`flex justify-between transition bg-element-light-darker-200 hover:bg-element-light-darker-300 w-full p-3 rounded ${
-                            versionId === deploymentHistory.execution_id ? 'bg-element-light-darker-300' : ''
-                          }`}
-                          to={
-                            ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-                            DEPLOYMENT_LOGS_VERSION_URL(serviceId, deploymentHistory.execution_id)
-                          }
-                        >
-                          <span className="flex">
-                            <StatusChip className="mr-3 relative top-[2px]" status={deploymentHistory.status} />
-                            <span className="text-brand-300 text-ssm">
-                              {trimId(deploymentHistory.execution_id || '')}
-                            </span>
-                          </span>
-                          <span className="text-text-300 text-ssm">{dateFullFormat(deploymentHistory.created_at)}</span>
-                        </Link>
-                      </div>
-                    )
-                )}
+                {deploymentsByServiceId?.map((deploymentHistory: DeploymentService) => (
+                  <div key={deploymentHistory.execution_id} className="flex items-center pb-2 last:pb-0">
+                    <Link
+                      className={`flex justify-between transition bg-element-light-darker-200 hover:bg-element-light-darker-300 w-full p-3 rounded ${
+                        versionId === deploymentHistory.execution_id ? 'bg-element-light-darker-300' : ''
+                      }`}
+                      to={
+                        ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+                        DEPLOYMENT_LOGS_VERSION_URL(serviceId, deploymentHistory.execution_id)
+                      }
+                    >
+                      <span className="flex">
+                        <StatusChip className="mr-3 relative top-[2px]" status={deploymentHistory.status} />
+                        <span className="text-brand-300 text-ssm">{trimId(deploymentHistory.execution_id || '')}</span>
+                      </span>
+                      <span className="text-text-300 text-ssm">{dateFullFormat(deploymentHistory.created_at)}</span>
+                    </Link>
+                  </div>
+                ))}
               </div>
               <div className="flex items-center justify-center bg-element-light-darker-300 h-9 border-t border-element-light-darker-100">
                 <p className="text-text-400 text-xs font-normal">

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -4,8 +4,8 @@ import { Link, useParams } from 'react-router-dom'
 import { ErrorLogsProps, LayoutLogs } from '@qovery/shared/console-shared'
 import { LoadingStatus, ServiceRunningStatus } from '@qovery/shared/interfaces'
 import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
-import { LoaderSpinner } from '@qovery/shared/ui'
-import { dateFullFormat } from '@qovery/shared/utils'
+import { LoaderSpinner, StatusChip } from '@qovery/shared/ui'
+import { dateFullFormat, trimId } from '@qovery/shared/utils'
 import RowDeployment from '../row-deployment/row-deployment'
 
 export interface DeploymentLogsProps {
@@ -81,7 +81,8 @@ export function DeploymentLogs({
                         DEPLOYMENT_LOGS_VERSION_URL(serviceId, deploymentHistory.id)
                       }
                     >
-                      <span className="text-brand-300 text-ssm">{deploymentHistory.id}</span>
+                      <StatusChip className="mr-3" status={deploymentHistory.status} />
+                      <span className="text-brand-300 text-ssm">{trimId(deploymentHistory.id)}</span>
                       <span className="text-text-300 text-ssm">{dateFullFormat(deploymentHistory.created_at)}</span>
                     </Link>
                   </div>

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -37,6 +37,8 @@ export function DeploymentLogs(props: DeploymentLogsProps) {
     [logs]
   )
 
+  console.log('serviceDeploymentStatus: ', serviceDeploymentStatus)
+
   const displayPlaceholder = (serviceDeploymentStatus?: ServiceDeploymentStatusEnum) => {
     switch (serviceDeploymentStatus) {
       case ServiceDeploymentStatusEnum.NEVER_DEPLOYED:
@@ -47,7 +49,7 @@ export function DeploymentLogs(props: DeploymentLogsProps) {
             No Deployment Logs available for this service.
             <p>
               Deployment Logs are available only for services deployed during the last deployment execution (
-              <a className="text-brand-400">in purple</a> within the list on the left).
+              <span className="text-brand-400">in purple</span> within the list on the left).
             </p>
             <p>
               You can still access the application logs from the{' '}

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { ErrorLogsProps, LayoutLogs } from '@qovery/shared/console-shared'
 import { LoadingStatus, ServiceRunningStatus } from '@qovery/shared/interfaces'
-import { ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
+import { ENVIRONMENT_LOGS_URL, SERVICE_LOGS_VERSION_URL } from '@qovery/shared/routes'
 import { Link } from '@qovery/shared/ui'
 import RowDeployment from '../row-deployment/row-deployment'
 
@@ -30,7 +30,7 @@ export function DeploymentLogs(props: DeploymentLogsProps) {
     loadingStatus,
   } = props
 
-  const { organizationId = '', projectId = '', environmentId = '', serviceId = '' } = useParams()
+  const { organizationId = '', projectId = '', environmentId = '', serviceId = '', versionId = '' } = useParams()
 
   const memoRow = useMemo(
     () => logs?.map((log: EnvironmentLogs, index: number) => <RowDeployment key={index} index={index} data={log} />),
@@ -54,7 +54,10 @@ export function DeploymentLogs(props: DeploymentLogsProps) {
               <Link
                 className="link text-accent2-500 mr-1"
                 size="text-base"
-                link={ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + SERVICE_LOGS_URL(serviceId)}
+                link={
+                  ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+                  SERVICE_LOGS_VERSION_URL(serviceId, versionId)
+                }
                 linkLabel="Live logs"
               />
               tab.

--- a/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/deployment-logs/deployment-logs.tsx
@@ -48,18 +48,23 @@ export function DeploymentLogs({
               No logs on this execution for <span className="text-brand-400">{serviceName}</span>.
             </p>
             <p className="text-text-300 font-normal text-sm">
-              This service has never been deployed and thus no Deployment logs are available.
+              This service was deployed more than 30 days and thus no deployment logs are available.
             </p>
           </div>
         )
       default:
         return (
-          <div>
-            <p className="mb-10">
-              <span className="text-brand-400">{serviceName}</span> service was not deployed within this deployment
-              execution.
-            </p>
-            <div className="bg-element-light-darker-500 border border-element-light-darker-100 rounded-lg overflow-hidden">
+          <div className="flex justify-center flex-col">
+            <div>
+              <p className="mb-1">
+                <span className="text-brand-400">{serviceName}</span> service was not deployed within this deployment
+                execution.
+              </p>
+              <p className="text-text-300 font-normal text-sm mb-10">
+                Below the list of executions where this service was deployed.
+              </p>
+            </div>
+            <div className="bg-element-light-darker-500 border border-element-light-darker-100 rounded-lg overflow-hidden w-[484px]">
               <div className="py-3 bg-element-light-darker-300 border-b border-element-light-darker-100">
                 Last deployment logs
               </div>
@@ -80,7 +85,9 @@ export function DeploymentLogs({
                 ))}
               </div>
               <div className="flex items-center justify-center bg-element-light-darker-300 h-9 border-t border-element-light-darker-100">
-                <p className="text-text-400 text-xs font-normal">You have reached the deployment history limit</p>
+                <p className="text-text-400 text-xs font-normal">
+                  Only the last 20 deployments of the environment over the last 30 days are available.
+                </p>
               </div>
             </div>
           </div>

--- a/libs/pages/logs/environment/src/lib/ui/row-deployment/row-deployment.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/row-deployment/row-deployment.tsx
@@ -44,7 +44,7 @@ export function RowDeployment(props: RowDeploymentProps) {
         <div className="text-right w-10 h-6 py-1 px-2 font-code">{index + 1}</div>
       </div>
       <div data-testid="cell-date" className={`py-1 pl-2 pr-3 font-code shrink-0 w-[158px] ${colorsCellClassName()}`}>
-        {dateFullFormat(data.timestamp, utc ? 'UTC' : undefined)}
+        {dateFullFormat(data.timestamp, utc ? 'UTC' : undefined, 'dd MMM, HH:mm:ss:SS')}
       </div>
       <div
         data-testid="cell-msg"

--- a/libs/pages/logs/environment/src/lib/ui/row-pod/row-pod.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/row-pod/row-pod.tsx
@@ -105,7 +105,7 @@ export function RowPod(props: RowPodProps) {
           )}
         </div>
         <div data-testid="cell-date" className="px-4 pt-0.5 text-element-light-lighter-700 whitespace-nowrap">
-          {dateFullFormat(data.created_at, utc ? 'UTC' : undefined)}
+          {dateFullFormat(data.created_at, utc ? 'UTC' : undefined, 'dd MMM, HH:mm:ss:SS')}
         </div>
         <div data-testid="cell-msg" className="select-text pr-6 pt-0.5 text-text-100 relative w-full">
           <span className="whitespace-pre-wrap break-all">{convertToAnsi(data.message)}</span>

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react'
+import SidebarHistory from './sidebar-history'
+
+describe('SidebarHistory', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<SidebarHistory />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.spec.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.spec.tsx
@@ -1,9 +1,68 @@
-import { render } from '@testing-library/react'
-import SidebarHistory from './sidebar-history'
+import { render, screen } from '__tests__/utils/setup-jest'
+import { ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
+import { renderWithProviders } from '@qovery/shared/util-tests'
+import { dateFullFormat, trimId } from '@qovery/shared/utils'
+import SidebarHistory, { SidebarHistoryProps } from './sidebar-history'
+
+const currentDate = new Date().toString()
+const mockNavigate = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}))
 
 describe('SidebarHistory', () => {
+  const props: SidebarHistoryProps = {
+    data: [
+      {
+        id: '1',
+        created_at: currentDate,
+        applications: [
+          {
+            id: '4',
+            created_at: currentDate,
+            name: 'my-app',
+          },
+        ],
+      },
+      {
+        id: '2',
+        created_at: currentDate,
+        applications: [
+          {
+            id: '4',
+            created_at: currentDate,
+            name: 'my-app',
+          },
+        ],
+      },
+    ],
+    pathLogs: ENVIRONMENT_LOGS_URL('1', '2', '3'),
+    serviceId: '4',
+    versionId: '5',
+  }
+
   it('should render successfully', () => {
-    const { baseElement } = render(<SidebarHistory />)
+    const { baseElement } = render(<SidebarHistory {...props} />)
     expect(baseElement).toBeTruthy()
+  })
+
+  it('should display the current deployment with date', () => {
+    render(<SidebarHistory {...props} />)
+
+    screen.getByText(`Deployment - ${dateFullFormat(currentDate)}`)
+  })
+
+  it('should open the menu and navigate to the logs page', async () => {
+    const { userEvent } = renderWithProviders(<SidebarHistory {...props} />)
+
+    const btn = screen.getByRole('button')
+    await userEvent.click(btn)
+
+    const item = screen.getByText(trimId(props.data[1].id))
+    await userEvent.click(item)
+
+    expect(mockNavigate).toHaveBeenCalledWith('/organization/1/project/2/environment/3/logs/4/deployment-logs/2')
   })
 })

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
@@ -1,0 +1,65 @@
+import { DeploymentHistoryEnvironment } from 'qovery-typescript-axios'
+import { useState } from 'react'
+import { DEPLOYMENT_LOGS_VERSION_URL } from '@qovery/shared/routes'
+import { Icon, IconAwesomeEnum, Menu, MenuData, StatusChip } from '@qovery/shared/ui'
+
+export interface SidebarHistoryProps {
+  data: DeploymentHistoryEnvironment[]
+  pathLogs: string
+  serviceId: string
+  versionId: string
+}
+
+export function SidebarHistory({ data, serviceId, versionId, pathLogs }: SidebarHistoryProps) {
+  const [open, setOpen] = useState(false)
+
+  const menuHistory: MenuData = [
+    {
+      items:
+        data?.map((item) => ({
+          name: item.id,
+          itemContentCustom: (
+            <div
+              className={`flex justify-between w-full py-2 text-xs ${
+                item.id === versionId ? 'text-brand-400' : 'text-text-100'
+              }`}
+            >
+              <StatusChip status={item.status} />
+              {item.id}
+            </div>
+          ),
+          link: {
+            url: pathLogs + DEPLOYMENT_LOGS_VERSION_URL(serviceId, item.id),
+          },
+        })) || [],
+    },
+  ]
+
+  const currentIndex = (data?.findIndex((item) => item.id === versionId) || 0) + 1
+
+  return (
+    <div className="flex justify-center border-b border-element-light-darker-100 px-4 py-3">
+      <div>
+        <Menu
+          menus={menuHistory}
+          onOpen={(isOpen) => setOpen(isOpen)}
+          trigger={
+            <div
+              role="button"
+              className={`text-xs font-medium hover:text-brand-400 transition ${
+                open ? 'text-brand-400' : 'text-text-100'
+              }`}
+            >
+              <span className="inline-block mr-1">
+                Deployment - {currentIndex}/{data.length}
+              </span>{' '}
+              <Icon name={IconAwesomeEnum.ANGLE_DOWN} />
+            </div>
+          }
+        />
+      </div>
+    </div>
+  )
+}
+
+export default SidebarHistory

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
@@ -1,8 +1,8 @@
 import { DeploymentHistoryEnvironment } from 'qovery-typescript-axios'
 import { useState } from 'react'
 import { DEPLOYMENT_LOGS_VERSION_URL } from '@qovery/shared/routes'
-import { Icon, IconAwesomeEnum, Menu, MenuAlign, MenuData, StatusChip } from '@qovery/shared/ui'
-import { dateFullFormat } from '@qovery/shared/utils'
+import { Icon, IconAwesomeEnum, Menu, MenuAlign, MenuData, StatusChip, Tooltip } from '@qovery/shared/ui'
+import { dateFullFormat, trimId } from '@qovery/shared/utils'
 
 export interface SidebarHistoryProps {
   data: DeploymentHistoryEnvironment[]
@@ -22,11 +22,16 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
           itemContentCustom: (
             <div
               className={`flex justify-between w-full py-2 text-xs ${
-                item.id === versionId ? 'text-brand-400' : 'text-text-100'
+                item.id === versionId ? 'text-brand-400' : 'text-text-300'
               }`}
             >
-              <StatusChip status={item.status} />
-              {item.id}
+              <div className="flex">
+                <StatusChip className="mr-3" status={item.status} />
+                <Tooltip content={item.id}>
+                  <p className="font-medium text-brand-300">{trimId(item.id)}</p>
+                </Tooltip>
+              </div>
+              <div>{dateFullFormat(item.created_at)}</div>
             </div>
           ),
           link: {
@@ -42,6 +47,7 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
     <div className="flex justify-center border-b border-element-light-darker-100 px-4 py-3">
       <div>
         <Menu
+          width={300}
           menus={menuHistory}
           arrowAlign={MenuAlign.CENTER}
           onOpen={(isOpen) => setOpen(isOpen)}

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
@@ -8,7 +8,7 @@ export interface SidebarHistoryProps {
   data: DeploymentHistoryEnvironment[]
   pathLogs: string
   serviceId: string
-  versionId: string
+  versionId?: string
 }
 
 export function SidebarHistory({ data, serviceId, versionId, pathLogs }: SidebarHistoryProps) {

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
@@ -37,7 +37,7 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
           link: {
             url: pathLogs + DEPLOYMENT_LOGS_VERSION_URL(serviceId, item.id),
           },
-        })) ?? [],
+        })) || [],
     },
   ]
 

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
@@ -1,7 +1,8 @@
 import { DeploymentHistoryEnvironment } from 'qovery-typescript-axios'
 import { useState } from 'react'
 import { DEPLOYMENT_LOGS_VERSION_URL } from '@qovery/shared/routes'
-import { Icon, IconAwesomeEnum, Menu, MenuData, StatusChip } from '@qovery/shared/ui'
+import { Icon, IconAwesomeEnum, Menu, MenuAlign, MenuData, StatusChip } from '@qovery/shared/ui'
+import { dateFullFormat } from '@qovery/shared/utils'
 
 export interface SidebarHistoryProps {
   data: DeploymentHistoryEnvironment[]
@@ -31,7 +32,7 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
           link: {
             url: pathLogs + DEPLOYMENT_LOGS_VERSION_URL(serviceId, item.id),
           },
-        })) || [],
+        })) ?? [],
     },
   ]
 
@@ -42,6 +43,7 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
       <div>
         <Menu
           menus={menuHistory}
+          arrowAlign={MenuAlign.CENTER}
           onOpen={(isOpen) => setOpen(isOpen)}
           trigger={
             <div
@@ -50,9 +52,7 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
                 open ? 'text-brand-400' : 'text-text-100'
               }`}
             >
-              <span className="inline-block mr-1">
-                Deployment - {currentIndex}/{data.length}
-              </span>{' '}
+              <span className="inline-block mr-1">Deployment - {dateFullFormat(data?.[currentIndex].created_at)}</span>
               <Icon name={IconAwesomeEnum.ANGLE_DOWN} />
             </div>
           }

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
@@ -17,12 +17,12 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
   const menuHistory: MenuData = [
     {
       items:
-        data?.map((item) => ({
+        data?.map((item, index) => ({
           name: item.id,
           itemContentCustom: (
             <div
               className={`flex justify-between w-full py-2 text-xs ${
-                item.id === versionId ? 'text-brand-400' : 'text-text-300'
+                item.id === versionId || (!versionId && index === 0) ? 'text-brand-400' : 'text-text-300'
               }`}
             >
               <div className="flex">

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-history/sidebar-history.tsx
@@ -41,7 +41,7 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
     },
   ]
 
-  const currentIndex = (data?.findIndex((item) => item.id === versionId) || 0) + 1
+  const currentIndex = data?.findIndex((item) => item.id === versionId)
 
   return (
     <div className="flex justify-center border-b border-element-light-darker-100 px-4 py-3">
@@ -58,7 +58,9 @@ export function SidebarHistory({ data, serviceId, versionId, pathLogs }: Sidebar
                 open ? 'text-brand-400' : 'text-text-100'
               }`}
             >
-              <span className="inline-block mr-1">Deployment - {dateFullFormat(data?.[currentIndex].created_at)}</span>
+              <span className="inline-block mr-1">
+                Deployment - {dateFullFormat(data?.[currentIndex === -1 ? 0 : currentIndex]?.created_at)}
+              </span>
               <Icon name={IconAwesomeEnum.ANGLE_DOWN} />
             </div>
           }

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline-item/sidebar-pipeline-item.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline-item/sidebar-pipeline-item.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { RunningStatus, getServiceType } from '@qovery/shared/enums'
 import { ApplicationEntity, DatabaseEntity } from '@qovery/shared/interfaces'
-import { DEPLOYMENT_LOGS_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
+import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
 import { BadgeDeploymentOrder, BadgeService, Icon, IconAwesomeEnum, StatusChip } from '@qovery/shared/ui'
 import { ServiceStageIdsContext } from '../../feature/service-stage-ids-context/service-stage-ids-context'
 
@@ -15,13 +15,13 @@ export function mergeServices(applications?: Status[], databases?: Status[], con
 
 export interface SidebarPipelineItemProps {
   serviceId: string
+  versionId: string
   index: number
   services: Array<ApplicationEntity | DatabaseEntity>
   currentStage: DeploymentStageWithServicesStatuses
 }
 
-export function SidebarPipelineItem(props: SidebarPipelineItemProps) {
-  const { currentStage, index, serviceId, services } = props
+export function SidebarPipelineItem({ currentStage, index, serviceId, versionId, services }: SidebarPipelineItemProps) {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
   const { updateStageId } = useContext(ServiceStageIdsContext)
 
@@ -69,7 +69,8 @@ export function SidebarPipelineItem(props: SidebarPipelineItemProps) {
                   <Link
                     key={service.id}
                     to={
-                      ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + DEPLOYMENT_LOGS_URL(service.id)
+                      ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+                      DEPLOYMENT_LOGS_VERSION_URL(service.id, versionId)
                     }
                     className={`flex justify-between items-center w-full text-ssm transition-all font-medium py-1.5 px-2.5 hover:text-text-100 rounded-[3px] ${
                       serviceId === service.id

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline-item/sidebar-pipeline-item.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline-item/sidebar-pipeline-item.tsx
@@ -70,7 +70,7 @@ export function SidebarPipelineItem({ currentStage, index, serviceId, versionId,
                     key={service.id}
                     to={
                       ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-                      DEPLOYMENT_LOGS_VERSION_URL(service.id, versionId === ':versionId' ? '' : versionId)
+                      DEPLOYMENT_LOGS_VERSION_URL(service.id, versionId ? versionId : '')
                     }
                     className={`flex justify-between items-center w-full text-ssm transition-all font-medium py-1.5 px-2.5 hover:text-text-100 rounded-[3px] ${
                       serviceId === service.id

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline-item/sidebar-pipeline-item.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline-item/sidebar-pipeline-item.tsx
@@ -14,11 +14,11 @@ export function mergeServices(applications?: Status[], databases?: Status[], con
 }
 
 export interface SidebarPipelineItemProps {
-  serviceId: string
-  versionId: string
   index: number
   services: Array<ApplicationEntity | DatabaseEntity>
   currentStage: DeploymentStageWithServicesStatuses
+  serviceId?: string
+  versionId?: string
 }
 
 export function SidebarPipelineItem({ currentStage, index, serviceId, versionId, services }: SidebarPipelineItemProps) {
@@ -70,7 +70,7 @@ export function SidebarPipelineItem({ currentStage, index, serviceId, versionId,
                     key={service.id}
                     to={
                       ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-                      DEPLOYMENT_LOGS_VERSION_URL(service.id, versionId)
+                      DEPLOYMENT_LOGS_VERSION_URL(service.id, versionId === ':versionId' ? '' : versionId)
                     }
                     className={`flex justify-between items-center w-full text-ssm transition-all font-medium py-1.5 px-2.5 hover:text-text-100 rounded-[3px] ${
                       serviceId === service.id

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline/sidebar-pipeline.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline/sidebar-pipeline.tsx
@@ -4,12 +4,12 @@ import SidebarPipelineItem from '../sidebar-pipeline-item/sidebar-pipeline-item'
 
 export interface SidebarPipelineProps {
   services: Array<ApplicationEntity | DatabaseEntity>
-  serviceId: string
-  versionId: string
+  serviceId?: string
+  versionId?: string
   statusStages?: DeploymentStageWithServicesStatuses[]
 }
 
-export function SidebarPipeline({ serviceId, services, versionId, statusStages }: SidebarPipelineProps) {
+export function SidebarPipeline({ services, versionId, serviceId, statusStages }: SidebarPipelineProps) {
   return (
     <div className="p-5">
       <p className="text-text-100 text-xs mb-4 font-medium">Pipeline</p>
@@ -17,8 +17,8 @@ export function SidebarPipeline({ serviceId, services, versionId, statusStages }
         <SidebarPipelineItem
           key={index}
           index={index}
-          serviceId={serviceId}
           versionId={versionId}
+          serviceId={serviceId}
           currentStage={currentStage}
           services={services}
         />

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline/sidebar-pipeline.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline/sidebar-pipeline.tsx
@@ -5,12 +5,11 @@ import SidebarPipelineItem from '../sidebar-pipeline-item/sidebar-pipeline-item'
 export interface SidebarPipelineProps {
   services: Array<ApplicationEntity | DatabaseEntity>
   serviceId: string
+  versionId: string
   statusStages?: DeploymentStageWithServicesStatuses[]
 }
 
-export function SidebarPipeline(props: SidebarPipelineProps) {
-  const { serviceId, services, statusStages } = props
-
+export function SidebarPipeline({ serviceId, services, versionId, statusStages }: SidebarPipelineProps) {
   return (
     <div className="p-5">
       <p className="text-text-100 text-xs mb-4 font-medium">Pipeline</p>
@@ -19,6 +18,7 @@ export function SidebarPipeline(props: SidebarPipelineProps) {
           key={index}
           index={index}
           serviceId={serviceId}
+          versionId={versionId}
           currentStage={currentStage}
           services={services}
         />

--- a/libs/pages/logs/environment/src/lib/ui/sidebar-status/sidebar-status.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-status/sidebar-status.tsx
@@ -15,7 +15,7 @@ export function SidebarStatus(props: SidebarStatusProps) {
         Deployment status:
         <StatusChip status={environmentStatus?.last_deployment_state || environmentStatus?.state} />
       </div>
-      <p className="flex items-center justify-between text-text-300 text-xs mb-2">
+      <div className="flex items-center justify-between text-text-300 text-xs mb-2">
         Deployment Execution id:
         <Tooltip content={environmentStatus?.last_deployment_id || ''}>
           <span className="text-brand-400">
@@ -27,7 +27,7 @@ export function SidebarStatus(props: SidebarStatusProps) {
               : environmentStatus?.last_deployment_id}
           </span>
         </Tooltip>
-      </p>
+      </div>
       {environmentStatus?.last_deployment_date && (
         <p className="flex items-center justify-between text-text-300 text-xs">
           Deployment start time:

--- a/libs/pages/logs/environment/src/lib/ui/sidebar/sidebar.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar/sidebar.tsx
@@ -3,10 +3,9 @@ import {
   DeploymentStageWithServicesStatuses,
   EnvironmentStatus,
 } from 'qovery-typescript-axios'
-import { useContext, useState } from 'react'
+import { useState } from 'react'
 import { ApplicationEntity, DatabaseEntity } from '@qovery/shared/interfaces'
 import { Icon, IconAwesomeEnum } from '@qovery/shared/ui'
-import { ServiceStageIdsContext } from '../../feature/service-stage-ids-context/service-stage-ids-context'
 import SidebarHistoryFeature from '../../feature/sidebar-history-feature/sidebar-history-feature'
 import SidebarPipeline from '../sidebar-pipeline/sidebar-pipeline'
 import SidebarStatus from '../sidebar-status/sidebar-status'
@@ -17,11 +16,18 @@ export interface SidebarProps {
   environmentStatus?: EnvironmentStatus
   environmentDeploymentHistory?: DeploymentHistoryEnvironment
   clusterBanner?: boolean
+  versionId?: string
+  serviceId?: string
 }
 
-export function Sidebar({ services, statusStages, environmentStatus, clusterBanner }: SidebarProps) {
-  const { serviceId, versionId } = useContext(ServiceStageIdsContext)
-
+export function Sidebar({
+  services,
+  statusStages,
+  environmentStatus,
+  clusterBanner,
+  versionId,
+  serviceId,
+}: SidebarProps) {
   const [openSidebar, setOpenSidebar] = useState(true)
 
   return (
@@ -30,7 +36,7 @@ export function Sidebar({ services, statusStages, environmentStatus, clusterBann
       ${clusterBanner ? 'h-[calc(100vh-8rem)]' : 'h-[calc(100vh-4rem)]'} ${openSidebar ? 'w-[340px]' : 'w-5'}`}
     >
       <div data-testid="sidebar" className={`w-full h-full overflow-x-scroll ${!openSidebar ? 'hidden' : ''}`}>
-        <SidebarHistoryFeature />
+        <SidebarHistoryFeature serviceId={serviceId} versionId={versionId} />
         <SidebarStatus environmentStatus={environmentStatus} />
         <SidebarPipeline services={services} versionId={versionId} serviceId={serviceId} statusStages={statusStages} />
       </div>

--- a/libs/pages/logs/environment/src/lib/ui/sidebar/sidebar.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar/sidebar.tsx
@@ -7,6 +7,7 @@ import { useContext, useState } from 'react'
 import { ApplicationEntity, DatabaseEntity } from '@qovery/shared/interfaces'
 import { Icon, IconAwesomeEnum } from '@qovery/shared/ui'
 import { ServiceStageIdsContext } from '../../feature/service-stage-ids-context/service-stage-ids-context'
+import SidebarHistoryFeature from '../../feature/sidebar-history-feature/sidebar-history-feature'
 import SidebarPipeline from '../sidebar-pipeline/sidebar-pipeline'
 import SidebarStatus from '../sidebar-status/sidebar-status'
 
@@ -31,6 +32,7 @@ export function Sidebar(props: SidebarProps) {
       ${clusterBanner ? 'h-[calc(100vh-8rem)]' : 'h-[calc(100vh-4rem)]'} ${openSidebar ? 'w-[340px]' : 'w-5'}`}
     >
       <div data-testid="sidebar" className={`w-full h-full overflow-x-scroll ${!openSidebar ? 'hidden' : ''}`}>
+        <SidebarHistoryFeature />
         <SidebarStatus environmentStatus={environmentStatus} />
         <SidebarPipeline services={services} serviceId={serviceId} statusStages={statusStages} />
       </div>

--- a/libs/pages/logs/environment/src/lib/ui/sidebar/sidebar.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar/sidebar.tsx
@@ -19,10 +19,8 @@ export interface SidebarProps {
   clusterBanner?: boolean
 }
 
-export function Sidebar(props: SidebarProps) {
-  const { services, statusStages, environmentStatus, clusterBanner } = props
-
-  const { serviceId } = useContext(ServiceStageIdsContext)
+export function Sidebar({ services, statusStages, environmentStatus, clusterBanner }: SidebarProps) {
+  const { serviceId, versionId } = useContext(ServiceStageIdsContext)
 
   const [openSidebar, setOpenSidebar] = useState(true)
 
@@ -34,7 +32,7 @@ export function Sidebar(props: SidebarProps) {
       <div data-testid="sidebar" className={`w-full h-full overflow-x-scroll ${!openSidebar ? 'hidden' : ''}`}>
         <SidebarHistoryFeature />
         <SidebarStatus environmentStatus={environmentStatus} />
-        <SidebarPipeline services={services} serviceId={serviceId} statusStages={statusStages} />
+        <SidebarPipeline services={services} versionId={versionId} serviceId={serviceId} statusStages={statusStages} />
       </div>
       <div
         data-testid="sidebar-resize-button"

--- a/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
+++ b/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
@@ -11,7 +11,7 @@ import { Link, useLocation, useParams } from 'react-router-dom'
 import { RunningStatus } from '@qovery/shared/enums'
 import { LoadingStatus, ServiceRunningStatus } from '@qovery/shared/interfaces'
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { DEPLOYMENT_LOGS_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
+import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
 import { Icon, IconAwesomeEnum, IconFa, InputCheckbox, LoaderSpinner, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { scrollParentToChild } from '@qovery/shared/utils'
 import ButtonsActionsLogs from './buttons-actions-logs/buttons-actions-logs'
@@ -69,7 +69,9 @@ export function LayoutLogs(props: PropsWithChildren<LayoutLogsProps>) {
   const refScrollSection = useRef<HTMLDivElement>(null)
   const [updateTimeContextValue, setUpdateTimeContext] = useState(defaultUpdateTimeContext)
 
-  const { organizationId = '', projectId = '', environmentId = '', serviceId = '' } = useParams()
+  const { organizationId = '', projectId = '', environmentId = '', serviceId = '', versionId = '' } = useParams()
+
+  console.log(versionId)
 
   const scrollToError = () => {
     const section = refScrollSection.current
@@ -116,7 +118,8 @@ export function LayoutLogs(props: PropsWithChildren<LayoutLogsProps>) {
         <div className="absolute z-20 overflow-y-auto left-1 flex items-center w-[calc(100%-8px)] h-11 border-b border-element-light-darker-200 bg-element-light-darker-700">
           {LinkNavigation(
             'Deployment logs',
-            ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + DEPLOYMENT_LOGS_URL(serviceId),
+            ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+              DEPLOYMENT_LOGS_VERSION_URL(serviceId, versionId),
             undefined,
             false
           )}

--- a/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
+++ b/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
@@ -11,7 +11,7 @@ import { Link, useLocation, useParams } from 'react-router-dom'
 import { RunningStatus } from '@qovery/shared/enums'
 import { LoadingStatus, ServiceRunningStatus } from '@qovery/shared/interfaces'
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
+import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_VERSION_URL } from '@qovery/shared/routes'
 import { Icon, IconAwesomeEnum, IconFa, InputCheckbox, LoaderSpinner, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { scrollParentToChild } from '@qovery/shared/utils'
 import ButtonsActionsLogs from './buttons-actions-logs/buttons-actions-logs'
@@ -71,8 +71,6 @@ export function LayoutLogs(props: PropsWithChildren<LayoutLogsProps>) {
 
   const { organizationId = '', projectId = '', environmentId = '', serviceId = '', versionId = '' } = useParams()
 
-  console.log(versionId)
-
   const scrollToError = () => {
     const section = refScrollSection.current
     if (!section) return
@@ -125,23 +123,19 @@ export function LayoutLogs(props: PropsWithChildren<LayoutLogsProps>) {
           )}
           {LinkNavigation(
             'Live logs',
-            ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + SERVICE_LOGS_URL(serviceId),
+            ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+              SERVICE_LOGS_VERSION_URL(serviceId, versionId),
             serviceRunningStatus
           )}
         </div>
       )}
       {!data || data.items?.length === 0 || data?.loadingStatus === 'not loaded' ? (
-        <div data-testid="loading-screen" className="mt-[100px] w-full flex justify-center text-center">
+        <div data-testid="loading-screen" className="mt-[88px] w-full flex justify-center text-center">
           {data?.loadingStatus === 'not loaded' || !data ? (
             <LoaderSpinner className="w-6 h-6" theme="dark" />
           ) : (
             <div className="flex flex-col items-center">
-              <img
-                className="w-40 pointer-events-none user-none"
-                src="/assets/images/event-placeholder-dark.svg"
-                alt="Event placeholder"
-              />
-              <div className="mt-5 text-text-100 font-medium text-center">{placeholderDescription}</div>
+              <div className="text-text-100 font-medium text-center">{placeholderDescription}</div>
             </div>
           )}
         </div>
@@ -190,7 +184,8 @@ export function LayoutLogs(props: PropsWithChildren<LayoutLogsProps>) {
             </div>
             <div className="flex">
               {location.pathname.includes(
-                ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + SERVICE_LOGS_URL(serviceId)
+                ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+                  SERVICE_LOGS_VERSION_URL(serviceId, versionId)
               ) && (
                 <MenuTimeFormat
                   updateTimeContextValue={updateTimeContextValue}

--- a/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
+++ b/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
@@ -117,7 +117,7 @@ export function LayoutLogs(props: PropsWithChildren<LayoutLogsProps>) {
           {LinkNavigation(
             'Deployment logs',
             ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-              DEPLOYMENT_LOGS_VERSION_URL(serviceId, versionId !== ':versionId' ? '' : versionId),
+              DEPLOYMENT_LOGS_VERSION_URL(serviceId, versionId),
             undefined,
             false
           )}

--- a/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
+++ b/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
@@ -11,7 +11,7 @@ import { Link, useLocation, useParams } from 'react-router-dom'
 import { RunningStatus } from '@qovery/shared/enums'
 import { LoadingStatus, ServiceRunningStatus } from '@qovery/shared/interfaces'
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_VERSION_URL } from '@qovery/shared/routes'
+import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
 import { Icon, IconAwesomeEnum, IconFa, InputCheckbox, LoaderSpinner, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { scrollParentToChild } from '@qovery/shared/utils'
 import ButtonsActionsLogs from './buttons-actions-logs/buttons-actions-logs'
@@ -117,14 +117,13 @@ export function LayoutLogs(props: PropsWithChildren<LayoutLogsProps>) {
           {LinkNavigation(
             'Deployment logs',
             ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-              DEPLOYMENT_LOGS_VERSION_URL(serviceId, versionId),
+              DEPLOYMENT_LOGS_VERSION_URL(serviceId, versionId !== ':versionId' ? '' : versionId),
             undefined,
             false
           )}
           {LinkNavigation(
             'Live logs',
-            ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-              SERVICE_LOGS_VERSION_URL(serviceId, versionId),
+            ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + SERVICE_LOGS_URL(serviceId),
             serviceRunningStatus
           )}
         </div>
@@ -184,8 +183,7 @@ export function LayoutLogs(props: PropsWithChildren<LayoutLogsProps>) {
             </div>
             <div className="flex">
               {location.pathname.includes(
-                ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-                  SERVICE_LOGS_VERSION_URL(serviceId, versionId)
+                ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + SERVICE_LOGS_URL(serviceId)
               ) && (
                 <MenuTimeFormat
                   updateTimeContextValue={updateTimeContextValue}

--- a/libs/shared/routes/src/lib/sub-router/logs.router.ts
+++ b/libs/shared/routes/src/lib/sub-router/logs.router.ts
@@ -11,6 +11,9 @@ export const ENVIRONMENT_LOGS_URL = (
 
 export const SERVICE_LOGS_URL = (serviceId = ':serviceId') => `/${serviceId}/live-logs`
 
+export const SERVICE_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId') =>
+  `/${serviceId}/live-logs/${versionId}`
+
 export const DEPLOYMENT_LOGS_URL = (serviceId = ':serviceId') => `/${serviceId}/deployment-logs`
 
 export const DEPLOYMENT_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId') =>

--- a/libs/shared/routes/src/lib/sub-router/logs.router.ts
+++ b/libs/shared/routes/src/lib/sub-router/logs.router.ts
@@ -11,10 +11,10 @@ export const ENVIRONMENT_LOGS_URL = (
 
 export const SERVICE_LOGS_URL = (serviceId = ':serviceId') => `/${serviceId}/live-logs`
 
-export const SERVICE_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId') =>
+export const SERVICE_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId?') =>
   `/${serviceId}/live-logs/${versionId}`
 
 export const DEPLOYMENT_LOGS_URL = (serviceId = ':serviceId') => `/${serviceId}/deployment-logs`
 
-export const DEPLOYMENT_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId') =>
+export const DEPLOYMENT_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId?') =>
   `/${serviceId}/deployment-logs/${versionId}`

--- a/libs/shared/routes/src/lib/sub-router/logs.router.ts
+++ b/libs/shared/routes/src/lib/sub-router/logs.router.ts
@@ -11,10 +11,7 @@ export const ENVIRONMENT_LOGS_URL = (
 
 export const SERVICE_LOGS_URL = (serviceId = ':serviceId') => `/${serviceId}/live-logs`
 
-export const SERVICE_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId?') =>
-  `/${serviceId}/live-logs/${versionId}`
-
 export const DEPLOYMENT_LOGS_URL = (serviceId = ':serviceId') => `/${serviceId}/deployment-logs`
 
-export const DEPLOYMENT_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId?') =>
+export const DEPLOYMENT_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId') =>
   `/${serviceId}/deployment-logs/${versionId}`

--- a/libs/shared/routes/src/lib/sub-router/logs.router.ts
+++ b/libs/shared/routes/src/lib/sub-router/logs.router.ts
@@ -12,3 +12,6 @@ export const ENVIRONMENT_LOGS_URL = (
 export const SERVICE_LOGS_URL = (serviceId = ':serviceId') => `/${serviceId}/live-logs`
 
 export const DEPLOYMENT_LOGS_URL = (serviceId = ':serviceId') => `/${serviceId}/deployment-logs`
+
+export const DEPLOYMENT_LOGS_VERSION_URL = (serviceId = ':serviceId', versionId = ':versionId') =>
+  `/${serviceId}/deployment-logs/${versionId}`

--- a/libs/shared/ui/src/lib/components/menu/menu.spec.tsx
+++ b/libs/shared/ui/src/lib/components/menu/menu.spec.tsx
@@ -88,17 +88,6 @@ describe('Menu', () => {
     expect(menu.classList.contains('szh-menu--dir-right')).toBe(true)
   })
 
-  it('should have accurate classname', () => {
-    props.open = true
-    props.className = 'some-class-name'
-
-    render(<Menu {...props} />)
-
-    const menu = screen.getByRole('menu')
-
-    expect(menu.classList.contains('some-class-name')).toBe(true)
-  })
-
   it('should an item have an icon', () => {
     props.menus = [
       {

--- a/libs/shared/ui/src/lib/components/menu/menu.tsx
+++ b/libs/shared/ui/src/lib/components/menu/menu.tsx
@@ -145,9 +145,9 @@ export function Menu(props: MenuProps) {
         anchorRef={ref}
         align={arrowAlign}
         className="menu z-20"
-        menuClassName={`rounded-md shadow-[0_0_32px_rgba(0,0,0,0.08)] p-0 ${className} menu__container menu__container--${direction} menu__container--${
+        menuClassName={`rounded-md shadow-[0_0_32px_rgba(0,0,0,0.08)] p-0 menu__container menu__container--${direction} menu__container--${
           isOpen ? 'open' : 'closed'
-        } menu__container--${arrowAlign}`}
+        } menu__container--${arrowAlign} dark:bg-element-light-darker-500`}
         portal
       >
         {children}

--- a/libs/shared/ui/src/lib/components/menu/menu.tsx
+++ b/libs/shared/ui/src/lib/components/menu/menu.tsx
@@ -144,7 +144,7 @@ export function Menu(props: MenuProps) {
         onClose={(e) => handleClick(e)}
         anchorRef={ref}
         align={arrowAlign}
-        className="menu z-20"
+        className="menu z-30"
         menuClassName={`rounded-md shadow-[0_0_32px_rgba(0,0,0,0.08)] p-0 menu__container menu__container--${direction} menu__container--${
           isOpen ? 'open' : 'closed'
         } menu__container--${arrowAlign} dark:bg-element-light-darker-500`}

--- a/libs/shared/ui/src/lib/styles/components/menu.scss
+++ b/libs/shared/ui/src/lib/styles/components/menu.scss
@@ -90,7 +90,7 @@ $menuTiming: 0.6s;
 .dark {
   .menu__container,
   .szh-menu__arrow {
-    background: theme('colors.element.light.darker.400');
+    background: theme('colors.element.light.darker.500');
   }
   .menu-item {
     &.szh-menu__item--hover:not(.text-error-600),

--- a/libs/shared/utils/src/lib/tools/date.spec.ts
+++ b/libs/shared/utils/src/lib/tools/date.spec.ts
@@ -1,0 +1,19 @@
+import * as formatModule from 'date-fns-tz'
+import { dateFullFormat } from './date'
+
+describe('date', () => {
+  it('dateFullFormat', () => {
+    // Mock Date.now() to return a fixed timestamp for consistent testing
+    Date.now = jest.fn(() => new Date('2023-09-15T10:23:20').getTime())
+
+    // Mock the formatInTimeZone function using jest.spyOn and mockImplementation
+    const mockFormatInTimeZone = jest.spyOn(formatModule, 'formatInTimeZone')
+    mockFormatInTimeZone.mockImplementation(() => '15 Sep, 10:23:20')
+
+    const resultDefault = dateFullFormat('2023-09-15T10:23:20')
+    const resultCustomFormat = dateFullFormat('2023-09-15T10:23:20', 'Europe/Paris', 'dd/MM/yyyy HH:mm')
+
+    expect(resultDefault).toBe('15 Sep, 10:23:20')
+    expect(resultCustomFormat).toBe('15/09/2023 10:23')
+  })
+})

--- a/libs/shared/utils/src/lib/tools/date.spec.ts
+++ b/libs/shared/utils/src/lib/tools/date.spec.ts
@@ -3,10 +3,8 @@ import { dateFullFormat } from './date'
 
 describe('date', () => {
   it('dateFullFormat', () => {
-    // Mock Date.now() to return a fixed timestamp for consistent testing
     Date.now = jest.fn(() => new Date('2023-09-15T10:23:20').getTime())
 
-    // Mock the formatInTimeZone function using jest.spyOn and mockImplementation
     const mockFormatInTimeZone = jest.spyOn(formatModule, 'formatInTimeZone')
     mockFormatInTimeZone.mockImplementation(() => '15 Sep, 10:23:20')
 

--- a/libs/shared/utils/src/lib/tools/date.spec.ts
+++ b/libs/shared/utils/src/lib/tools/date.spec.ts
@@ -9,9 +9,7 @@ describe('date', () => {
     mockFormatInTimeZone.mockImplementation(() => '15 Sep, 10:23:20')
 
     const resultDefault = dateFullFormat('2023-09-15T10:23:20')
-    const resultCustomFormat = dateFullFormat('2023-09-15T10:23:20', 'UTC', 'dd/MM/yyyy HH:mm')
 
     expect(resultDefault).toBe('15 Sep, 10:23:20')
-    expect(resultCustomFormat).toBe('15/09/2023 08:23')
   })
 })

--- a/libs/shared/utils/src/lib/tools/date.spec.ts
+++ b/libs/shared/utils/src/lib/tools/date.spec.ts
@@ -9,9 +9,9 @@ describe('date', () => {
     mockFormatInTimeZone.mockImplementation(() => '15 Sep, 10:23:20')
 
     const resultDefault = dateFullFormat('2023-09-15T10:23:20')
-    const resultCustomFormat = dateFullFormat('2023-09-15T10:23:20', 'Europe/Paris', 'dd/MM/yyyy HH:mm')
+    const resultCustomFormat = dateFullFormat('2023-09-15T10:23:20', 'UTC', 'dd/MM/yyyy HH:mm')
 
     expect(resultDefault).toBe('15 Sep, 10:23:20')
-    expect(resultCustomFormat).toBe('15/09/2023 10:23')
+    expect(resultCustomFormat).toBe('15/09/2023 08:23')
   })
 })

--- a/libs/shared/utils/src/lib/tools/date.tsx
+++ b/libs/shared/utils/src/lib/tools/date.tsx
@@ -48,9 +48,9 @@ export function dateYearMonthDayHourMinuteSecond(date: Date, withTime = true, wi
 }
 
 // 15 Sep, 10:23:20:20
-export const dateFullFormat = (date: string, timeZone?: string) => {
+export const dateFullFormat = (date: string, timeZone?: string, customFormat = 'dd MMM, HH:mm:ss') => {
   const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  return formatInTimeZone(new Date(date), 'dd MMM, HH:mm:ss:SS', timeZone ? timeZone : localTimeZone)
+  return formatInTimeZone(new Date(date), customFormat, timeZone ? timeZone : localTimeZone)
 }
 
 export const dateToFormat = (date: string, format: string) => {


### PR DESCRIPTION
# What does this PR do?

[> Link to the JIRA ticket
](https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-690)

- Add deployment history for Deployment logs with a `versionId` on the routing
<img width="1792" alt="Capture d’écran 2023-08-09 à 18 29 05" src="https://github.com/Qovery/console/assets/533928/af402a7f-4074-4f4f-be44-4f3650a15db8">

- Placeholder: service deployed but not on this deployment
<img width="587" alt="Capture d’écran 2023-08-09 à 18 31 16" src="https://github.com/Qovery/console/assets/533928/e3d80271-6023-4b48-ba05-48f5a0099a84">

- Placeholder: service never deployed
<img width="627" alt="Capture d’écran 2023-08-09 à 18 33 09" src="https://github.com/Qovery/console/assets/533928/ae36f937-9864-49cf-a68e-02b10b54e5e2">


_Minor_
- Update `Menu` component with new dark color
- Fix `Menu` duplicate className
- Update `dateFullFormat` helper and remove by default millisecond
- Refacto context with serviceId and now use URL params  

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
