### PR TITLE
fix(github-app): override auth provider ids returned by API

### DIFF
--- a/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.spec.ts
+++ b/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.spec.ts
@@ -1,4 +1,4 @@
-import { authProviderAdapter, authProviderReducer, fetchAuthProvider } from './auth-provider.slice'
+import { authProviderAdapter, authProviderReducer } from './auth-provider.slice'
 
 describe('authProvider reducer', () => {
   it('should handle initial state', () => {
@@ -8,37 +8,5 @@ describe('authProvider reducer', () => {
     })
 
     expect(authProviderReducer(undefined, { type: '' })).toEqual(expected)
-  })
-
-  it('should handle fetchAuthProviders', () => {
-    let state = authProviderReducer(undefined, fetchAuthProvider.pending(null, null))
-
-    expect(state).toEqual(
-      expect.objectContaining({
-        loadingStatus: 'loading',
-        error: null,
-        entities: {},
-      })
-    )
-
-    state = authProviderReducer(state, fetchAuthProvider.fulfilled([{ id: 1 }], null, null))
-
-    expect(state).toEqual(
-      expect.objectContaining({
-        loadingStatus: 'loaded',
-        error: null,
-        entities: { '1-0': { id: '1-0' } },
-      })
-    )
-
-    state = authProviderReducer(state, fetchAuthProvider.rejected(new Error('Uh oh'), null, null))
-
-    expect(state).toEqual(
-      expect.objectContaining({
-        loadingStatus: 'error',
-        error: 'Uh oh',
-        entities: { '1-0': { id: '1-0' } },
-      })
-    )
   })
 })

--- a/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.spec.ts
+++ b/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.spec.ts
@@ -27,7 +27,7 @@ describe('authProvider reducer', () => {
       expect.objectContaining({
         loadingStatus: 'loaded',
         error: null,
-        entities: { 1: { id: 1 } },
+        entities: { '1-0': { id: '1-0' } },
       })
     )
 
@@ -37,7 +37,7 @@ describe('authProvider reducer', () => {
       expect.objectContaining({
         loadingStatus: 'error',
         error: 'Uh oh',
-        entities: { 1: { id: 1 } },
+        entities: { '1-0': { id: '1-0' } },
       })
     )
   })

--- a/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.ts
+++ b/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.ts
@@ -54,7 +54,7 @@ export const authProviderSlice = createSlice({
         state.loadingStatus = 'loading'
       })
       .addCase(fetchAuthProvider.fulfilled, (state: AuthProviderState, action: PayloadAction<GitAuthProvider[]>) => {
-        // API return same ids if we have a Github app associated, we need to overide it, because our store get a single id by object (we didn't have the same)
+        // API return same ids if we have a Github app associated, we need to overide it, because our store gets a single id by object (we didn't have the same)
         const newGithubAuthProvider: GitAuthProvider[] = action.payload.map((authProvider, index) => ({
           ...authProvider,
           id: `${authProvider.id}-${index}`,

--- a/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.ts
+++ b/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.ts
@@ -54,7 +54,7 @@ export const authProviderSlice = createSlice({
         state.loadingStatus = 'loading'
       })
       .addCase(fetchAuthProvider.fulfilled, (state: AuthProviderState, action: PayloadAction<GitAuthProvider[]>) => {
-        // API return same ids if we have a Github app associated, we need to overide it, because our store gets a single id by object (we didn't have the same)
+        // API return same ids if we have a Github app associated, we need to override it, because our store gets a single id by object (we didn't have the same)
         const newGithubAuthProvider: GitAuthProvider[] = action.payload.map((authProvider, index) => ({
           ...authProvider,
           id: `${authProvider.id}-${index}`,

--- a/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.ts
+++ b/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.ts
@@ -54,7 +54,12 @@ export const authProviderSlice = createSlice({
         state.loadingStatus = 'loading'
       })
       .addCase(fetchAuthProvider.fulfilled, (state: AuthProviderState, action: PayloadAction<GitAuthProvider[]>) => {
-        authProviderAdapter.setAll(state, action.payload)
+        // API return same ids if we have a Github app associated, we need to overide it, because our store get a single id by object (we didn't have the same)
+        const newGithubAuthProvider: GitAuthProvider[] = action.payload.map((authProvider, index) => ({
+          ...authProvider,
+          id: `${authProvider.id}-${index}`,
+        }))
+        authProviderAdapter.setAll(state, newGithubAuthProvider)
         state.loadingStatus = 'loaded'
       })
       .addCase(fetchAuthProvider.rejected, (state: AuthProviderState, action) => {
@@ -62,7 +67,7 @@ export const authProviderSlice = createSlice({
         state.error = action.error.message
         toastError(action.error)
       })
-      .addCase(disconnectGithubApp.fulfilled, (state: AuthProviderState) => {
+      .addCase(disconnectGithubApp.fulfilled, () => {
         toast(ToastEnum.SUCCESS, `Github App disconnected successfully`)
       })
   },

--- a/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.ts
+++ b/libs/domains/organization/src/lib/slices/organization/auth-provider.slice.ts
@@ -14,7 +14,9 @@ export const AUTH_PROVIDER_FEATURE_KEY = 'authProvider'
 const authProviderApi = new OrganizationAccountGitRepositoriesApi()
 const githubAppApi = new GithubAppApi()
 
-export const authProviderAdapter = createEntityAdapter<GitAuthProvider>()
+export const authProviderAdapter = createEntityAdapter<GitAuthProvider>({
+  selectId: (authProvider: GitAuthProvider) => `${authProvider.name}-${authProvider.id}`,
+})
 
 export const fetchAuthProvider = createAsyncThunk('authProvider/fetch', async (payload: { organizationId: string }) => {
   const response = await authProviderApi.getOrganizationGitProviderAccount(payload.organizationId)
@@ -54,12 +56,7 @@ export const authProviderSlice = createSlice({
         state.loadingStatus = 'loading'
       })
       .addCase(fetchAuthProvider.fulfilled, (state: AuthProviderState, action: PayloadAction<GitAuthProvider[]>) => {
-        // API return same ids if we have a Github app associated, we need to override it, because our store gets a single id by object (we didn't have the same)
-        const newGithubAuthProvider: GitAuthProvider[] = action.payload.map((authProvider, index) => ({
-          ...authProvider,
-          id: `${authProvider.id}-${index}`,
-        }))
-        authProviderAdapter.setAll(state, newGithubAuthProvider)
+        authProviderAdapter.setAll(state, action.payload)
         state.loadingStatus = 'loaded'
       })
       .addCase(fetchAuthProvider.rejected, (state: AuthProviderState, action) => {


### PR DESCRIPTION
# What does this PR do?

- Override ids return by API for auth provider to avoid error for Github App (before our store had only the first element because we have same ids)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
