### PR TITLE
fix: added reason to last_terminated error message

### DIFF
--- a/libs/domains/services/feature/src/lib/pod-details/__snapshots__/pod-details.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/pod-details/__snapshots__/pod-details.spec.tsx.snap
@@ -330,7 +330,10 @@ exports[`PodDetails should match snapshot with git based pod and with last_termi
               <dd
                 class="text-neutral-400 font-medium dark:text-white dark:font-normal"
               >
-                Baz
+                Baz reason
+                :
+                 
+                baz
                  (
                 1
                 ).

--- a/libs/domains/services/feature/src/lib/pod-details/pod-details.tsx
+++ b/libs/domains/services/feature/src/lib/pod-details/pod-details.tsx
@@ -126,8 +126,8 @@ export function PodDetails({ pod, serviceId, serviceType }: PodDetailsProps) {
                           {last_terminated_state.finished_at && dateFullFormat(last_terminated_state.finished_at)}
                         </Dt>
                         <Dd>
-                          {upperCaseFirstLetter(last_terminated_state.exit_code_message)} (
-                          {last_terminated_state.exit_code}).
+                          {upperCaseFirstLetter(last_terminated_state.reason)}:{' '}
+                          {last_terminated_state.exit_code_message} ({last_terminated_state.exit_code}).
                           {restart_count ? (
                             <>
                               <br />


### PR DESCRIPTION
# What does this PR do?

add the last_terminated_state.reason at the beginning of the last_terminated message of a pod

https://qovery.atlassian.net/browse/FRT-951

⚠️ ⚠️ : tests are not passing


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
