### PR TITLE
chore: upgrade qovery-typescript-axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fast-deep-equal": "^3.1.3",
     "logrocket": "^3.0.1",
     "posthog-js": "^1.24.0",
-    "qovery-typescript-axios": "^1.1.252",
+    "qovery-typescript-axios": "^1.1.258",
     "react": "18.2.0",
     "react-beautiful-dnd": "^13.1.0",
     "react-country-flag": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18129,7 +18129,7 @@ __metadata:
     posthog-js: ^1.24.0
     prettier: ^2.8.2
     pretty-quick: ^3.1.3
-    qovery-typescript-axios: ^1.1.252
+    qovery-typescript-axios: ^1.1.258
     qovery-ws-typescript-axios: ^0.1.56
     react: 18.2.0
     react-beautiful-dnd: ^13.1.0
@@ -18168,12 +18168,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"qovery-typescript-axios@npm:^1.1.252":
-  version: 1.1.252
-  resolution: "qovery-typescript-axios@npm:1.1.252"
+"qovery-typescript-axios@npm:^1.1.258":
+  version: 1.1.258
+  resolution: "qovery-typescript-axios@npm:1.1.258"
   dependencies:
     axios: ^0.27.2
-  checksum: 7c5faf2b04b4dd287117215d530c9c1e062b05fb377f9075fdef1054178c205037e67e25a7230331632de37b25a7fd69b7f22b412aba0bf026fa946db4ab68a3
+  checksum: 1e8af82dab28aaac90b8a25d650d9995def667d670b72db9b9a69e5b369417f1efd881573205f09f2bec0de6e2d70385bb1686ef14c97a1a4dbff5123f20c30c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/browse/FRT-882

Bump qovery-typescript-axios to get this fix https://github.com/Qovery/qovery-openapi-spec/pull/482
