### PR TITLE
fix(services): fix helm networking settings

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-networking-feature/page-settings-networking-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-networking-feature/page-settings-networking-feature.tsx
@@ -17,7 +17,7 @@ export function PageSettingsNetworkingFeature() {
   const methods = useForm<HelmNetworkingData>({
     mode: 'onChange',
     defaultValues: {
-      ports: [],
+      ports: service?.ports ?? [],
     },
   })
   const ports = methods.watch('ports')


### PR DESCRIPTION
# What does this PR do?

Add missing helm networking initial values
