### PR TITLE
fix(deployment-logs): update parallel deploys count

### DIFF
--- a/libs/pages/logs/environment/src/lib/ui/sidebar-status/sidebar-status.tsx
+++ b/libs/pages/logs/environment/src/lib/ui/sidebar-status/sidebar-status.tsx
@@ -37,7 +37,7 @@ export function SidebarStatus(props: SidebarStatusProps) {
       <p className="flex items-center justify-between text-neutral-300 text-xs mt-2">
         Parallel Deployment:
         <span className="flex text-neutral-50">
-          4{' '}
+          7{' '}
           <Tooltip side="right" content="Number of services deployed in parallel on each pipeline stage">
             <span className="flex items-center">
               <Icon className="cursor-pointer ml-1 text-xs text-neutral-300" name="icon-solid-circle-info" />


### PR DESCRIPTION
Fixing parallel deploy counts from 4 to 7.

# What does this PR do?
Fixing parallel deploy counts from 4 to 7 (actual parallel deployments count)

> Link to the JIRA ticket

Put description here

> Screenshot of the feature
![image](https://github.com/Qovery/console/assets/1393795/29096cbb-1299-4f94-92d7-c86ba8c5cdce)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
