### PR TITLE
refactor(ui): align form validation behavior

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-delete-modal/cluster-delete-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-delete-modal/cluster-delete-modal.tsx
@@ -90,6 +90,7 @@ export function ClusterDeleteModal({ cluster }: ClusterDeleteModalProps) {
         }
       }}
       ctaButtonDisabled={ctaButtonDisabled}
+      shouldValidate
       isDelete
     >
       <div className="mb-6 rounded border border-red-500 bg-red-50 p-4 text-sm text-neutral-400">

--- a/libs/domains/clusters/feature/src/lib/cluster-delete-modal/cluster-delete-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-delete-modal/cluster-delete-modal.tsx
@@ -1,5 +1,5 @@
 import { type CheckedState } from '@radix-ui/react-checkbox'
-import { type Cluster, ClusterDeleteMode, Value } from 'qovery-typescript-axios'
+import { type Cluster, ClusterDeleteMode } from 'qovery-typescript-axios'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { match } from 'ts-pattern'
@@ -60,12 +60,6 @@ export function ClusterDeleteModal({ cluster }: ClusterDeleteModalProps) {
       )
     )
     .otherwise(() => clusterDeleteModeOptions)
-
-  match(clusterDeleteMode)
-    .with('DEFAULT', () => 'Default')
-    .with('DELETE_CLUSTER_AND_QOVERY_CONFIG', () => 'Cluster and Qovery config')
-    .with('DELETE_QOVERY_CONFIG', () => 'Qovery Config only')
-    .exhaustive()
 
   const navigate = useNavigate()
 

--- a/libs/shared/ui/src/lib/components/modals/modal-confirmation/modal-confirmation.tsx
+++ b/libs/shared/ui/src/lib/components/modals/modal-confirmation/modal-confirmation.tsx
@@ -17,6 +17,7 @@ export interface ModalConfirmationProps extends PropsWithChildren {
   ctaButton?: string
   ctaButtonDisabled?: boolean
   isDelete?: boolean
+  shouldValidate?: boolean
 }
 
 export function ModalConfirmation({
@@ -29,9 +30,10 @@ export function ModalConfirmation({
   placeholder = isDelete ? 'Enter "delete"' : 'Enter the current name',
   ctaButton = 'Confirm',
   ctaButtonDisabled,
+  shouldValidate = false,
   children,
 }: ModalConfirmationProps) {
-  const { handleSubmit, control } = useForm()
+  const { handleSubmit, control, formState } = useForm()
   const { closeModal } = useModal()
 
   const onSubmit = handleSubmit((data) => {
@@ -107,7 +109,12 @@ export function ModalConfirmation({
           <Button type="button" color="neutral" variant="plain" size="lg" onClick={() => closeModal()}>
             Cancel
           </Button>
-          <Button type="submit" size="lg" color={isDelete ? 'red' : 'brand'} disabled={ctaButtonDisabled}>
+          <Button
+            type="submit"
+            size="lg"
+            color={isDelete ? 'red' : 'brand'}
+            disabled={ctaButtonDisabled || (shouldValidate ? !formState.isValid : false)}
+          >
             {ctaButton}
           </Button>
         </div>


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/browse/FRT-1232

There is difference in behavior between our generic delete modal and this specific cluster delete modal.
Since we introduced the checkboxes, the submit button is now disabled until all checkboxes are checked.
Whereas the generic modal allow submit then show errors in concerned fields.
https://ux.stackexchange.com/questions/9788/disabled-submit-button-on-form-vs-allow-submit-then-show-errors

Thus I need to introduce an hybrid behavior here to drive the generic delete modal towards the "disabled submit on form" behavior. In consequence, code isn't the most elegant ¯ \ _ (ツ) _ / ¯

