### PR TITLE
chore(depl-restriction): updated links

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-deployment-restrictions-feature/page-settings-deployment-restrictions-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-deployment-restrictions-feature/page-settings-deployment-restrictions-feature.tsx
@@ -77,7 +77,7 @@ export function PageSettingsDeploymentRestrictionsFeature() {
         description="Need help? You may find these links useful"
         links={[
           {
-            link: 'https://hub.qovery.com/docs/using-qovery/configuration/environment/#auto-deploy',
+            link: 'https://hub.qovery.com/docs/using-qovery/deployment/deploying-with-auto-deploy/#filtering-commits-triggering-the-auto-deploy',
             linkLabel: 'How to configure the deployment restrictions',
           },
         ]}

--- a/libs/pages/application/src/lib/ui/page-settings-deployment-restrictions/crud-modal/crud-modal.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-deployment-restrictions/crud-modal/crud-modal.tsx
@@ -36,7 +36,7 @@ export function CrudModal({ onClose, onSubmit, isEdit, isLoading }: CrudModalPro
           <p>Wildcards are not supported in the "Value" field</p>
           <ExternalLink
             className="mt-2"
-            href="https://hub.qovery.com/docs/using-qovery/configuration/environment/#auto-deploy"
+            href="https://hub.qovery.com/docs/using-qovery/deployment/deploying-with-auto-deploy/#filtering-commits-triggering-the-auto-deploy"
           >
             Documentation
           </ExternalLink>


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/browse/FRT-964

updated links to point to the new deployment restriction doc

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [ ] I made sure the code is type safe (no any)
