### PR TITLE
feat(cluster-upgrade): display error and success toasts

### DIFF
--- a/libs/domains/clusters/feature/src/lib/hooks/use-upgrade-cluster/use-upgrade-cluster.ts
+++ b/libs/domains/clusters/feature/src/lib/hooks/use-upgrade-cluster/use-upgrade-cluster.ts
@@ -18,6 +18,12 @@ export function useUpgradeCluster({ organizationId }: UseUpgradeClusterProps) {
         queryKey: queries.clusters.listStatuses({ organizationId }).queryKey,
       })
     },
+    meta: {
+      notifyOnSuccess: {
+        title: 'Your cluster is being upgraded',
+      },
+      notifyOnError: true,
+    },
   })
 }
 


### PR DESCRIPTION
# What does this PR do?

- Display error and succes toasts when we upgrade cluster

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
