### PR TITLE
fix(ui): truncate container version in pod-metrics

### DIFF
--- a/libs/domains/services/feature/src/lib/pods-metrics/pods-metrics.tsx
+++ b/libs/domains/services/feature/src/lib/pods-metrics/pods-metrics.tsx
@@ -127,7 +127,9 @@ export function PodsMetrics({ environmentId, serviceId }: PodsMetricsProps) {
           value && (
             <Badge variant="surface" size="xs" className="shrink max-w-full">
               {containerImage ? (
-                `${containerImage.image_name}:${containerImage.tag}`
+                <div className="truncate">
+                  {containerImage.image_name}:{containerImage.tag}
+                </div>
               ) : (
                 <span className="max-w-full truncate">
                   <Icon className="mr-2" name={IconAwesomeEnum.CODE_COMMIT} />


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/browse/FRT-900

![2023-11-10-170913_793x354_scrot](https://github.com/Qovery/console/assets/1716173/c5dcab99-9e46-45cb-ac29-969c4068c593)

