### PR TITLE
fix(custom-domain-settings): size tooltip check custom domain

### DIFF
--- a/libs/pages/application/src/lib/ui/page-settings-domains/page-settings-domains.tsx
+++ b/libs/pages/application/src/lib/ui/page-settings-domains/page-settings-domains.tsx
@@ -72,15 +72,11 @@ export function PageSettingsDomains(props: PageSettingsDomainsProps) {
                     <Tooltip
                       disabled={props.isFetchingCheckedCustomDomains}
                       content={
-                        <div className="max-w-56">
+                        <div className="max-w-64">
+                          <span className="text-xs font-medium">Click to check set-up again.</span>
                           {checkedCustomDomain?.error_details && (
-                            <>
-                              {checkedCustomDomain?.error_details}
-                              <br />
-                              <br />
-                            </>
+                            <p className="text-[11px] font-normal">{checkedCustomDomain?.error_details}</p>
                           )}
-                          <strong>Click to check set-up again.</strong>
                         </div>
                       }
                     >
@@ -89,11 +85,11 @@ export function PageSettingsDomains(props: PageSettingsDomainsProps) {
                         variant="surface"
                         color="neutral"
                         size="lg"
-                        className="group h-[52px] w-[52px] justify-center"
+                        className="group relative h-[52px] w-[52px] justify-center"
                         onClick={() => props.onCheckCustomDomains()}
                       >
                         {props.isFetchingCheckedCustomDomains ? (
-                          <LoaderSpinner />
+                          <LoaderSpinner className="absolute left-0 right-0 m-auto group-hover:hidden" theme="dark" />
                         ) : checkedCustomDomain?.error_details ? (
                           <Icon
                             iconName="circle-exclamation"


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/jira/software/projects/FRT/boards/23?selectedIssue=FRT-1281
+ Fixed hover bug when the button loads and the Spinner doesn't have the correct size (iso with loading state of btns)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
