### PR TITLE
fix(service-logs): topbar labels

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
@@ -208,7 +208,14 @@ export function ListServiceLogs({ clusterId }: ListServiceLogsProps) {
               </Button>
               {table.getState().columnFilters.map((c) => (
                 <div key={c.id} className="flex items-center gap-2">
-                  <span className="text-xs text-neutral-250">{upperCaseFirstLetter(c.id).replace('_', '')}: </span>
+                  <span className="text-xs text-neutral-250">
+                    {match(c.id)
+                      .with('pod_name', () => 'Podname')
+                      .with('version', () => 'Version')
+                      .with('container_name', () => 'Container')
+                      .otherwise(() => '')}
+                    :{' '}
+                  </span>
                   <Button
                     key={c.id}
                     type="button"


### PR DESCRIPTION
# What does this PR do?

- Labels for service logs filter, display `Container` instead of `Container name`

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
