### PR TITLE
fix(services): fix status websocket in corner case.

### DIFF
--- a/libs/pages/environments/src/lib/ui/container/container.tsx
+++ b/libs/pages/environments/src/lib/ui/container/container.tsx
@@ -27,7 +27,7 @@ export function Container(props: PropsWithChildren<ContainerProps>) {
 
   const tabsItems = [
     {
-      icon: <Icon name={IconEnum.SUCCESS} viewBox="0 0 16 16" className="w-4 mt-0.5" />,
+      icon: <Icon name={IconAwesomeEnum.LAYER_GROUP} />,
       name: 'Environments',
       active: pathname === `${ENVIRONMENTS_URL(organizationId, projectId)}/general`,
       link: `${ENVIRONMENTS_URL(organizationId, projectId)}/general`,

--- a/libs/shared/factories/src/lib/container-factory.mock.ts
+++ b/libs/shared/factories/src/lib/container-factory.mock.ts
@@ -17,7 +17,7 @@ export const containerFactoryMock = (howMany: number): ContainerApplicationEntit
     maximum_cpu: 10,
     maximum_memory: 10,
     image_name: chance.word({ length: 10 }),
-    updated_at: new Date().toString(),
+    updated_at: '2022-08-10T14:55:21.382762Z',
     storage: [
       {
         id: chance.guid(),
@@ -40,7 +40,7 @@ export const containerFactoryMock = (howMany: number): ContainerApplicationEntit
     environment: {
       id: chance.guid(),
     },
-    created_at: new Date().toString(),
+    created_at: '2022-06-10T14:55:21.382761Z',
     links: {
       loadingStatus: 'loaded',
       items: [],

--- a/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
+++ b/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
@@ -1,6 +1,4 @@
 import { type EnvironmentStatus, type Status } from 'qovery-typescript-axios'
-import { useParams } from 'react-router-dom'
-import { useEnvironment } from '@qovery/domains/environments/feature'
 import { type RunningState } from '@qovery/shared/enums'
 import { type ServiceRunningStatus } from '@qovery/shared/interfaces'
 import { useReactQueryWsSubscription } from '@qovery/state/util-queries'
@@ -27,16 +25,27 @@ interface WSServiceStatus {
   }[]
 }
 
-export function useStatusWebSockets() {
-  const { organizationId = '', projectId = '', environmentId = '', versionId = '' } = useParams()
-  const { data: environment } = useEnvironment({ environmentId })
+export interface UseStatusWebSocketsProps {
+  organizationId: string
+  clusterId: string
+  projectId?: string
+  environmentId?: string
+  versionId?: string
+}
 
+export function useStatusWebSockets({
+  organizationId,
+  clusterId,
+  projectId,
+  environmentId,
+  versionId,
+}: UseStatusWebSocketsProps) {
   useReactQueryWsSubscription({
     url: 'wss://ws.qovery.com/deployment/status',
     urlSearchParams: {
       organization: organizationId,
-      environment: environment?.id,
-      cluster: environment?.cluster_id,
+      environment: environmentId,
+      cluster: clusterId,
       project: projectId,
       version: versionId,
     },
@@ -60,8 +69,8 @@ export function useStatusWebSockets() {
     url: 'wss://ws.qovery.com/service/status',
     urlSearchParams: {
       organization: organizationId,
-      environment: environment?.id,
-      cluster: environment?.cluster_id,
+      environment: environmentId,
+      cluster: clusterId,
       project: projectId,
     },
     enabled: Boolean(organizationId) && Boolean(clusterId),

--- a/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
+++ b/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
@@ -40,6 +40,7 @@ export function useStatusWebSockets() {
       project: projectId,
       version: versionId,
     },
+    enabled: Boolean(organizationId) && Boolean(clusterId) && Boolean(projectId) && Boolean(environmentId),
     onMessage(queryClient, message: WSDeploymentStatus) {
       const environmentId = message.environment.id
       queryClient.setQueryData(queries.environments.deploymentStatus(environmentId).queryKey, () => message.environment)
@@ -63,6 +64,7 @@ export function useStatusWebSockets() {
       cluster: environment?.cluster_id,
       project: projectId,
     },
+    enabled: Boolean(organizationId) && Boolean(clusterId),
     onMessage(queryClient, message: WSServiceStatus) {
       for (const env of message.environments) {
         queryClient.setQueryData(queries.environments.runningStatus(env.id).queryKey, () => ({

--- a/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.spec.tsx
+++ b/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.spec.tsx
@@ -94,6 +94,20 @@ describe('useReactQueryWsSubscription', () => {
     unmount()
   })
 
+  it('should do nothing when not enabled', async () => {
+    const onMessage = jest.fn()
+    const { unmount } = renderHook(() =>
+      useReactQueryWsSubscription({ url: 'ws://localhost:1234', onMessage, enabled: false })
+    )
+    const queryClient = useQueryClient()
+
+    server.send({ foo: 'bar' })
+
+    expect(queryClient.invalidateQueries).not.toHaveBeenCalled()
+    expect(onMessage).not.toHaveBeenCalled()
+    unmount()
+  })
+
   it('should close connection on unmount', async () => {
     const onMessage = jest.fn()
     const { unmount } = renderHook(() => useReactQueryWsSubscription({ url: 'ws://localhost:1234', onMessage }))

--- a/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.ts
+++ b/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.ts
@@ -13,6 +13,7 @@ export interface UseReactQueryWsSubscriptionProps {
   /** WebSocket onmessage will be automatically handled if they are aligned with the expected format (https://tkdodo.eu/blog/using-web-sockets-with-react-query#consuming-data) otherwise you should provide an handler */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onMessage?: (queryClient: QueryClient, data: any) => void
+  enabled?: boolean
 }
 
 interface InvalidateOperation {
@@ -29,6 +30,7 @@ export function useReactQueryWsSubscription({
   url,
   urlSearchParams,
   onMessage = (_, data) => console.error('Unhandled websocket onmessage, data:', data),
+  enabled = true,
 }: UseReactQueryWsSubscriptionProps) {
   const queryClient = useQueryClient()
   const { getAccessTokenSilently } = useAuth0()
@@ -50,6 +52,9 @@ export function useReactQueryWsSubscription({
   const searchParams = new URLSearchParams(_urlSearchParams)
 
   useEffect(() => {
+    if (!enabled) {
+      return
+    }
     let websocket: WebSocket | undefined
 
       // XXX: This sounds ugly but its recommended by Auth0 ¯\_(ツ)_/¯
@@ -76,7 +81,7 @@ export function useReactQueryWsSubscription({
         websocket.close()
       }
     }
-  }, [queryClient, getAccessTokenSilently, onMessage, url, searchParams.toString()])
+  }, [queryClient, getAccessTokenSilently, onMessage, url, searchParams.toString(), enabled])
 }
 
 export default useReactQueryWsSubscription


### PR DESCRIPTION
# What does this PR do?

Add `enabled` param to `useReactQueryWsSubscription` to avoid bad WS call.
Here are the corresponding structures
https://gitlab.com/qovery/backend/rust-backend/-/blob/58aca6e768c2d091ec38c6132858e8af6027a196/websocket-gateway/src/deployment/types.rs#L5
https://gitlab.com/qovery/backend/rust-backend/-/blob/58aca6e768c2d091ec38c6132858e8af6027a196/websocket-gateway/src/service_status/types.rs

In addition, we currently have a bug in the recently merged web-socket status feature.
WebSockets require `clusterId` however frontend side environments are listed despite their cluster ownership.
So frontend is forced to create one WS per cluster to listen to all environments statuses.
This is far from ideal and data modeling should be challenged with backend team.