### PR TITLE
fix(need-redeploy-flag): database id

### DIFF
--- a/libs/domains/services/feature/src/lib/need-redeploy-flag/need-redeploy-flag.tsx
+++ b/libs/domains/services/feature/src/lib/need-redeploy-flag/need-redeploy-flag.tsx
@@ -7,19 +7,18 @@ import { useDeploymentStatus } from '../hooks/use-deployment-status/use-deployme
 import { useService } from '../hooks/use-service/use-service'
 
 export function NeedRedeployFlag() {
-  const { organizationId = '', projectId = '', environmentId = '', applicationId = '' } = useParams()
+  const { organizationId = '', projectId = '', environmentId = '', applicationId = '', databaseId = '' } = useParams()
   const navigate = useNavigate()
 
-  const { data: service } = useService({ serviceId: applicationId })
+  const { data: service } = useService({ environmentId, serviceId: applicationId || databaseId })
   const { data: serviceDeploymentStatus } = useDeploymentStatus({
     environmentId,
     serviceId: service?.id,
   })
+  const { mutate: deployService } = useDeployService({ environmentId })
 
   const serviceDeploymentStatusState =
     serviceDeploymentStatus?.service_deployment_status ?? ServiceDeploymentStatusEnum.NEVER_DEPLOYED
-
-  const { mutate: deployService } = useDeployService({ environmentId })
 
   if (serviceDeploymentStatusState === ServiceDeploymentStatusEnum.UP_TO_DATE) return null
 
@@ -29,7 +28,7 @@ export function NeedRedeployFlag() {
   const mutationDeployService = () => {
     if (service) {
       deployService({ serviceId: service.id, serviceType: service.serviceType })
-      navigate(ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + DEPLOYMENT_LOGS_URL(applicationId))
+      navigate(ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) + DEPLOYMENT_LOGS_URL(service.id))
     }
   }
 

--- a/libs/pages/database/src/lib/feature/page-settings-feature/page-settings-feature.tsx
+++ b/libs/pages/database/src/lib/feature/page-settings-feature/page-settings-feature.tsx
@@ -13,7 +13,7 @@ import PageSettings from '../../ui/page-settings/page-settings'
 
 export function PageSettingsFeature() {
   const { organizationId = '', projectId = '', environmentId = '', databaseId = '' } = useParams()
-  const { data: database } = useService({ serviceId: databaseId })
+  const { data: database } = useService({ environmentId, serviceId: databaseId })
 
   useDocumentTitle('Database - Settings')
 

--- a/libs/pages/database/src/lib/feature/page-settings-feature/page-settings-feature.tsx
+++ b/libs/pages/database/src/lib/feature/page-settings-feature/page-settings-feature.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Route, Routes, useParams } from 'react-router-dom'
+import { useService } from '@qovery/domains/services/feature'
 import {
   DATABASE_SETTINGS_DANGER_ZONE_URL,
   DATABASE_SETTINGS_GENERAL_URL,
@@ -12,8 +13,11 @@ import PageSettings from '../../ui/page-settings/page-settings'
 
 export function PageSettingsFeature() {
   const { organizationId = '', projectId = '', environmentId = '', databaseId = '' } = useParams()
+  const { data: database } = useService({ serviceId: databaseId })
 
-  useDocumentTitle('Application - Settings')
+  useDocumentTitle('Database - Settings')
+
+  if (!database) return null
 
   const pathSettings = `${DATABASE_URL(organizationId, projectId, environmentId, databaseId)}${DATABASE_SETTINGS_URL}`
 


### PR DESCRIPTION
# What does this PR do?

<img width="604" alt="Capture d’écran 2024-01-09 à 14 33 43" src="https://github.com/Qovery/console/assets/533928/9dbf034b-e0f3-4505-ab40-6ef45d6b3359">

And, add condition to waiting `database` before displaying settings, because we have a bug when we reload settings we don't see default values.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
