### PR TITLE
fix(action-toolbar): brand color and remove gap for link children

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-action-toolbar/__snapshots__/cluster-action-toolbar.spec.tsx.snap
+++ b/libs/domains/clusters/feature/src/lib/cluster-action-toolbar/__snapshots__/cluster-action-toolbar.spec.tsx.snap
@@ -143,7 +143,7 @@ exports[`ClusterActionToolbar should match manage deployment snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-rotate-right text-sm mr-3 text-brand-400"
+          class="fa-solid fa-rotate-right text-sm mr-3 text-brand-500"
         />
         Update
       </div>
@@ -156,7 +156,7 @@ exports[`ClusterActionToolbar should match manage deployment snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-circle-stop text-sm mr-3 text-brand-400"
+          class="fa-solid fa-circle-stop text-sm mr-3 text-brand-500"
         />
         Stop
       </div>
@@ -315,7 +315,7 @@ exports[`ClusterActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-400"
+          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-500"
         />
         See audit logs
       </div>
@@ -328,7 +328,7 @@ exports[`ClusterActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-copy text-sm mr-3 text-brand-400"
+          class="fa-solid fa-copy text-sm mr-3 text-brand-500"
         />
         Copy identifier
       </div>
@@ -341,7 +341,7 @@ exports[`ClusterActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-download text-sm mr-3 text-brand-400"
+          class="fa-solid fa-download text-sm mr-3 text-brand-500"
         />
         Get Kubeconfig
       </div>
@@ -518,7 +518,7 @@ exports[`ClusterActionToolbar should match outdated snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-400"
+          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-500"
         />
         See audit logs
       </div>
@@ -531,7 +531,7 @@ exports[`ClusterActionToolbar should match outdated snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-copy text-sm mr-3 text-brand-400"
+          class="fa-solid fa-copy text-sm mr-3 text-brand-500"
         />
         Copy identifier
       </div>
@@ -544,7 +544,7 @@ exports[`ClusterActionToolbar should match outdated snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-download text-sm mr-3 text-brand-400"
+          class="fa-solid fa-download text-sm mr-3 text-brand-500"
         />
         Get Kubeconfig
       </div>

--- a/libs/domains/environments/feature/src/lib/environment-action-toolbar/__snapshots__/environment-action-toolbar.spec.tsx.snap
+++ b/libs/domains/environments/feature/src/lib/environment-action-toolbar/__snapshots__/environment-action-toolbar.spec.tsx.snap
@@ -130,7 +130,7 @@ exports[`EnvironmentActionToolbar should match manage deployment snapshot 1`] = 
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-rotate-right text-sm mr-3 text-brand-400"
+          class="fa-solid fa-rotate-right text-sm mr-3 text-brand-500"
         />
         Redeploy
       </div>
@@ -143,7 +143,7 @@ exports[`EnvironmentActionToolbar should match manage deployment snapshot 1`] = 
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-circle-stop text-sm mr-3 text-brand-400"
+          class="fa-solid fa-circle-stop text-sm mr-3 text-brand-500"
         />
         Stop
       </div>
@@ -161,7 +161,7 @@ exports[`EnvironmentActionToolbar should match manage deployment snapshot 1`] = 
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-rotate text-sm mr-3 text-brand-400"
+          class="fa-solid fa-rotate text-sm mr-3 text-brand-500"
         />
         Deploy latest version for..
       </div>
@@ -299,7 +299,7 @@ exports[`EnvironmentActionToolbar should match other actions snapshot 1`] = `
         </svg>
       </span>
       <a
-        class="transition duration-100 gap-1 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500"
+        class="transition duration-100 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500 gap-0"
         data-orientation="vertical"
         data-radix-collection-item=""
         href="/organization/123/project/123/environment/3840068565336064/logs"
@@ -308,12 +308,12 @@ exports[`EnvironmentActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-scroll text-sm mr-3 text-brand-400"
+          class="fa-solid fa-scroll text-sm mr-3 text-brand-500"
         />
         Logs
       </a>
       <a
-        class="transition duration-100 gap-1 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500"
+        class="transition duration-100 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500 gap-0"
         data-orientation="vertical"
         data-radix-collection-item=""
         href="/organization/123/audit-logs/general?targetType=ENVIRONMENT&projectId=123&targetId=3840068565336064"
@@ -322,7 +322,7 @@ exports[`EnvironmentActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-400"
+          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-500"
         />
         See audit logs
       </a>
@@ -335,7 +335,7 @@ exports[`EnvironmentActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-copy text-sm mr-3 text-brand-400"
+          class="fa-solid fa-copy text-sm mr-3 text-brand-500"
         />
         Copy identifier
       </div>
@@ -348,7 +348,7 @@ exports[`EnvironmentActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-file-export text-sm mr-3 text-brand-400"
+          class="fa-solid fa-file-export text-sm mr-3 text-brand-500"
         />
         Export as Terraform
       </div>
@@ -361,7 +361,7 @@ exports[`EnvironmentActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-copy text-sm mr-3 text-brand-400"
+          class="fa-solid fa-copy text-sm mr-3 text-brand-500"
         />
         Clone
       </div>

--- a/libs/domains/environments/feature/src/lib/environment-action-toolbar/environment-action-toolbar.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-action-toolbar/environment-action-toolbar.tsx
@@ -172,6 +172,7 @@ function MenuOtherActions({ state, environment }: { state: StateEnum; environmen
       <DropdownMenu.Content>
         <DropdownMenu.Item icon={<Icon iconName="scroll" />} asChild>
           <Link
+            className="gap-0"
             to={ENVIRONMENT_LOGS_URL(environment.organization.id, environment.project.id, environment.id)}
             state={{ prevUrl: pathname }}
           >
@@ -180,6 +181,7 @@ function MenuOtherActions({ state, environment }: { state: StateEnum; environmen
         </DropdownMenu.Item>
         <DropdownMenu.Item icon={<Icon iconName="clock-rotate-left" />} asChild>
           <Link
+            className="gap-0"
             to={AUDIT_LOGS_PARAMS_URL(environment.organization.id, {
               targetType: OrganizationEventTargetType.ENVIRONMENT,
               projectId: environment.project.id,

--- a/libs/domains/services/feature/src/lib/service-action-toolbar/__snapshots__/service-action-toolbar.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-action-toolbar/__snapshots__/service-action-toolbar.spec.tsx.snap
@@ -157,7 +157,7 @@ exports[`ServiceActionToolbar should match manage deployment snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-400"
+          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-500"
         />
         Deploy another chart version
       </div>
@@ -295,7 +295,7 @@ exports[`ServiceActionToolbar should match other actions snapshot 1`] = `
         </svg>
       </span>
       <a
-        class="transition duration-100 gap-1 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500"
+        class="transition duration-100 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500 gap-0"
         data-orientation="vertical"
         data-radix-collection-item=""
         href="/organization/123/project/456/environment/789/logs/0/live-logs"
@@ -304,7 +304,7 @@ exports[`ServiceActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-scroll text-sm mr-3 text-brand-400"
+          class="fa-solid fa-scroll text-sm mr-3 text-brand-500"
         />
         Logs
       </a>
@@ -322,13 +322,13 @@ exports[`ServiceActionToolbar should match other actions snapshot 1`] = `
         >
           <i
             aria-hidden="true"
-            class="fa-solid fa-code text-sm mr-3 text-brand-400"
+            class="fa-solid fa-code text-sm mr-3 text-brand-500"
           />
           Edit code
         </div>
       </a>
       <a
-        class="transition duration-100 gap-1 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500"
+        class="transition duration-100 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500 gap-0"
         data-orientation="vertical"
         data-radix-collection-item=""
         href="/organization/123/audit-logs/general?targetId=0&targetType=HELM&projectId=123&environmentId=3840068565336064"
@@ -337,7 +337,7 @@ exports[`ServiceActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-400"
+          class="fa-solid fa-clock-rotate-left text-sm mr-3 text-brand-500"
         />
         See audit logs
       </a>
@@ -350,12 +350,12 @@ exports[`ServiceActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-copy text-sm mr-3 text-brand-400"
+          class="fa-solid fa-copy text-sm mr-3 text-brand-500"
         />
         Copy identifiers
       </div>
       <a
-        class="transition duration-100 gap-1 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500"
+        class="transition duration-100 px-3 flex items-center h-9 text-sm font-medium rounded-sm outline-none dark:text-neutral-100 data-[highlighted]:bg-brand-50 data-[highlighted]:text-brand-500 cursor-pointer text-neutral-400 hover:bg-brand-50 hover:text-brand-500 gap-0"
         data-orientation="vertical"
         data-radix-collection-item=""
         href="/organization/123/project/123/environment/3840068565336064/application/0/settings/general"
@@ -364,7 +364,7 @@ exports[`ServiceActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-gear text-sm mr-3 text-brand-400"
+          class="fa-solid fa-gear text-sm mr-3 text-brand-500"
         />
         Open settings
       </a>
@@ -377,7 +377,7 @@ exports[`ServiceActionToolbar should match other actions snapshot 1`] = `
       >
         <i
           aria-hidden="true"
-          class="fa-solid fa-copy text-sm mr-3 text-brand-400"
+          class="fa-solid fa-copy text-sm mr-3 text-brand-500"
         />
         Clone
       </div>

--- a/libs/domains/services/feature/src/lib/service-action-toolbar/service-action-toolbar.tsx
+++ b/libs/domains/services/feature/src/lib/service-action-toolbar/service-action-toolbar.tsx
@@ -568,7 +568,7 @@ function MenuOtherActions({
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
         <DropdownMenu.Item icon={<Icon iconName="scroll" />} asChild>
-          <Link to={environmentLogsLink + SERVICE_LOGS_URL(service.id)} state={{ prevUrl: pathname }}>
+          <Link className="gap-0" to={environmentLogsLink + SERVICE_LOGS_URL(service.id)} state={{ prevUrl: pathname }}>
             Logs
           </Link>
         </DropdownMenu.Item>
@@ -579,6 +579,7 @@ function MenuOtherActions({
         )}
         <DropdownMenu.Item icon={<Icon iconName="clock-rotate-left" />} asChild>
           <Link
+            className="gap-0"
             to={AUDIT_LOGS_PARAMS_URL(organizationId, {
               targetId: service.id,
               targetType: service.serviceType,
@@ -594,6 +595,7 @@ function MenuOtherActions({
         </DropdownMenu.Item>
         <DropdownMenu.Item icon={<Icon iconName="gear" />} asChild>
           <Link
+            className="gap-0"
             to={match(service?.serviceType)
               .with(
                 'DATABASE',

--- a/libs/shared/ui/src/lib/components/dropdown-menu/dropdown-menu.tsx
+++ b/libs/shared/ui/src/lib/components/dropdown-menu/dropdown-menu.tsx
@@ -73,7 +73,7 @@ const dropdownMenuItemIconVariants = cva(['text-sm', 'mr-3'], {
     {
       color: 'brand',
       disabled: false,
-      className: ['text-brand-400'],
+      className: ['text-brand-500'],
     },
     {
       color: 'red',


### PR DESCRIPTION
# What does this PR do?

- Update default brand icon color from `400` to `500`
- Removed gap for children item with Link asChild, `linkVariants` provides default `gap-1`

**_Before:_**
<img width="319" alt="Screenshot 2024-08-30 at 08 45 56" src="https://github.com/user-attachments/assets/f7396da4-03b4-48e8-abf4-b744e101fb16">

**_After_**
<img width="319" alt="Screenshot 2024-08-30 at 08 45 37" src="https://github.com/user-attachments/assets/ac8fba14-e334-447a-b5ab-8d93f1b78abd">

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I have followed the library pattern i.e `feature`, `ui`, `data`, `utils`
- [x] I made sure the code is type safe (no any)
