### PR TITLE
fix(cluster-network): description field is required

### DIFF
--- a/libs/pages/cluster/src/lib/ui/page-settings-network/crud-modal/crud-modal.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-network/crud-modal/crud-modal.tsx
@@ -61,13 +61,16 @@ export function CrudModal(props: CrudModalProps) {
       <Controller
         name="description"
         control={control}
+        rules={{
+          required: 'Please enter an description.',
+        }}
         render={({ field, fieldState: { error } }) => (
           <InputTextArea
             className="mb-3"
             name={field.name}
             onChange={field.onChange}
             value={field.value}
-            label="Description (optionnal)"
+            label="Description"
             error={error?.message}
           />
         )}


### PR DESCRIPTION
# What does this PR do?
It fixes cluster network description field flagged as optional which is required by the API.

> Link to the JIRA ticket

Put description here

> Screenshot of the feature

**Broken**
<img width="556" alt="image" src="https://github.com/Qovery/console/assets/1393795/eb36028a-4d1a-4442-b324-3482dc8485e4">

**Fixed**
<img width="540" alt="image" src="https://github.com/Qovery/console/assets/1393795/7d67773e-732c-4af3-9962-36d2914eae40">


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
