### PR TITLE
fix(environment): invalidate new environment queries for editing

### DIFF
--- a/libs/domains/environment/src/lib/slices/environments.queries.ts
+++ b/libs/domains/environment/src/lib/slices/environments.queries.ts
@@ -76,7 +76,7 @@ export const useEditEnvironment = (projectId: string, onSettledCallback: () => v
     },
     {
       onSuccess: (result, variables) => {
-        // Needed to invalidate the environment quey with new format
+        // Needed to invalidate the environment query with new data access
         queryClient.invalidateQueries({
           queryKey: queries.environments.detail(variables.environmentId).queryKey,
         })

--- a/libs/domains/environment/src/lib/slices/environments.queries.ts
+++ b/libs/domains/environment/src/lib/slices/environments.queries.ts
@@ -19,6 +19,7 @@ import {
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { ToastEnum, toast, toastError } from '@qovery/shared/ui'
 import { refactoPayload } from '@qovery/shared/util-js'
+import { queries } from '@qovery/state/util-queries'
 
 export const ENVIRONMENTS_FEATURE_KEY = 'environments'
 
@@ -75,6 +76,11 @@ export const useEditEnvironment = (projectId: string, onSettledCallback: () => v
     },
     {
       onSuccess: (result, variables) => {
+        // Needed to invalidate the environment quey with new format
+        queryClient.invalidateQueries({
+          queryKey: queries.environments.detail(variables.environmentId).queryKey,
+        })
+
         queryClient.setQueryData<Environment[] | undefined>(['project', projectId, 'environments'], (old) => {
           return old?.map((environment) => (environment.id === variables.environmentId ? result : environment))
         })


### PR DESCRIPTION
# What does this PR do?

- Invalidate the environment query with new data access

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
