### PR TITLE
fix(deployment-history): add status from the history and not the current

### DIFF
--- a/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline-item/sidebar-pipeline-item.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-pipeline-item/sidebar-pipeline-item.tsx
@@ -1,7 +1,7 @@
 import { DeploymentStageWithServicesStatuses, Status } from 'qovery-typescript-axios'
 import { useContext, useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { RunningState, getServiceType } from '@qovery/shared/enums'
+import { getServiceType } from '@qovery/shared/enums'
 import { ApplicationEntity, DatabaseEntity } from '@qovery/shared/interfaces'
 import { DEPLOYMENT_LOGS_VERSION_URL, ENVIRONMENT_LOGS_URL } from '@qovery/shared/routes'
 import { BadgeDeploymentOrder, BadgeService, Icon, IconAwesomeEnum, StatusChip } from '@qovery/shared/ui'
@@ -89,7 +89,7 @@ export function SidebarPipelineItem({ currentStage, index, serviceId, versionId,
                       />
                       <span className="truncate max-w-[190px]">{currentApplication(service.id)?.name}</span>
                     </span>
-                    <StatusChip status={currentApplication(service.id)?.status?.state || RunningState.STOPPED} />
+                    <StatusChip status={service.state} />
                   </Link>
                 )}
               </div>

--- a/libs/shared/ui/src/lib/components/status-chip/status-chip.tsx
+++ b/libs/shared/ui/src/lib/components/status-chip/status-chip.tsx
@@ -18,6 +18,7 @@ export function StatusChip(props: StatusChipProps) {
       case StateEnum.DEPLOYED:
       case RunningState.COMPLETED:
       case RunningState.RUNNING:
+      case StateEnum.RESTARTED:
         return true
       default:
         return false


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-793


- Fix status for stage pipeline on the sidebar
<img width="390" alt="Capture d’écran 2023-08-23 à 17 40 26" src="https://github.com/Qovery/console/assets/533928/c5d16a85-4810-436c-943e-87bfd886964f">


- Add missing RESTARTED status for StatusChip component
<img width="327" alt="Capture d’écran 2023-08-23 à 17 39 57" src="https://github.com/Qovery/console/assets/533928/df34a531-16a1-440e-b3ab-5437735275a4">

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
