### PR TITLE
fix(cluster-settings): karpenter remove instance type condition

### DIFF
--- a/libs/pages/cluster/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.tsx
@@ -14,22 +14,20 @@ export const handleSubmit = (data: FieldValues, cluster: Cluster): Cluster => {
     instance_type: data['instance_type'],
   }
 
-  if (cluster.instance_type === 'KARPENTER') {
-    payload.features = cluster.features?.map((feature) => {
-      if (feature.id === 'KARPENTER') {
-        return {
-          ...feature,
-          value: {
-            spot_enabled: data['karpenter'].spot_enabled,
-            disk_size_in_gib: parseInt(data['karpenter'].disk_size_in_gib),
-            default_service_architecture: data['karpenter'].default_service_architecture,
-          },
-        }
+  payload.features = cluster.features?.map((feature) => {
+    if (feature.id === 'KARPENTER') {
+      return {
+        ...feature,
+        value: {
+          spot_enabled: data['karpenter'].spot_enabled,
+          disk_size_in_gib: parseInt(data['karpenter'].disk_size_in_gib),
+          default_service_architecture: data['karpenter'].default_service_architecture,
+        },
       }
+    }
 
-      return feature
-    })
-  }
+    return feature
+  })
 
   return payload
 }


### PR DESCRIPTION
# What does this PR do?

Removing the condition to allow editing when the cluster is migrated

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
