### PR TITLE
fix(sidebar-pod-statuses): update description for starting pods

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/sidebar-pod-statuses/sidebar-pod-statuses.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/sidebar-pod-statuses/sidebar-pod-statuses.spec.tsx
@@ -171,8 +171,9 @@ describe('SidebarPodStatuses', () => {
     const toggleButton = screen.getByRole('button')
     await userEvent.click(toggleButton)
 
+    expect(screen.getByText('1 running')).toBeInTheDocument()
     expect(screen.getByText('1 warning')).toBeInTheDocument()
-    expect(screen.getByText('2 starting')).toBeInTheDocument()
+    expect(screen.getByText('1 starting')).toBeInTheDocument()
     expect(screen.getByText('1 failing')).toBeInTheDocument()
   })
 

--- a/libs/domains/service-logs/feature/src/lib/sidebar-pod-statuses/sidebar-pod-statuses.tsx
+++ b/libs/domains/service-logs/feature/src/lib/sidebar-pod-statuses/sidebar-pod-statuses.tsx
@@ -59,7 +59,7 @@ export function SidebarPodStatuses({ organizationId, projectId, service, childre
           .with('COMPLETED', () => ({ type: 'running', message: 'completed', color: 'bg-green-500' }))
           .with('WARNING', () => ({ type: 'warning', message: 'warning', color: 'bg-yellow-500' }))
           .with('STARTING', () => ({
-            type: 'running',
+            type: 'starting',
             message: 'starting',
             color: 'bg-purple-500',
           }))


### PR DESCRIPTION
# What does this PR do?

https://qovery.slack.com/archives/D063URVH85V/p1732795510051319

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
