### PR TITLE
fix(services): remove default instance_type

### DIFF
--- a/libs/pages/services/src/lib/feature/page-database-create-feature/page-database-create-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-database-create-feature/page-database-create-feature.tsx
@@ -43,7 +43,6 @@ export function PageDatabaseCreateFeature() {
     memory: 512,
     cpu: 500,
     storage: 10,
-    instance_type: 'db.t3.medium',
   })
 
   const navigate = useNavigate()


### PR DESCRIPTION
Not all DBs have the same instance type, for example Redis doesn't have 'db.t3.medium'. So we chose to remove default instance type and let the user choose.

https://qovery.atlassian.net/browse/FRT-894
