### PR TITLE
fix(ui): fix icons

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-action-toolbar/__snapshots__/cluster-action-toolbar.spec.tsx.snap
+++ b/libs/domains/clusters/feature/src/lib/cluster-action-toolbar/__snapshots__/cluster-action-toolbar.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`ClusterActionToolbar should match manage deployment snapshot 1`] = `
         />
         <i
           aria-hidden="true"
-          class="fa-solid fa-angle-down "
+          class="fa-solid fa-chevron-down "
         />
       </div>
     </button>
@@ -215,7 +215,7 @@ exports[`ClusterActionToolbar should match other actions snapshot 1`] = `
         />
         <i
           aria-hidden="true"
-          class="fa-solid fa-angle-down "
+          class="fa-solid fa-chevron-down "
         />
       </div>
     </button>

--- a/libs/domains/clusters/feature/src/lib/cluster-action-toolbar/cluster-action-toolbar.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-action-toolbar/cluster-action-toolbar.tsx
@@ -93,7 +93,7 @@ function MenuManageDeployment({ cluster, clusterStatus }: { cluster: Cluster; cl
           <Tooltip content="Manage Deployment">
             <div className="flex items-center justify-center w-full h-full">
               <Icon iconName="play" className="mr-4" />
-              <Icon iconName="angle-down" />
+              <Icon iconName="chevron-down" />
             </div>
           </Tooltip>
         </ActionToolbar.Button>

--- a/libs/domains/environments/feature/src/lib/environment-action-toolbar/__snapshots__/environment-action-toolbar.spec.tsx.snap
+++ b/libs/domains/environments/feature/src/lib/environment-action-toolbar/__snapshots__/environment-action-toolbar.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`EnvironmentActionToolbar should match manage deployment snapshot 1`] = 
         />
         <i
           aria-hidden="true"
-          class="fa-solid fa-angle-down "
+          class="fa-solid fa-chevron-down "
         />
       </div>
     </button>
@@ -219,7 +219,7 @@ exports[`EnvironmentActionToolbar should match other actions snapshot 1`] = `
         />
         <i
           aria-hidden="true"
-          class="fa-solid fa-angle-down "
+          class="fa-solid fa-chevron-down "
         />
       </div>
     </button>

--- a/libs/domains/environments/feature/src/lib/environment-action-toolbar/environment-action-toolbar.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-action-toolbar/environment-action-toolbar.tsx
@@ -78,7 +78,7 @@ function MenuManageDeployment({ environment, state }: { environment: Environment
           <Tooltip content="Manage Deployment">
             <div className="flex items-center justify-center w-full h-full">
               <Icon iconName="play" className="mr-4" />
-              <Icon iconName="angle-down" />
+              <Icon iconName="chevron-down" />
             </div>
           </Tooltip>
         </ActionToolbar.Button>

--- a/libs/domains/environments/feature/src/lib/environment-list/__snapshots__/environment-list.spec.tsx.snap
+++ b/libs/domains/environments/feature/src/lib/environment-list/__snapshots__/environment-list.spec.tsx.snap
@@ -25,7 +25,7 @@ exports[`EnvironmentList should match snapshot 1`] = `
               Environment
               <i
                 aria-hidden="true"
-                class="fa-solid fa-angle-down "
+                class="fa-solid fa-chevron-down "
               />
             </button>
           </div>
@@ -48,7 +48,7 @@ exports[`EnvironmentList should match snapshot 1`] = `
               Environment status
               <i
                 aria-hidden="true"
-                class="fa-solid fa-angle-down "
+                class="fa-solid fa-chevron-down "
               />
             </button>
           </div>
@@ -71,7 +71,7 @@ exports[`EnvironmentList should match snapshot 1`] = `
               Last deployment
               <i
                 aria-hidden="true"
-                class="fa-solid fa-angle-down "
+                class="fa-solid fa-chevron-down "
               />
             </button>
           </div>
@@ -94,7 +94,7 @@ exports[`EnvironmentList should match snapshot 1`] = `
               Cluster
               <i
                 aria-hidden="true"
-                class="fa-solid fa-angle-down "
+                class="fa-solid fa-chevron-down "
               />
             </button>
           </div>

--- a/libs/domains/environments/feature/src/lib/environment-list/environment-list-filter.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-list/environment-list-filter.tsx
@@ -45,7 +45,7 @@ export function EnvironmentListFilter({ column }: { column: Column<any, unknown>
               ) : (
                 <>
                   {column.columnDef.header?.toString()}
-                  <Icon iconName="angle-down" />
+                  <Icon iconName="chevron-down" />
                 </>
               )}
             </Button>

--- a/libs/domains/services/feature/src/lib/service-action-toolbar/__snapshots__/service-action-toolbar.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-action-toolbar/__snapshots__/service-action-toolbar.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`ServiceActionToolbar should match manage deployment snapshot 1`] = `
         />
         <i
           aria-hidden="true"
-          class="fa-solid fa-angle-down "
+          class="fa-solid fa-chevron-down "
         />
       </div>
     </button>
@@ -206,7 +206,7 @@ exports[`ServiceActionToolbar should match other actions snapshot 1`] = `
         />
         <i
           aria-hidden="true"
-          class="fa-solid fa-angle-down "
+          class="fa-solid fa-chevron-down "
         />
       </div>
     </button>

--- a/libs/domains/services/feature/src/lib/service-action-toolbar/service-action-toolbar.tsx
+++ b/libs/domains/services/feature/src/lib/service-action-toolbar/service-action-toolbar.tsx
@@ -237,7 +237,7 @@ function MenuManageDeployment({
           <Tooltip content="Manage Deployment">
             <div className="flex items-center justify-center w-full h-full">
               <Icon iconName="play" className="mr-4" />
-              <Icon iconName="angle-down" />
+              <Icon iconName="chevron-down" />
             </div>
           </Tooltip>
         </ActionToolbar.Button>

--- a/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
@@ -45,7 +45,7 @@ exports[`ServiceList should match snapshot 1`] = `
                 Name
                 <i
                   aria-hidden="true"
-                  class="fa-solid fa-angle-down "
+                  class="fa-solid fa-chevron-down "
                 />
               </button>
             </div>
@@ -68,7 +68,7 @@ exports[`ServiceList should match snapshot 1`] = `
                 Service status
                 <i
                   aria-hidden="true"
-                  class="fa-solid fa-angle-down "
+                  class="fa-solid fa-chevron-down "
                 />
               </button>
             </div>
@@ -91,7 +91,7 @@ exports[`ServiceList should match snapshot 1`] = `
                 Last deployment
                 <i
                   aria-hidden="true"
-                  class="fa-solid fa-angle-down "
+                  class="fa-solid fa-chevron-down "
                 />
               </button>
             </div>

--- a/libs/domains/services/feature/src/lib/service-list/service-list-filter.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-filter.tsx
@@ -45,7 +45,7 @@ export function ServiceListFilter({ column }: { column: Column<any, unknown> }) 
               ) : (
                 <>
                   {column.columnDef.header?.toString()}
-                  <Icon iconName="angle-down" />
+                  <Icon iconName="chevron-down" />
                 </>
               )}
             </Button>

--- a/libs/shared/ui/src/lib/components/action-toolbar/action-toolbar.stories.tsx
+++ b/libs/shared/ui/src/lib/components/action-toolbar/action-toolbar.stories.tsx
@@ -23,7 +23,7 @@ export const Primary = {
         <DropdownMenu.Trigger asChild>
           <ActionToolbar.Button>
             <Icon iconName="play" className="mr-4" />
-            <Icon iconName="angle-down" />
+            <Icon iconName="chevron-down" />
           </ActionToolbar.Button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content>
@@ -54,7 +54,7 @@ export const Brand = {
         <DropdownMenu.Trigger asChild>
           <ActionToolbar.Button color="brand" variant="solid">
             <Icon iconName="play" className="mr-4" />
-            <Icon iconName="angle-down" />
+            <Icon iconName="chevron-down" />
           </ActionToolbar.Button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content>


### PR DESCRIPTION
# What does this PR do?

FontAwesome distinguish `angle-down` from `chevron-down` where
`chevron-*` seems to be centered horizontally / vertically

`angle-down`
![2024-04-18-163037_246x49_scrot](https://github.com/Qovery/console/assets/1716173/494499d4-60f5-4ab8-99e1-2ced1167e1f0)

`chevron-down`
![2024-04-18-163016_249x48_scrot](https://github.com/Qovery/console/assets/1716173/9e959a16-eb1e-4df5-9f74-bc9b11605d47)

