### PR TITLE
fix(ui): add fakeModal to avoid scroll lock in select nested in modal

### DIFF
--- a/libs/pages/settings/src/lib/feature/page-organization-container-registries-feature/page-organization-container-registries-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-container-registries-feature/page-organization-container-registries-feature.tsx
@@ -29,6 +29,9 @@ export function PageOrganizationContainerRegistriesFeature() {
       onAddRegistry={() => {
         openModal({
           content: <ContainerRegistryCreateEditModal organizationId={organizationId} onClose={closeModal} />,
+          options: {
+            fakeModal: true,
+          },
         })
       }}
       onEdit={(registry: ContainerRegistryResponse) => {
@@ -41,6 +44,9 @@ export function PageOrganizationContainerRegistriesFeature() {
               isEdit
             />
           ),
+          options: {
+            fakeModal: true,
+          },
         })
       }}
       onDelete={(registry: ContainerRegistryResponse) => {

--- a/libs/shared/console-shared/src/lib/general-container-settings/ui/general-container-settings.tsx
+++ b/libs/shared/console-shared/src/lib/general-container-settings/ui/general-container-settings.tsx
@@ -52,6 +52,9 @@ export function GeneralContainerSettings({ organization }: GeneralContainerSetti
                         }}
                       />
                     ),
+                    options: {
+                      fakeModal: true,
+                    },
                   })
                 },
               }}

--- a/libs/shared/ui/src/lib/components/modal/modal-root.tsx
+++ b/libs/shared/ui/src/lib/components/modal/modal-root.tsx
@@ -5,6 +5,18 @@ import Modal from './modal'
 interface ModalOptions {
   width?: number
   fullScreen?: boolean
+  /**
+   * This is a workaround to avoid radix dialog restriction.
+   * Radix use [react-remove-scroll](https://www.npmjs.com/package/react-remove-scroll) to prevent wheel / scroll event directly on `<html>` node
+   * in some cases like with Select inside Modal, it causes issues.
+   * https://qovery.atlassian.net/browse/FRT-868
+   * https://qovery.atlassian.net/browse/FRT-1134
+   *
+   * It worth noting that scroll lock is also important for accessibility reasons
+   * This `fakeModal` mode is visually identical than the `modal` mode without the drawback of locking the scroll.
+   * https://github.com/radix-ui/primitives/blob/b32a93318cdfce383c2eec095710d35ffbd33a1c/packages/react/dialog/src/Dialog.tsx#L204
+   */
+  fakeModal?: boolean
 }
 
 interface DefaultContextProps {
@@ -32,6 +44,7 @@ export const defaultContext = {
   optionsModal: {
     width: 488,
     fullScreen: false,
+    fakeModal: false,
   },
   alertClickOutside: false,
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/libs/shared/ui/src/lib/components/modal/modal.tsx
+++ b/libs/shared/ui/src/lib/components/modal/modal.tsx
@@ -108,7 +108,19 @@ export const Modal = (props: ModalProps) => {
           }}
           className="modal__overlay fixed left-0 top-0 flex h-screen w-full bg-neutral-700/20"
         />
-        {fakeModal && <div className="modal__overlay fixed left-0 top-0 flex h-screen w-full bg-neutral-700/20" />}
+        {fakeModal && (
+          <div
+            className="modal__overlay fixed left-0 top-0 flex h-screen w-full bg-neutral-700/20"
+            onClick={(event) => {
+              if (alertClickOutside) {
+                event.preventDefault()
+                setModalAlertOpen(true)
+              } else {
+                setExternalOpen ? setExternalOpen(false) : setOpen(false)
+              }
+            }}
+          />
+        )}
         <Dialog.Content
           onPointerDownOutside={(event) => {
             event.preventDefault()

--- a/libs/shared/ui/src/lib/components/modal/modal.tsx
+++ b/libs/shared/ui/src/lib/components/modal/modal.tsx
@@ -14,6 +14,18 @@ export interface ModalProps {
   className?: string
   externalOpen?: boolean
   setExternalOpen?: (e: boolean) => void
+  /**
+   * This is a workaround to avoid radix dialog restriction.
+   * Radix use [react-remove-scroll](https://www.npmjs.com/package/react-remove-scroll) to prevent wheel / scroll event directly on `<html>` node
+   * in some cases like with Select inside Modal, it causes issues.
+   * https://qovery.atlassian.net/browse/FRT-868
+   * https://qovery.atlassian.net/browse/FRT-1134
+   *
+   * It worth noting that scroll lock is also important for accessibility reasons
+   * This `fakeModal` mode is visually identical than the `modal` mode without the drawback of locking the scroll.
+   * https://github.com/radix-ui/primitives/blob/b32a93318cdfce383c2eec095710d35ffbd33a1c/packages/react/dialog/src/Dialog.tsx#L204
+   */
+  fakeModal?: boolean
 }
 
 export interface ModalContentProps {
@@ -31,6 +43,7 @@ export const Modal = (props: ModalProps) => {
     buttonClose = true,
     externalOpen = false,
     setExternalOpen,
+    fakeModal = false,
   } = props
 
   const [open, setOpen] = useState(defaultOpen)
@@ -79,6 +92,7 @@ export const Modal = (props: ModalProps) => {
               setOpen(!open)
             }
       }
+      modal={!fakeModal}
     >
       {trigger && <div onClick={() => setOpen(!open)}>{trigger}</div>}
       <Dialog.Portal>
@@ -94,6 +108,7 @@ export const Modal = (props: ModalProps) => {
           }}
           className="modal__overlay fixed left-0 top-0 flex h-screen w-full bg-neutral-700/20"
         />
+        {fakeModal && <div className="modal__overlay fixed left-0 top-0 flex h-screen w-full bg-neutral-700/20" />}
         <Dialog.Content
           onPointerDownOutside={(event) => {
             event.preventDefault()

--- a/libs/shared/ui/src/lib/components/modal/use-modal/use-modal.tsx
+++ b/libs/shared/ui/src/lib/components/modal/use-modal/use-modal.tsx
@@ -6,6 +6,18 @@ export interface UseModalProps {
   options?: {
     width?: number
     fullScreen?: boolean
+    /**
+     * This is a workaround to avoid radix dialog restriction.
+     * Radix use [react-remove-scroll](https://www.npmjs.com/package/react-remove-scroll) to prevent wheel / scroll event directly on `<html>` node
+     * in some cases like with Select inside Modal, it causes issues.
+     * https://qovery.atlassian.net/browse/FRT-868
+     * https://qovery.atlassian.net/browse/FRT-1134
+     *
+     * It worth noting that scroll lock is also important for accessibility reasons
+     * This `fakeModal` mode is visually identical than the `modal` mode without the drawback of locking the scroll.
+     * https://github.com/radix-ui/primitives/blob/b32a93318cdfce383c2eec095710d35ffbd33a1c/packages/react/dialog/src/Dialog.tsx#L204
+     */
+    fakeModal?: boolean
   }
 }
 


### PR DESCRIPTION
# What does this PR do?

This is a workaround to avoid radix dialog restriction. Radix use [react-remove-scroll](https://www.npmjs.com/package/react-remove-scroll) to prevent wheel / scroll event directly on `<html>` node in some cases like with Select inside Modal, it causes issues. https://qovery.atlassian.net/browse/FRT-868
https://qovery.atlassian.net/browse/FRT-1134

It worth noting that scroll lock is also important for accessibility reasons This `fakeModal` mode is visually identical than the `modal` mode without the drawback of locking the scroll.

https://github.com/radix-ui/primitives/blob/b32a93318cdfce383c2eec095710d35ffbd33a1c/packages/react/dialog/src/Dialog.tsx#L204

