### PR TITLE
fix(FRT-1437): add one day in selected date to align with invoice

### DIFF
--- a/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/show-usage-modal-feature/show-usage-modal-feature.tsx
+++ b/libs/pages/settings/src/lib/feature/page-organization-billing-summary-feature/show-usage-modal-feature/show-usage-modal-feature.tsx
@@ -31,8 +31,10 @@ export function ShowUsageModalFeature({ organizationId, currentCost }: ShowUsage
       const res = await usageBillingReport({
         organizationId,
         usageReportRequest: {
-          from: selectedReportPeriod.from,
-          to: selectedReportPeriod.to ?? new Date().toISOString(),
+          from: new Date(new Date(selectedReportPeriod.from).getTime() + 24 * 60 * 60 * 1000).toISOString(),
+          to: selectedReportPeriod.to
+            ? new Date(new Date(selectedReportPeriod.to).getTime() + 24 * 60 * 60 * 1000).toISOString()
+            : new Date().toISOString(),
           report_expiration_in_seconds: methods.getValues('expires') * 60 * 60, // hours to seconds
         },
       })


### PR DESCRIPTION
# What does this PR do?

The date selected in the report is shifted by one day and thus it doesn’t match the invoice.

https://qovery.atlassian.net/browse/FRT-1437



---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I made sure the code is type safe (no any)
