### PR TITLE
fix(last-commit): UI padding and width 

### DIFF
--- a/libs/domains/services/feature/src/lib/last-commit/__snapshots__/last-commit.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/last-commit/__snapshots__/last-commit.spec.tsx.snap
@@ -22,15 +22,15 @@ exports[`LastCommit should match snapshot 1`] = `
         data-state="closed"
       >
         <button
-          class="inline-flex items-center shrink-0 font-medium rounded text-xs px-1 py-0.5 bg-neutral-100 border border-neutral-250 text-neutral-400 group justify-between w-20"
+          class="inline-flex items-center shrink-0 font-medium rounded text-xs px-1 py-0.5 bg-neutral-100 border border-neutral-250 text-neutral-400 group justify-between gap-1"
           type="button"
         >
           <span
-            class="icon-solid-copy shrink-0 hidden group-hover:inline"
+            class="icon-solid-copy shrink-0 hidden group-hover:inline w-4"
             role="img"
           />
           <span
-            class="icon-solid-code-commit shrink-0 group-hover:hidden"
+            class="icon-solid-code-commit shrink-0 group-hover:hidden w-4"
             role="img"
           />
           ddd1cee

--- a/libs/domains/services/feature/src/lib/last-commit/last-commit.tsx
+++ b/libs/domains/services/feature/src/lib/last-commit/last-commit.tsx
@@ -75,7 +75,7 @@ export function LastCommit({ className, gitRepository, serviceId, serviceType }:
               variant="surface"
               color="neutral"
               size="xs"
-              className={twMerge(`group justify-between ${delta > 0 ? 'w-24 pr-[26px]' : 'gap-1'}`, className)}
+              className={twMerge(`group justify-between ${delta > 0 ? 'w-[98px] pr-[26px]' : 'gap-1'}`, className)}
               onClick={() => onClickCopyToClipboard(deployedCommit.git_commit_id)}
             >
               <Icon name={IconAwesomeEnum.COPY} className="hidden group-hover:inline w-4" />

--- a/libs/domains/services/feature/src/lib/last-commit/last-commit.tsx
+++ b/libs/domains/services/feature/src/lib/last-commit/last-commit.tsx
@@ -75,11 +75,11 @@ export function LastCommit({ className, gitRepository, serviceId, serviceType }:
               variant="surface"
               color="neutral"
               size="xs"
-              className={twMerge(`group justify-between ${delta > 0 ? 'w-24 pr-[26px]' : 'w-20'}`, className)}
+              className={twMerge(`group justify-between ${delta > 0 ? 'w-24 pr-[26px]' : 'gap-1'}`, className)}
               onClick={() => onClickCopyToClipboard(deployedCommit.git_commit_id)}
             >
-              <Icon name={IconAwesomeEnum.COPY} className="hidden group-hover:inline" />
-              <Icon name={IconAwesomeEnum.CODE_COMMIT} className="group-hover:hidden" />
+              <Icon name={IconAwesomeEnum.COPY} className="hidden group-hover:inline w-4" />
+              <Icon name={IconAwesomeEnum.CODE_COMMIT} className="group-hover:hidden w-4" />
               {deployedCommit.git_commit_id.substring(0, 7)}
               {delta > 0 ? (
                 // TODO: improve inset

--- a/libs/domains/services/feature/src/lib/last-commit/last-commit.tsx
+++ b/libs/domains/services/feature/src/lib/last-commit/last-commit.tsx
@@ -75,7 +75,7 @@ export function LastCommit({ className, gitRepository, serviceId, serviceType }:
               variant="surface"
               color="neutral"
               size="xs"
-              className={twMerge(`group justify-between ${delta > 0 ? 'w-28 pr-9' : 'w-20'}`, className)}
+              className={twMerge(`group justify-between ${delta > 0 ? 'w-24 pr-[26px]' : 'w-20'}`, className)}
               onClick={() => onClickCopyToClipboard(deployedCommit.git_commit_id)}
             >
               <Icon name={IconAwesomeEnum.COPY} className="hidden group-hover:inline" />
@@ -83,7 +83,7 @@ export function LastCommit({ className, gitRepository, serviceId, serviceType }:
               {deployedCommit.git_commit_id.substring(0, 7)}
               {delta > 0 ? (
                 // TODO: improve inset
-                <span className="absolute right-0 inset-y-0 bg-orange-500 text-white px-2 rounded-tr rounded-br flex items-center w-8 justify-center">
+                <span className="absolute right-0 inset-y-0 bg-orange-500 text-white px-1 rounded-tr rounded-br flex items-center min-w-[22px] justify-center">
                   {delta}
                 </span>
               ) : null}

--- a/libs/domains/services/feature/src/lib/service-details/__snapshots__/service-details.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-details/__snapshots__/service-details.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`ServiceDetails should match application snapshot 1`] = `
           <dd
             class="text-neutral-400 font-medium"
           >
-            12 Apr, 10:48:51
+            12 Apr, 08:48:51
           </dd>
           <dt
             class="text-neutral-350"
@@ -90,7 +90,7 @@ exports[`ServiceDetails should match database snapshot 1`] = `
           <dd
             class="text-neutral-400 font-medium"
           >
-            28 Jul, 16:50:09
+            28 Jul, 14:50:09
           </dd>
           <dt
             class="text-neutral-350"
@@ -152,7 +152,7 @@ exports[`ServiceDetails should match job snapshot 1`] = `
           <dd
             class="text-neutral-400 font-medium"
           >
-            12 Sep, 12:08:39
+            12 Sep, 10:08:39
           </dd>
           <dt
             class="text-neutral-350"

--- a/libs/domains/services/feature/src/lib/service-details/__snapshots__/service-details.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-details/__snapshots__/service-details.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`ServiceDetails should match application snapshot 1`] = `
           <dd
             class="text-neutral-400 font-medium"
           >
-            12 Apr, 08:48:51
+            12 Apr, 10:48:51
           </dd>
           <dt
             class="text-neutral-350"
@@ -90,7 +90,7 @@ exports[`ServiceDetails should match database snapshot 1`] = `
           <dd
             class="text-neutral-400 font-medium"
           >
-            28 Jul, 14:50:09
+            28 Jul, 16:50:09
           </dd>
           <dt
             class="text-neutral-350"
@@ -152,7 +152,7 @@ exports[`ServiceDetails should match job snapshot 1`] = `
           <dd
             class="text-neutral-400 font-medium"
           >
-            12 Sep, 10:08:39
+            12 Sep, 12:08:39
           </dd>
           <dt
             class="text-neutral-350"

--- a/libs/domains/services/feature/src/lib/service-details/service-details.tsx
+++ b/libs/domains/services/feature/src/lib/service-details/service-details.tsx
@@ -1,6 +1,7 @@
 import { type ComponentPropsWithoutRef } from 'react'
 import { match } from 'ts-pattern'
 import { IconEnum, ServiceTypeEnum } from '@qovery/shared/enums'
+import { APPLICATION_SETTINGS_RESOURCES_URL, APPLICATION_SETTINGS_URL } from '@qovery/shared/routes'
 import {
   Badge,
   DescriptionDetails as Dd,
@@ -239,7 +240,11 @@ export function ServiceDetails({ className, environmentId, serviceId, ...props }
                   </span>
                 </Tooltip>
               </span>
-              <Link color="current" to="../settings/resources" relative="path">
+              <Link
+                color="current"
+                to={`..${APPLICATION_SETTINGS_URL + APPLICATION_SETTINGS_RESOURCES_URL}`}
+                relative="path"
+              >
                 <Icon name={IconAwesomeEnum.WHEEL} className="text-base text-neutral-300" />
               </Link>
             </div>


### PR DESCRIPTION
# What does this PR do?

- Improved the last commit component
- And should be more ISO with other Badges and Figma
<img width="192" alt="Capture d’écran 2023-10-06 à 14 48 28" src="https://github.com/Qovery/console/assets/533928/55876238-8671-4b2d-a871-05d023f3e5cd">

----  

Before:
<img width="441" alt="Capture d’écran 2023-10-06 à 14 45 18" src="https://github.com/Qovery/console/assets/533928/05579ba2-676e-48a4-befa-39fc597aa01a">
After:
<img width="390" alt="Capture d’écran 2023-10-06 à 14 46 40" src="https://github.com/Qovery/console/assets/533928/6eff412b-2aab-403b-ab4d-23bdb97d4f2d">

Before:
<img width="335" alt="Capture d’écran 2023-10-06 à 14 47 54" src="https://github.com/Qovery/console/assets/533928/a923a08b-6d44-4b0d-8300-5e86da5e59e3">
After:
<img width="326" alt="Capture d’écran 2023-10-06 à 14 47 15" src="https://github.com/Qovery/console/assets/533928/93bebdfd-36a0-45ad-a93e-85192584c910">

Case with double numbers and large characters:
![Capture d’écran 2023-10-09 à 10 44 11](https://github.com/Qovery/console/assets/533928/b11d9094-68b3-458a-82cc-d40139db3d4f)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
