### PR TITLE
Add http security headers in nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,6 +35,11 @@ server {
     text/plain
     text/xml;
 
+  # https://webdock.io/en/docs/how-guides/security-guides/how-to-configure-security-headers-in-nginx-and-apache
+  add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
+  add_header X-Frame-Options "DENY";
+  add_header X-Content-Type-Options nosniff;
+  
   location / {
     root /usr/share/nginx/html/;
     include /etc/nginx/mime.types;


### PR DESCRIPTION
# What does this PR do?

Set HTTP security headers in nginx.
See https://webdock.io/en/docs/how-guides/security-guides/how-to-configure-security-headers-in-nginx-and-apache for more details.
Mainly because we often receive email from security scanners about the X-FRAME-OPTIONS

## PR Checklist

- [] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
