### PR TITLE
fix(services): fix running status on first deployment

### DIFF
--- a/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
+++ b/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
@@ -74,6 +74,7 @@ export function useStatusWebSockets({
     },
     // NOTE: projectId is not required by the API but it limits WS messages when cluster handles my environments / services
     enabled: Boolean(organizationId) && Boolean(clusterId) && Boolean(projectId),
+    shouldReconnect: true,
     onMessage(queryClient, message: ServiceStatusDto) {
       for (const env of message.environments) {
         queryClient.setQueryData(queries.environments.runningStatus(env.id).queryKey, () => ({


### PR DESCRIPTION
# What does this PR do?

During the first deployment, the websocket can timeout because the websocket isn't completely setup.
We must auto-reconnect till connection is setup.

https://qovery.atlassian.net/browse/FRT-1119

