### PR TITLE
fix(layout): remove useless double fetch for Organization and UserSignUp

### DIFF
--- a/libs/pages/layout/src/lib/feature/layout/layout.tsx
+++ b/libs/pages/layout/src/lib/feature/layout/layout.tsx
@@ -55,12 +55,9 @@ export function Layout(props: PropsWithChildren<LayoutProps>) {
         }
       })
       .catch((error) => console.error(error))
-
-    dispatch(fetchUserSignUp())
   }, [dispatch, organizationId])
 
   useEffect(() => {
-    dispatch(fetchOrganization())
     dispatch(fetchUserSignUp())
   }, [dispatch])
 


### PR DESCRIPTION
# What does this PR do?

- Remove on the first loading, the double fetch for Organization and UserSignUp

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
