### PR TITLE
Fix/add utc scheduling

### DIFF
--- a/libs/domains/services/feature/src/lib/pods-metrics/pods-metrics.tsx
+++ b/libs/domains/services/feature/src/lib/pods-metrics/pods-metrics.tsx
@@ -179,7 +179,7 @@ export function PodsMetrics({ environmentId, serviceId }: PodsMetricsProps) {
           return value ? (
             <Tooltip content={dateFullFormat(value)}>
               <span className="text-xs text-neutral-350">
-                {dateFormat === 'relative' ? timeAgo(new Date(value)) : dateFullFormat(value)}
+                {dateFormat === 'relative' ? timeAgo(new Date(value)) : dateFullFormat(value, 'UTC')}
               </span>
             </Tooltip>
           ) : (
@@ -190,7 +190,7 @@ export function PodsMetrics({ environmentId, serviceId }: PodsMetricsProps) {
 
     return match(service?.serviceType)
       .with(ServiceTypeEnum.JOB, () => [
-        startedAtColumn('Job executions', 'absolute'),
+        startedAtColumn('Job executions (UTC)', 'absolute'),
         statusColumn,
         versionColumn,
         memoryColumn,

--- a/libs/domains/services/feature/src/lib/service-details/service-details.tsx
+++ b/libs/domains/services/feature/src/lib/service-details/service-details.tsx
@@ -190,7 +190,10 @@ export function ServiceDetails({ className, environmentId, serviceId, ...props }
               />
             ))
             .with({ job_type: 'CRON' }, ({ schedule }) => (
-              <ResourceUnit value={formatCronExpression(schedule.cronjob?.scheduled_at)} description="Scheduling" />
+              <ResourceUnit
+                value={formatCronExpression(schedule.cronjob?.scheduled_at)}
+                description="Scheduling (UTC)"
+              />
             ))
             .exhaustive()}
           <ResourceUnit value={max_nb_restart} description="Restart (max)" />

--- a/libs/shared/console-shared/src/lib/job-configure-settings/ui/job-configure-settings.spec.tsx
+++ b/libs/shared/console-shared/src/lib/job-configure-settings/ui/job-configure-settings.spec.tsx
@@ -82,7 +82,7 @@ describe('JobConfigureSettings', () => {
         fireEvent.change(inputSchedule, { target: { value: '9 * * * *' } })
       })
 
-      getByText(baseElement, 'At 9 minutes past the hour')
+      getByText(baseElement, 'At 9 minutes past the hour (UTC)')
 
       expect(baseElement).toBeTruthy()
     })

--- a/libs/shared/console-shared/src/lib/job-configure-settings/ui/job-configure-settings.tsx
+++ b/libs/shared/console-shared/src/lib/job-configure-settings/ui/job-configure-settings.tsx
@@ -50,7 +50,9 @@ export function JobConfigureSettings(props: JobConfigureSettingsProps) {
             )}
           />
           <div className="mb-3 flex justify-between">
-            <p className="text-neutral-400 text-xs">{formatCronExpression(watchSchedule)}</p>
+            <p className="text-neutral-400 text-xs">
+              {formatCronExpression(watchSchedule) ? formatCronExpression(watchSchedule) + ' (UTC)' : ''}
+            </p>
             <ExternalLink href="https://crontab.guru" size="xs" className="text-neutral-350">
               CRON expression builder
             </ExternalLink>


### PR DESCRIPTION
# What does this PR do?

- ensure it is clear that the scheduling is in UTC
- display job scheduling in UTC to align it with the setup


![image](https://github.com/Qovery/console/assets/105300721/9d3ee403-85e6-4cc9-9834-c512da293839)

NOTE: we could convert everything in browser timezone, including the result from the library cronstrue (to be updated to the latest version to add the timezone offset) but this is a quicker fix and in the future we should add instead a global UI switch to display the data based on the user preferences

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
