### PR TITLE
fix(parser-args): remove quote for back-end and display it for UI only

### DIFF
--- a/libs/domains/service-helm/feature/src/lib/deployment-setting/deployment-setting.tsx
+++ b/libs/domains/service-helm/feature/src/lib/deployment-setting/deployment-setting.tsx
@@ -1,10 +1,10 @@
 import { Controller, useFormContext } from 'react-hook-form'
 import { ExternalLink, InputText, InputToggle } from '@qovery/shared/ui'
-import { parseCmd } from '@qovery/shared/util-js'
+import { joinArgsWithQuotes, parseCmd } from '@qovery/shared/util-js'
 
 export const displayParsedCmd = (cmd: string) => {
   const parsedArgs = parseCmd(cmd)
-  return parsedArgs.join(' ')
+  return joinArgsWithQuotes(parsedArgs)
 }
 
 export function DeploymentSetting() {

--- a/libs/pages/application/src/lib/feature/page-settings-general-feature/page-settings-general-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-general-feature/page-settings-general-feature.tsx
@@ -19,7 +19,7 @@ import { useEditService, useService } from '@qovery/domains/services/feature'
 import { type HelmGeneralData } from '@qovery/pages/services'
 import { isHelmGitSource, isHelmRepositorySource, isJobContainerSource, isJobGitSource } from '@qovery/shared/enums'
 import { type ApplicationGeneralData, type JobGeneralData } from '@qovery/shared/interfaces'
-import { buildGitRepoUrl, parseCmd } from '@qovery/shared/util-js'
+import { buildGitRepoUrl, joinArgsWithQuotes, parseCmd } from '@qovery/shared/util-js'
 import PageSettingsGeneral from '../../ui/page-settings-general/page-settings-general'
 
 export const handleGitApplicationSubmit = (
@@ -222,7 +222,7 @@ export function PageSettingsGeneralFeature() {
       dockerfile_path: service.dockerfile_path ?? 'Dockerfile',
       build_mode: service.build_mode,
       image_entry_point: service.entrypoint,
-      cmd_arguments: service.arguments?.length ? service.arguments.join(' ') : '',
+      cmd_arguments: service.arguments?.length ? joinArgsWithQuotes(service.arguments) : '',
       labels_groups: service.labels_groups?.map((group) => group.id),
       annotations_groups: service.annotations_groups?.map((group) => group.id),
     }))
@@ -232,7 +232,7 @@ export function PageSettingsGeneralFeature() {
       image_tag: service.tag,
       image_entry_point: service.entrypoint,
       auto_deploy: service.auto_deploy,
-      cmd_arguments: service.arguments?.length ? service.arguments.join(' ') : '',
+      cmd_arguments: service.arguments?.length ? joinArgsWithQuotes(service.arguments) : '',
       labels_groups: service.labels_groups?.map((group) => group.id),
       annotations_groups: service.annotations_groups?.map((group) => group.id),
     }))
@@ -274,7 +274,7 @@ export function PageSettingsGeneralFeature() {
       auto_preview: service.auto_preview,
       allow_cluster_wide_resources: service.allow_cluster_wide_resources,
       timeout_sec: service.timeout_sec,
-      arguments: service.arguments.join(' '),
+      arguments: joinArgsWithQuotes(service.arguments),
     }))
     .otherwise(() => undefined)
 

--- a/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.spec.tsx
+++ b/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.spec.tsx
@@ -1,4 +1,5 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
+import { joinArgsWithQuotes } from '@qovery/shared/util-js'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import EntrypointCmdInputs, { displayParsedCmd } from './entrypoint-cmd-inputs'
 
@@ -30,5 +31,37 @@ describe('displayParsedCmd', () => {
   it('command with special operator', () => {
     const cmd = 'docker run --entrypoint test image-name arg1 arg2 ||'
     expect(displayParsedCmd(cmd)).toBe('docker run --entrypoint test image-name arg1 arg2 ||')
+  })
+})
+
+describe('joinArgsWithQuotes', () => {
+  it('should handle single word arguments correctly', () => {
+    const input = ['arg1', 'arg2']
+    const expected = 'arg1 arg2'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
+  })
+
+  it('should handle arguments with multiple words correctly', () => {
+    const input = ['arg1', 'arg3 arg4']
+    const expected = 'arg1 "arg3 arg4"'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
+  })
+
+  it('should handle arguments starting with # correctly', () => {
+    const input = ['arg1', '# hello world 123']
+    const expected = 'arg1 # hello world 123'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
+  })
+
+  it('should handle mixed arguments correctly', () => {
+    const input = ['arg2', 'arg3 arg4', '# test test test']
+    const expected = 'arg2 "arg3 arg4" # test test test'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
+  })
+
+  it('should handle multiple words starting with # correctly', () => {
+    const input = ['# singleword', 'multiple words here']
+    const expected = '# singleword "multiple words here"'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
   })
 })

--- a/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.spec.tsx
+++ b/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.spec.tsx
@@ -24,7 +24,7 @@ describe('displayParsedCmd', () => {
 
   it('command with comment', () => {
     const cmd = 'docker run --entrypoint test image-name arg1 arg2 # comment'
-    expect(displayParsedCmd(cmd)).toBe('docker run --entrypoint test image-name arg1 arg2 #  comment')
+    expect(displayParsedCmd(cmd)).toBe('docker run --entrypoint test image-name arg1 arg2 # comment')
   })
 
   it('command with special operator', () => {

--- a/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.spec.tsx
+++ b/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.spec.tsx
@@ -1,5 +1,4 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
-import { joinArgsWithQuotes } from '@qovery/shared/util-js'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import EntrypointCmdInputs, { displayParsedCmd } from './entrypoint-cmd-inputs'
 
@@ -31,37 +30,5 @@ describe('displayParsedCmd', () => {
   it('command with special operator', () => {
     const cmd = 'docker run --entrypoint test image-name arg1 arg2 ||'
     expect(displayParsedCmd(cmd)).toBe('docker run --entrypoint test image-name arg1 arg2 ||')
-  })
-})
-
-describe('joinArgsWithQuotes', () => {
-  it('should handle single word arguments correctly', () => {
-    const input = ['arg1', 'arg2']
-    const expected = 'arg1 arg2'
-    expect(joinArgsWithQuotes(input)).toBe(expected)
-  })
-
-  it('should handle arguments with multiple words correctly', () => {
-    const input = ['arg1', 'arg3 arg4']
-    const expected = 'arg1 "arg3 arg4"'
-    expect(joinArgsWithQuotes(input)).toBe(expected)
-  })
-
-  it('should handle arguments starting with # correctly', () => {
-    const input = ['arg1', '# hello world 123']
-    const expected = 'arg1 # hello world 123'
-    expect(joinArgsWithQuotes(input)).toBe(expected)
-  })
-
-  it('should handle mixed arguments correctly', () => {
-    const input = ['arg2', 'arg3 arg4', '# test test test']
-    const expected = 'arg2 "arg3 arg4" # test test test'
-    expect(joinArgsWithQuotes(input)).toBe(expected)
-  })
-
-  it('should handle multiple words starting with # correctly', () => {
-    const input = ['# singleword', 'multiple words here']
-    const expected = '# singleword "multiple words here"'
-    expect(joinArgsWithQuotes(input)).toBe(expected)
   })
 })

--- a/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.tsx
+++ b/libs/shared/console-shared/src/lib/entrypoint-cmd-inputs/ui/entrypoint-cmd-inputs.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from 'react-hook-form'
 import { InputText } from '@qovery/shared/ui'
-import { parseCmd } from '@qovery/shared/util-js'
+import { joinArgsWithQuotes, parseCmd } from '@qovery/shared/util-js'
 
 export interface EntrypointCmdInputsProps {
   entrypointRequired?: boolean
@@ -11,7 +11,7 @@ export interface EntrypointCmdInputsProps {
 
 export const displayParsedCmd = (cmd: string) => {
   const parsedArgs = parseCmd(cmd)
-  return parsedArgs.join(' ')
+  return joinArgsWithQuotes(parsedArgs)
 }
 
 export function EntrypointCmdInputs({

--- a/libs/shared/util-js/src/lib/parse-cmd.spec.ts
+++ b/libs/shared/util-js/src/lib/parse-cmd.spec.ts
@@ -1,4 +1,4 @@
-import { parseCmd } from './parse-cmd'
+import { joinArgsWithQuotes, parseCmd } from './parse-cmd'
 
 describe('parseCmd function', () => {
   it('should parse a simple command string', () => {
@@ -22,7 +22,7 @@ describe('parseCmd function', () => {
   it('should handle comments', () => {
     const cmd = 'docker run nginx # start nginx container'
     const result = parseCmd(cmd)
-    expect(result).toEqual(['docker', 'run', 'nginx', '#', ' start nginx container'])
+    expect(result).toEqual(['docker', 'run', 'nginx', '# start nginx container'])
   })
 
   it('should handle env variables', () => {
@@ -43,8 +43,39 @@ describe('parseCmd function', () => {
       '8080:80',
       'nginx',
       'arg arg',
-      '#',
-      ' start nginx container',
+      '# start nginx container',
     ])
+  })
+})
+
+describe('joinArgsWithQuotes', () => {
+  it('should handle single word arguments correctly', () => {
+    const input = ['arg1', 'arg2']
+    const expected = 'arg1 arg2'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
+  })
+
+  it('should handle arguments with multiple words correctly', () => {
+    const input = ['arg1', 'arg3 arg4']
+    const expected = 'arg1 "arg3 arg4"'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
+  })
+
+  it('should handle arguments starting with # correctly', () => {
+    const input = ['arg1', '# hello world 123']
+    const expected = 'arg1 # hello world 123'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
+  })
+
+  it('should handle mixed arguments correctly', () => {
+    const input = ['arg2', 'arg3 arg4', '# test test test']
+    const expected = 'arg2 "arg3 arg4" # test test test'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
+  })
+
+  it('should handle multiple words starting with # correctly', () => {
+    const input = ['# singleword', 'multiple words here']
+    const expected = '# singleword "multiple words here"'
+    expect(joinArgsWithQuotes(input)).toBe(expected)
   })
 })

--- a/libs/shared/util-js/src/lib/parse-cmd.spec.ts
+++ b/libs/shared/util-js/src/lib/parse-cmd.spec.ts
@@ -10,7 +10,7 @@ describe('parseCmd function', () => {
   it('should handle quoted arguments', () => {
     const cmd = 'docker run -v  "arg arg" "/data:/mnt/data" nginx'
     const result = parseCmd(cmd)
-    expect(result).toEqual(['docker', 'run', '-v', '"arg arg"', '/data:/mnt/data', 'nginx'])
+    expect(result).toEqual(['docker', 'run', '-v', 'arg arg', '/data:/mnt/data', 'nginx'])
   })
 
   it('should handle operations', () => {
@@ -42,7 +42,7 @@ describe('parseCmd function', () => {
       '-p',
       '8080:80',
       'nginx',
-      '"arg arg"',
+      'arg arg',
       '#',
       ' start nginx container',
     ])

--- a/libs/shared/util-js/src/lib/parse-cmd.ts
+++ b/libs/shared/util-js/src/lib/parse-cmd.ts
@@ -15,10 +15,6 @@ export const parseCmd = (cmd: string): string[] => {
 
   return args.flatMap((arg) => {
     if (typeof arg === 'string') {
-      const words = arg.split(' ').length
-      if (words > 1) {
-        return `"${arg}"`
-      }
       return arg
     }
     if ('op' in arg) {
@@ -42,4 +38,8 @@ function extractEnvVariables(inputString: string): { [key: string]: string } {
   })
 
   return envObject
+}
+// Necessary to display args with quotes in the UI
+export function joinArgsWithQuotes(args: string[]) {
+  return args.map((arg) => (arg.split(' ').length > 1 ? `"${arg}"` : arg)).join(' ')
 }

--- a/libs/shared/util-js/src/lib/parse-cmd.ts
+++ b/libs/shared/util-js/src/lib/parse-cmd.ts
@@ -21,7 +21,7 @@ export const parseCmd = (cmd: string): string[] => {
       return arg.op
     }
     if ('comment' in arg) {
-      return ['#', arg.comment]
+      return `#${arg.comment}`
     }
     return arg
   })
@@ -39,7 +39,18 @@ function extractEnvVariables(inputString: string): { [key: string]: string } {
 
   return envObject
 }
+
 // Necessary to display args with quotes in the UI
-export function joinArgsWithQuotes(args: string[]) {
-  return args.map((arg) => (arg.split(' ').length > 1 ? `"${arg}"` : arg)).join(' ')
+export function joinArgsWithQuotes(args: string[]): string {
+  return args
+    .map((arg) => {
+      if (arg.startsWith('#') && arg.split(' ').length > 1) {
+        return arg
+      }
+      if (arg.split(' ').length > 1) {
+        return `"${arg}"`
+      }
+      return arg
+    })
+    .join(' ')
 }


### PR DESCRIPTION
# What does this PR do?

We need to keep quote on the UI side but removing it for the back-end

Before
```
 ["args", "\"arg2 arg3"\"]
```
After 
``` 
["args", "args2 args3"]
```

https://qovery.slack.com/archives/C038JMN9GUE/p1720513590483949

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
