### PR TITLE
fix(services): update service payload to add icon_uri

### DIFF
--- a/libs/shared/util-services/src/lib/build-edit-service-payload.spec.ts
+++ b/libs/shared/util-services/src/lib/build-edit-service-payload.spec.ts
@@ -7,6 +7,7 @@ describe('testing payload refactoring', () => {
     const response: Application = {
       id: '1',
       serviceType: 'APPLICATION',
+      icon_uri: 'app://qovery-console/application',
       created_at: '',
       updated_at: '',
       storage: [
@@ -36,6 +37,7 @@ describe('testing payload refactoring', () => {
 
     expect(buildEditServicePayload({ service: response })).toEqual({
       serviceType: 'APPLICATION',
+      icon_uri: 'app://qovery-console/application',
       storage: [
         {
           id: '1',
@@ -61,6 +63,7 @@ describe('testing payload refactoring', () => {
     const response: Container = {
       id: '1',
       serviceType: 'CONTAINER',
+      icon_uri: 'app://qovery-console/container',
       created_at: '',
       updated_at: '',
       environment: {
@@ -101,6 +104,7 @@ describe('testing payload refactoring', () => {
 
     expect(buildEditServicePayload({ service: response })).toEqual({
       serviceType: 'CONTAINER',
+      icon_uri: 'app://qovery-console/container',
       name: 'hello-2',
       description: 'test',
       storage: [
@@ -133,6 +137,7 @@ describe('testing payload refactoring', () => {
       name: 'hello',
       description: 'test',
       serviceType: 'DATABASE',
+      icon_uri: 'app://qovery-console/database',
       type: DatabaseTypeEnum.POSTGRESQL,
       mode: DatabaseModeEnum.CONTAINER,
       created_at: '',
@@ -150,6 +155,7 @@ describe('testing payload refactoring', () => {
 
     expect(buildEditServicePayload({ service: response })).toEqual({
       serviceType: 'DATABASE',
+      icon_uri: 'app://qovery-console/database',
       name: 'hello',
       description: 'test',
       version: '12',
@@ -171,6 +177,7 @@ describe('testing payload refactoring', () => {
       name: 'my-job',
       job_type: 'CRON',
       serviceType: 'JOB',
+      icon_uri: 'app://qovery-console/cron-job',
       description: '',
       cpu: 500,
       memory: 512,
@@ -208,6 +215,7 @@ describe('testing payload refactoring', () => {
 
     expect(buildEditServicePayload({ service: job })).toEqual({
       serviceType: 'JOB',
+      icon_uri: 'app://qovery-console/cron-job',
       name: 'my-job',
       description: '',
       cpu: 500,

--- a/libs/shared/util-services/src/lib/build-edit-service-payload.ts
+++ b/libs/shared/util-services/src/lib/build-edit-service-payload.ts
@@ -105,6 +105,7 @@ function refactoApplication({ service: application, request = {} }: applicationP
 
   const applicationRequestPayload: ApplicationEditRequest = {
     name: application.name,
+    icon_uri: application.icon_uri,
     storage: application.storage,
     cpu: application.cpu,
     git_repository: application.git_repository as ApplicationGitRepositoryRequest,
@@ -129,6 +130,7 @@ function refactoApplication({ service: application, request = {} }: applicationP
 function refactoContainer({ service: container, request = {} }: containerProps): ContainerRequest {
   const containerRequestPayload = {
     name: container.name || '',
+    icon_uri: container.icon_uri,
     description: container.description || '',
     storage: container.storage,
     ports: container.ports,
@@ -152,6 +154,7 @@ function refactoContainer({ service: container, request = {} }: containerProps):
 function refactoJob({ service: job, request = {} }: jobProps): JobRequest {
   const jobRequest = {
     name: job.name,
+    icon_uri: job.icon_uri,
     description: job.description,
     cpu: job.cpu,
     memory: job.memory,
@@ -197,6 +200,7 @@ function refactoJob({ service: job, request = {} }: jobProps): JobRequest {
 function refactoDatabase({ service: database, request = {} }: databaseProps): DatabaseEditRequest {
   const databaseRequestPayload = {
     name: database.name,
+    icon_uri: database.icon_uri,
     description: database.description,
     version: database.version,
     accessibility: database.accessibility,
@@ -238,6 +242,7 @@ function refactoHelm({ service: helm, request = {} }: helmProps): HelmRequest {
 
   const helmRequestPayload: HelmRequest = {
     name: helm.name,
+    icon_uri: helm.icon_uri,
     description: helm.description,
     auto_preview: helm.auto_preview,
     auto_deploy: helm.auto_deploy,


### PR DESCRIPTION
# What does this PR do?

Fix the `buildEditServicePayload` function to handles `icon_uri` param. Otherwise existing service `icon_uri` will be trim from the payload when you goes from service response -> service request