### PR TITLE
fix(environments): fix use-environments if projectId missing

### DIFF
--- a/libs/domains/environments/feature/src/lib/hooks/use-environments/use-environments.ts
+++ b/libs/domains/environments/feature/src/lib/hooks/use-environments/use-environments.ts
@@ -15,6 +15,7 @@ export function useEnvironments({ projectId }: UseEnvironmentsProps) {
       environments?.sort(({ name: nameA }, { name: nameB }) => nameA.localeCompare(nameB))
       return environments
     },
+    enabled: Boolean(projectId),
   })
 
   const runningStatusResults = useQueries({


### PR DESCRIPTION
# What does this PR do?

Prevent this error on cluster pages
![2024-02-15-120719_1920x163_scrot](https://github.com/Qovery/console/assets/1716173/aa8db875-01ea-4c48-b8be-2c1ee79b6f59)

