### PR TITLE
fix(layout-logs): display progressing by service deployment status

### DIFF
--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -7,6 +7,7 @@ import useWebSocket from 'react-use-websocket'
 import { selectApplicationsEntitiesByEnvId } from '@qovery/domains/application'
 import { selectDatabasesEntitiesByEnvId } from '@qovery/domains/database'
 import { useFetchEnvironment } from '@qovery/domains/environment'
+import { useDeploymentStatus } from '@qovery/domains/services/feature'
 import { useAuth } from '@qovery/shared/auth'
 import { type ApplicationEntity, type DatabaseEntity } from '@qovery/shared/interfaces'
 import {
@@ -49,6 +50,8 @@ export function PageEnvironmentLogs() {
 
   const matchServiceId = matchDeploymentVersion || matchServiceLogs || matchDeployment
   const serviceId = matchServiceId?.params.serviceId !== ':serviceId' ? matchServiceId?.params.serviceId : undefined
+
+  const { data: deploymentStatus } = useDeploymentStatus({ environmentId, serviceId })
 
   const applications = useSelector<RootState, ApplicationEntity[]>(
     (state) => selectApplicationsEntitiesByEnvId(state, environmentId),
@@ -94,7 +97,7 @@ export function PageEnvironmentLogs() {
     StateEnum.RESTART_QUEUED,
     StateEnum.STOP_QUEUED,
     StateEnum.DEPLOYMENT_QUEUED,
-  ].includes(environmentStatus?.state as StateEnum)
+  ].includes(deploymentStatus?.state as StateEnum)
 
   return (
     <div className="flex h-full">

--- a/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
+++ b/libs/shared/console-shared/src/lib/layout-logs/layout-logs.tsx
@@ -238,10 +238,10 @@ export function LayoutLogs({
               <div className="relative z-20">
                 {children}
                 {isProgressing && (
-                  <div role="progressbar" className="flex ml-4 relative -top-5">
-                    <div className="animate-[pulse_1s_cubic-bezier(0.4,0,0.6,1)_100ms_infinite] w-2 h-2 bg-brand-300 mr-1" />
-                    <div className="animate-[pulse_1s_cubic-bezier(0.4,0,0.6,1)_300ms_infinite] w-2 h-2 bg-brand-300 mr-1" />
-                    <div className="animate-[pulse_1s_cubic-bezier(0.4,0,0.6,1)_600ms_infinite] w-2 h-2 bg-brand-300" />
+                  <div role="progressbar" className="flex ml-5 relative -top-5">
+                    <div className="animate-[pulse_1s_cubic-bezier(0.4,0,0.6,1)_100ms_infinite] w-1.5 h-1.5 bg-brand-300 mr-1" />
+                    <div className="animate-[pulse_1s_cubic-bezier(0.4,0,0.6,1)_300ms_infinite] w-1.5 h-1.5 bg-brand-300 mr-1" />
+                    <div className="animate-[pulse_1s_cubic-bezier(0.4,0,0.6,1)_600ms_infinite] w-1.5 h-1.5 bg-brand-300" />
                   </div>
                 )}
               </div>

--- a/libs/shared/ui/src/lib/components/icon/icon.stories.tsx
+++ b/libs/shared/ui/src/lib/components/icon/icon.stories.tsx
@@ -130,13 +130,13 @@ export const ManyItems: Story = {
         <h2 className="w-full mb-2">Status Icons</h2>
         <DeployedIcon />
         <RestartedIcon />
-        <QueuedIcon />
         <BuildingIcon />
         <CancelingIcon />
         <RestartingIcon />
         <DeployingIcon />
         <DeletingIcon />
         <StoppingIcon />
+        <QueuedIcon />
         <StoppedIcon />
         <CanceledIcon />
         <DeletedIcon />

--- a/libs/shared/ui/src/lib/components/icon/icons-status/queued.tsx
+++ b/libs/shared/ui/src/lib/components/icon/icons-status/queued.tsx
@@ -1,12 +1,25 @@
-import { type ElementRef, forwardRef } from 'react'
+import { forwardRef } from 'react'
 import { twMerge } from 'tailwind-merge'
-import SpinnerIcon from './spinner'
+import { type IconSVGProps } from '../icon'
 
-export const QueuedIcon = forwardRef<ElementRef<typeof SpinnerIcon>, { className?: string }>(function QueuedIcon(
-  { className = '' },
+export const QueuedIcon = forwardRef<SVGSVGElement, IconSVGProps>(function QueuedIcon(
+  { className = '', ...props },
   forwardedRef
 ) {
-  return <SpinnerIcon className={twMerge('text-brand-500 dark:text-brand-300', className)} ref={forwardedRef} />
+  return (
+    <svg
+      className={twMerge('text-neutral-300', className)}
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+      ref={forwardedRef}
+      {...props}
+    >
+      <path fill="currentColor" d="M8 1.5V8H1.5c0-3.59 2.91-6.5 6.5-6.5zM16 8A8 8 0 100 8a8 8 0 0016 0z"></path>
+    </svg>
+  )
 })
 
 export default QueuedIcon

--- a/libs/shared/ui/src/lib/components/status-chip/__snapshots__/status-chip.spec.tsx.snap
+++ b/libs/shared/ui/src/lib/components/status-chip/__snapshots__/status-chip.spec.tsx.snap
@@ -66,13 +66,19 @@ exports[`StatusChip should match snapshot for QUEUED status 1`] = `
     class=""
     data-state="closed"
   >
-    <div
-      class="relative flex items-center justify-center w-4 h-4 text-brand-500 dark:text-brand-300"
+    <svg
+      class="text-neutral-300"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <div
-        class="animate-spin absolute top-0 left-0 w-full h-full rounded-full border-[1.5px] border-current border-r-transparent"
+      <path
+        d="M8 1.5V8H1.5c0-3.59 2.91-6.5 6.5-6.5zM16 8A8 8 0 100 8a8 8 0 0016 0z"
+        fill="currentColor"
       />
-    </div>
+    </svg>
   </div>
 </div>
 `;


### PR DESCRIPTION
# What does this PR do?

- Display progressing animation by service deployment status and not environment status
- Added a new Queued icon
<img width="215" alt="Capture d’écran 2023-09-22 à 08 49 10" src="https://github.com/Qovery/console/assets/533928/d6d87df8-2eef-4ad9-8aee-8cb2f02db199">

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
