### PR TITLE
fix(services): fix react error when reloading page

### DIFF
--- a/libs/pages/application/src/lib/ui/container/container.tsx
+++ b/libs/pages/application/src/lib/ui/container/container.tsx
@@ -98,11 +98,13 @@ export function Container({ service, environment, children }: PropsWithChildren<
             {service?.serviceType === 'HELM' ? (
               <ServiceActionToolbar serviceId={service.id} />
             ) : (
-              <ApplicationButtonsActions
-                application={service as ApplicationEntity}
-                environmentMode={environment.mode}
-                clusterId={environment.cluster_id}
-              />
+              service && (
+                <ApplicationButtonsActions
+                  application={service as ApplicationEntity}
+                  environmentMode={environment.mode}
+                  clusterId={environment.cluster_id}
+                />
+              )
             )}
           </div>
         )}


### PR DESCRIPTION
This occurs when you reload an application settings page, the `getServiceType` isn't fully type safe and can lead to this error
