### PR TITLE
fix(list-service-logs): filter by container and version first rendering

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
@@ -143,8 +143,10 @@ export function ListServiceLogs({ environment, clusterId, serviceStatus, environ
       setColumnFilters((prevFilters) => {
         const existingFilter = prevFilters.find((f) => f.id === id)
         const updatedFilters = existingFilter ? prevFilters.filter((f) => f.id !== id) : [...prevFilters, { id, value }]
-        existingFilter ? searchParams.delete(id) : searchParams.append(id, value)
-        setSearchParams(searchParams)
+        if (id === 'pod_name') {
+          existingFilter ? searchParams.delete(id) : searchParams.append(id, value)
+          setSearchParams(searchParams)
+        }
         return updatedFilters
       })
     },


### PR DESCRIPTION
# What does this PR do?


- Filter by container or version doesn't if using memorised columnFilters, rollback to `useEffect` to avoid it

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
