### PR TITLE
fix(deployment-logs): service status and hide pod sidebar for db managed

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -80,7 +80,7 @@ export function HeaderLogs({
                     <circle cx="2.5" cy="2.955" r="2.5" fill="#383E50"></circle>
                   </svg>
                   <ActionTriggerStatusChip
-                    status={environmentStatus?.last_deployment_state}
+                    status={serviceStatus?.state}
                     triggerAction={deploymentHistory.trigger_action}
                   />
                 </>

--- a/libs/domains/service-logs/feature/src/lib/sidebar-pod-statuses/sidebar-pod-statuses.tsx
+++ b/libs/domains/service-logs/feature/src/lib/sidebar-pod-statuses/sidebar-pod-statuses.tsx
@@ -137,6 +137,8 @@ export function SidebarPodStatuses({ organizationId, projectId, service, childre
     }))
   }, [pods])
 
+  if (service?.serviceType === 'DATABASE' && service?.mode === 'MANAGED') return children
+
   return (
     <div className="flex" style={{ '--padding-sidebar': currentPadding } as React.CSSProperties}>
       {children}


### PR DESCRIPTION
# What does this PR do?

This pull request includes updates to the `header-logs` and `sidebar-pod-statuses` components in the `libs/domains/service-logs/feature` directory. The changes focus on improving the status display logic and handling specific service conditions.

Updates to status display logic:

* [`libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx`](diffhunk://#diff-476b9ba8aca95449c76dde0e11538ae8448454669039d5a329b47ef9d8a70b92L83-R83): Modified the `ActionTriggerStatusChip` component to use `serviceStatus?.state` instead of `environmentStatus?.last_deployment_state` for the `status` prop.

Hide sidebar pods status for Database managed

* [`libs/domains/service-logs/feature/src/lib/sidebar-pod-statuses/sidebar-pod-statuses.tsx`](diffhunk://#diff-e608ac2678f8feee5fce87a0e80cd780f1a10667c21685c0419cff977dd3d4f0R140-R141): Added a conditional return to bypass rendering if the service type is 'DATABASE' and the mode is 'MANAGED'.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
