### PR TITLE
fix(clusters): hide replace kubeconfig which isn't implemented now

### DIFF
--- a/libs/pages/cluster/src/lib/ui/page-settings-kubeconfig/__snapshots__/page-settings-kubeconfig.spec.tsx.snap
+++ b/libs/pages/cluster/src/lib/ui/page-settings-kubeconfig/__snapshots__/page-settings-kubeconfig.spec.tsx.snap
@@ -55,7 +55,7 @@ exports[`PageSettingsKubeconfig should match snapshot 1`] = `
           </a>
         </div>
         <div
-          class="flex gap-2"
+          class="flex gap-2 hidden"
         >
           <button
             class="inline-flex items-center shrink-0 font-medium transition text-xs h-7 px-2 rounded border border-neutral-250 dark:border-neutral-350 text-neutral-400 dark:text-neutral-300 hover:[&:not(:active)]:border-neutral-300 active:bg-neutral-150 disabled:text-neutral-300 disabled:bg-neutral-150 disabled:border-none bg-transparent"

--- a/libs/pages/cluster/src/lib/ui/page-settings-kubeconfig/page-settings-kubeconfig.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-kubeconfig/page-settings-kubeconfig.tsx
@@ -59,7 +59,7 @@ export function PageSettingsKubeconfig({ cluster, onSubmit }: PageSettingsKubeco
               View <Icon name={IconAwesomeEnum.EYE} />
             </Link>
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 hidden">
             <Button type="button" variant="outline" {...getRootProps()} color="neutral">
               <input {...getInputProps()} />
               <Icon name={IconAwesomeEnum.ARROWS_ROTATE} />


### PR DESCRIPTION
# What does this PR do?

Hide kubeconfig for now because it's not implemented backend side

