### PR TITLE
fix(github-app): fix disconnection modal

### DIFF
--- a/libs/pages/settings/src/lib/feature/page-organization-github-repository-access-feature/page-organization-github-repository-access-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-github-repository-access-feature/page-organization-github-repository-access-feature.tsx
@@ -103,7 +103,7 @@ export function PageOrganizationGithubRepositoryAccessFeature() {
       .catch((error) => {
         setForceLoading(false)
 
-        if (error.name === 'Bad Request' && error.code === '400' && error.message.includes('This git provider is')) {
+        if ((error.name === 'Bad Request' || error.code === '400') && error.message.includes('This git provider is')) {
           onDisconnectWithModal()
         }
       })


### PR DESCRIPTION
Related to https://qovery.atlassian.net/browse/FRT-746

![2023-08-04-121447_854x143_scrot](https://github.com/Qovery/console/assets/1716173/317e0a0e-dfbe-4bc8-83b7-a78788a75959)

`error.name` was `undefined` so I changed the condition to match the current error.