### PR TITLE
fix(need-redeploy-flag): hide if no service deployment state to avoid glitch reloading

### DIFF
--- a/libs/domains/services/feature/src/lib/need-redeploy-flag/need-redeploy-flag.tsx
+++ b/libs/domains/services/feature/src/lib/need-redeploy-flag/need-redeploy-flag.tsx
@@ -17,6 +17,8 @@ export function NeedRedeployFlag() {
   })
   const { mutate: deployService } = useDeployService({ environmentId })
 
+  if (!serviceDeploymentStatus) return null
+
   const serviceDeploymentStatusState =
     serviceDeploymentStatus?.service_deployment_status ?? ServiceDeploymentStatusEnum.NEVER_DEPLOYED
 


### PR DESCRIPTION
# What does this PR do?

- Avoid to display the `need-redeploy-flag` if no service deployment data 

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
