### PR TITLE
fix(service-terminal): remove bind escap to close terminal

### DIFF
--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -68,8 +68,6 @@ export function ServiceTerminal({
     [setOpen]
   )
 
-  const onKeyUpHandler = useCallback((event: KeyboardEvent) => event.key === 'Escape' && setOpen(false), [setOpen])
-
   // Necesssary to calculate the number of rows and columns (tty) for the terminal
   // https://github.com/xtermjs/xterm.js/issues/1412#issuecomment-724421101
   // 16 is the font height
@@ -180,7 +178,7 @@ export function ServiceTerminal({
             <LoaderSpinner />
           </div>
         ) : (
-          <MemoizedXTerm className="h-full" onKeyUp={onKeyUpHandler} addons={addons} />
+          <MemoizedXTerm className="h-full" addons={addons} />
         )}
       </div>
     </div>,


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-1179

I can't find any cool solution to keep the escape bind. I think the best way is to remove it and hand over control to the terminal

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
