### PR TITLE
chore: fix storybook config

### DIFF
--- a/libs/shared/ui/.storybook/preview.tsx
+++ b/libs/shared/ui/.storybook/preview.tsx
@@ -1,5 +1,5 @@
 import { TooltipProvider } from '@radix-ui/react-tooltip'
-import { withThemeByDataAttribute } from '@storybook/addon-themes'
+import { withThemeByClassName } from '@storybook/addon-themes'
 import { type Preview } from '@storybook/react'
 import { MemoryRouter } from 'react-router-dom'
 import '../src/lib/styles/main.scss'
@@ -11,13 +11,12 @@ const preview: Preview = {
     },
   },
   decorators: [
-    withThemeByDataAttribute({
+    withThemeByClassName({
       themes: {
         light: 'light',
         dark: 'dark',
       },
       defaultTheme: 'light',
-      attributeName: 'data-mode',
     }),
     (Story) => (
       <MemoryRouter initialEntries={['/']}>


### PR DESCRIPTION
# What does this PR do?

https://github.com/Qovery/console/pull/1349/files#diff-98b116aa7b1f6ac5f26ea2e8c101af671143eccbbdaa510720584c0fe07d4e78R91

Due to style conflict with log pages and data attribute, we need to use `withThemeByClassName` instead of `withThemeByDataAttribute`

https://github.com/storybookjs/storybook/blob/next/code/addons/themes/docs/api.md