### PR TITLE
chore(deps): bump qovery-typescript-axios 1.1.457

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "logrocket": "^8.1.0",
     "monaco-editor": "^0.44.0",
     "posthog-js": "^1.131.4",
-    "qovery-typescript-axios": "^1.1.454",
+    "qovery-typescript-axios": "^1.1.457",
     "react": "18.2.0",
     "react-beautiful-dnd": "^13.1.0",
     "react-country-flag": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3886,7 +3886,7 @@ __metadata:
     prettier: ^3.2.5
     prettier-plugin-tailwindcss: ^0.5.14
     pretty-quick: ^4.0.0
-    qovery-typescript-axios: ^1.1.454
+    qovery-typescript-axios: ^1.1.457
     qovery-ws-typescript-axios: ^0.1.153
     react: 18.2.0
     react-beautiful-dnd: ^13.1.0
@@ -19283,12 +19283,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:^1.1.454":
-  version: 1.1.454
-  resolution: "qovery-typescript-axios@npm:1.1.454"
+"qovery-typescript-axios@npm:^1.1.457":
+  version: 1.1.457
+  resolution: "qovery-typescript-axios@npm:1.1.457"
   dependencies:
     axios: ^0.27.2
-  checksum: 703816a7be5979d62190e27099365aa168e9c222d5e5937c37ec9fa784906993c83f2aa9d162614e7f6d83793c04440cfd51ac9cab1cfa981b3bfb77954eb7b6
+  checksum: db7bbac5cd7f61b41eeabd961769319021e2300a5e4aca243ce14b1e804541fa4411acf84d84ac131b7cb1e869c21ef716e8cc5de03a66b0a25a2afc99a1701e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What does this PR do?

- Update open-api package

https://qovery.slack.com/archives/C02P2JB4SEM/p1721981768208349

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
