### PR TITLE
fix(cluster-card): align name and status

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-card/__snapshots__/cluster-card.spec.tsx.snap
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/__snapshots__/cluster-card.spec.tsx.snap
@@ -7,10 +7,10 @@ exports[`ClusterCard should render correctly 1`] = `
     href="/organization/org-id/cluster/cluster-id/settings"
   >
     <div
-      class="flex items-start justify-between gap-2"
+      class="flex items-start items-center justify-between gap-2"
     >
       <div
-        class="flex gap-3 marker:items-center"
+        class="flex items-center gap-3"
       >
         <svg
           class="shrink-0 "

--- a/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.tsx
@@ -30,8 +30,8 @@ export function ClusterCard({ organizationId, cluster }: ClusterCardProps) {
       to={CLUSTER_URL(cluster.organization.id, cluster.id) + CLUSTER_SETTINGS_URL}
       className="flex flex-col gap-5 rounded border border-neutral-200 p-5 shadow-sm transition-colors duration-150 hover:border-brand-500"
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex gap-3 marker:items-center">
+      <div className="flex items-start items-center justify-between gap-2">
+        <div className="flex items-center gap-3">
           <Icon width={28} height={28} name={cloudProviderIcon} />
           <span className="line-clamp-2 block text-base font-semibold text-neutral-400">{cluster.name}</span>
         </div>


### PR DESCRIPTION
# What does this PR do?

- Fix alignment between cloud provider icon, name and status

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
