### PR TITLE
fix(cluster-resources-settings): corrected set default architecture after karpenter checked

### DIFF
--- a/libs/shared/console-shared/src/lib/cluster-settings/ui/cluster-resources-settings/cluster-resources-settings.tsx
+++ b/libs/shared/console-shared/src/lib/cluster-settings/ui/cluster-resources-settings/cluster-resources-settings.tsx
@@ -101,9 +101,13 @@ export function ClusterResourcesSettings(props: ClusterResourcesSettingsProps) {
                     if (props.fromDetail) {
                       const diskSize = watchDiskSize >= 50 ? watchDiskSize.toString() : '50'
                       setValue('karpenter.disk_size_in_gib', diskSize)
-                      const architecture = watchInstanceType.includes('AMD') ? 'AMD64' : 'ARM64'
-                      setValue('karpenter.default_service_architecture', architecture)
                     }
+
+                    const instanceTypeLabel: string | undefined = props.instanceTypeOptions
+                      ?.find((option) => option.value === watchInstanceType)
+                      ?.label?.toString()
+                    const architecture = instanceTypeLabel?.includes('AMD') ? 'AMD64' : 'ARM64'
+                    setValue('karpenter.default_service_architecture', architecture)
 
                     field.onChange(e)
                   }}


### PR DESCRIPTION
# What does this PR do?

The condition was always `ARM64` because the `watchInstanceType` doesn't return `label` but the `id` without this architecture detail.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
