### PR TITLE
fix(cluster-settings): title remote access

### DIFF
--- a/libs/pages/cluster/src/lib/ui/page-settings-remote/page-settings-remote.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-remote/page-settings-remote.tsx
@@ -1,7 +1,7 @@
 import { type FormEventHandler } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ClusterRemoteSettings } from '@qovery/shared/console-shared'
-import { ButtonLegacy, ButtonLegacySize, ButtonLegacyStyle, HelpSection } from '@qovery/shared/ui'
+import { ButtonLegacy, ButtonLegacySize, ButtonLegacyStyle, Heading, HelpSection, Section } from '@qovery/shared/ui'
 
 export interface PageSettingsRemoteProps {
   onSubmit: FormEventHandler<HTMLFormElement>
@@ -14,8 +14,8 @@ export function PageSettingsRemote(props: PageSettingsRemoteProps) {
 
   return (
     <div className="flex flex-col justify-between w-full">
-      <div className="p-8 max-w-content-with-navigation-left">
-        <h2 className="h5 mb-2 text-neutral-400">Remote access</h2>
+      <Section className="p-8 max-w-content-with-navigation-left">
+        <Heading className="mb-8">Remote access</Heading>
         <form onSubmit={onSubmit}>
           <ClusterRemoteSettings fromDetail />
           <div className="flex justify-end">
@@ -32,7 +32,7 @@ export function PageSettingsRemote(props: PageSettingsRemoteProps) {
             </ButtonLegacy>
           </div>
         </form>
-      </div>
+      </Section>
       <HelpSection
         description="Need help? You may find these links useful"
         links={[


### PR DESCRIPTION
# What does this PR do?

<img width="1437" alt="Capture d’écran 2024-02-15 à 11 14 54" src="https://github.com/Qovery/console/assets/533928/83e29745-4d8e-4596-b48a-1a73217f5048">


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
