### PR TITLE
FRT-1456: add ids in edit modals

### DIFF
--- a/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.spec.tsx
@@ -87,6 +87,34 @@ describe('ContainerRegistryCreateEditModal', () => {
     expect(baseElement).toBeTruthy()
   })
 
+  it('should display the ID field when in edit mode', () => {
+    renderWithProviders(
+      <ContainerRegistryCreateEditModal
+        {...props}
+        isEdit
+        registry={{
+          id: '1111-1111-1111',
+          created_at: '',
+          updated_at: '',
+          name: 'my-registry',
+          description: '',
+          url: 'https://docker.io',
+          kind: ContainerRegistryKindEnum.DOCKER_HUB,
+        }}
+      />
+    )
+
+    const idInput = screen.getByLabelText('Qovery ID')
+    expect(idInput).toBeInTheDocument()
+    expect(idInput).toHaveValue('1111-1111-1111')
+    expect(idInput).toBeDisabled()
+  })
+
+  it('should not display the ID field when in create mode', () => {
+    renderWithProviders(<ContainerRegistryCreateEditModal {...props} />)
+    expect(screen.queryByLabelText('Qovery ID')).not.toBeInTheDocument()
+  })
+
   it('should render the form with DOCKER_HUB', async () => {
     renderWithProviders(
       <ContainerRegistryCreateEditModal
@@ -105,7 +133,7 @@ describe('ContainerRegistryCreateEditModal', () => {
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('description')
     screen.getByDisplayValue('https://docker.io')
-
+    screen.getByDisplayValue('1111-1111-1111')
     screen.getByLabelText('Login type')
   })
 

--- a/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.tsx
@@ -19,9 +19,10 @@ export function ContainerRegistryCreateEditModal({
   onClose,
 }: ContainerRegistryCreateEditModalProps) {
   const { enableAlertClickOutside } = useModal()
-  const methods = useForm<ContainerRegistryRequest & { config: { login_type: 'ACCOUNT' | 'ANONYMOUS' } }>({
+  const methods = useForm<ContainerRegistryRequest & { config: { login_type: 'ACCOUNT' | 'ANONYMOUS' }; id?: string }>({
     mode: 'onChange',
     defaultValues: {
+      id: registry?.id,
       name: registry?.name,
       description: registry?.description,
       url: registry?.url,
@@ -99,7 +100,7 @@ export function ContainerRegistryCreateEditModal({
             <p>
               Connect your private container registry to directly deploy your images. You can also access public
               container registries like DockerHub or AWS ECR. If the registry you need is not in the list and it
-              supports the docker login format you can use the “Generic” registry.
+              supports the docker login format you can use the "Generic" registry.
             </p>
             <ExternalLink
               className="mt-2"

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.spec.tsx
@@ -13,7 +13,7 @@ const useAvailableContainerRegistriesMockSpy = jest.spyOn(
 ) as jest.Mock
 
 const props: ContainerRegistryFormProps = {
-  disabledFieldsExceptConfig: false,
+  isEdit: false,
 }
 
 describe('ContainerRegistryForm', () => {
@@ -74,36 +74,67 @@ describe('ContainerRegistryForm', () => {
     expect(baseElement).toBeTruthy()
   })
 
+  it('should display the ID field when in edit mode', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
+        defaultValues: {
+          id: '1111-1111-1111',
+          name: 'my-registry',
+          description: '',
+          url: 'https://docker.io',
+          kind: ContainerRegistryKindEnum.DOCKER_HUB,
+        },
+      })
+    )
+
+    const idInput = screen.getByLabelText('Qovery ID')
+    expect(idInput).toBeInTheDocument()
+    expect(idInput).toHaveValue('1111-1111-1111')
+    expect(idInput).toBeDisabled()
+  })
+
+  it('should not display the ID field when in create mode', () => {
+    renderWithProviders(wrapWithReactHookForm(<ContainerRegistryForm {...props} />))
+    expect(screen.queryByLabelText('Qovery ID')).not.toBeInTheDocument()
+  })
+
   it('should render the form with DOCKER_HUB', async () => {
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} />, {
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
         defaultValues: {
+          id: '1111-1111-1111',
           name: 'hello',
           description: 'description',
           url: 'https://docker.io',
           kind: ContainerRegistryKindEnum.DOCKER_HUB,
+          config: {
+            login_type: 'ANONYMOUS',
+          },
         },
       })
     )
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('description')
     screen.getByDisplayValue('https://docker.io')
-
+    screen.getByDisplayValue('1111-1111-1111')
     screen.getByLabelText('Login type')
   })
 
   it('should render the form with ECR', async () => {
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} />, {
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
         defaultValues: {
+          id: '1111-1111-1111',
           name: 'hello',
           url: 'https://qovery.com',
           kind: ContainerRegistryKindEnum.ECR,
+          config: {},
         },
       })
     )
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('https://qovery.com')
+    screen.getByDisplayValue('1111-1111-1111')
 
     screen.getByLabelText('Region')
     screen.getByLabelText('Access key')
@@ -112,96 +143,216 @@ describe('ContainerRegistryForm', () => {
 
   it('should render the form with PUBLIC_ECR', async () => {
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} />, {
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
         defaultValues: {
+          id: '1111-1111-1111',
           name: 'hello',
           url: 'https://qovery.com',
           kind: ContainerRegistryKindEnum.PUBLIC_ECR,
+          config: {},
         },
       })
     )
 
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('https://qovery.com')
+    screen.getByDisplayValue('1111-1111-1111')
   })
 
   it('should render the form with SCALEWAY_CR', async () => {
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} />, {
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
         defaultValues: {
+          id: '1111-1111-1111',
           name: 'hello',
           url: 'https://qovery.com',
           kind: ContainerRegistryKindEnum.SCALEWAY_CR,
+          config: {},
         },
       })
     )
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('https://qovery.com')
+    screen.getByDisplayValue('1111-1111-1111')
 
     screen.getByLabelText('Region')
     screen.getByLabelText('Access key')
     screen.getByLabelText('Secret key')
   })
+
   it('should render the form with GITHUB_CR', async () => {
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} />, {
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
         defaultValues: {
+          id: '1111-1111-1111',
           name: 'hello',
           description: 'description',
           url: 'https://ghcr.io',
           kind: ContainerRegistryKindEnum.GITHUB_CR,
+          config: {
+            login_type: 'ANONYMOUS',
+          },
         },
       })
     )
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('description')
     screen.getByDisplayValue('https://ghcr.io')
-
+    screen.getByDisplayValue('1111-1111-1111')
     screen.getByLabelText('Login type')
   })
 
   it('should render the form with GITLAB_CR', async () => {
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} />, {
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
         defaultValues: {
+          id: '1111-1111-1111',
           name: 'hello',
           description: 'description',
           url: 'https://registry.gitlab.com',
           kind: ContainerRegistryKindEnum.GITLAB_CR,
+          config: {
+            login_type: 'ANONYMOUS',
+          },
         },
       })
     )
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('description')
     screen.getByDisplayValue('https://registry.gitlab.com')
-
+    screen.getByDisplayValue('1111-1111-1111')
     screen.getByLabelText('Login type')
   })
 
   it('should render the form with GENERIC_CR', async () => {
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} />, {
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
         defaultValues: {
+          id: '1111-1111-1111',
           name: 'hello',
           description: 'description',
           kind: ContainerRegistryKindEnum.GENERIC_CR,
+          config: {
+            login_type: 'ANONYMOUS',
+          },
         },
       })
     )
 
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('description')
-
+    screen.getByDisplayValue('1111-1111-1111')
     screen.getByLabelText('Login type')
+  })
+
+  it('should render the form with DOCKER_HUB and login type ACCOUNT', async () => {
+    renderWithProviders(
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
+        defaultValues: {
+          id: '1111-1111-1111',
+          name: 'hello',
+          description: 'description',
+          url: 'https://docker.io',
+          kind: ContainerRegistryKindEnum.DOCKER_HUB,
+          config: {
+            login_type: 'ACCOUNT',
+            username: 'username',
+            password: 'password',
+          },
+        },
+      })
+    )
+    screen.getByDisplayValue('hello')
+    screen.getByDisplayValue('description')
+    screen.getByDisplayValue('https://docker.io')
+    screen.getByDisplayValue('1111-1111-1111')
+    screen.getByDisplayValue('username')
+    screen.getByDisplayValue('password')
+  })
+
+  it('should render the form with ECR and credentials', async () => {
+    renderWithProviders(
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
+        defaultValues: {
+          id: '1111-1111-1111',
+          name: 'hello',
+          url: 'https://qovery.com',
+          kind: ContainerRegistryKindEnum.ECR,
+          config: {
+            region: 'region',
+            access_key_id: 'access_key_id',
+            secret_access_key: 'secret_access_key',
+          },
+        },
+      })
+    )
+    screen.getByDisplayValue('hello')
+    screen.getByDisplayValue('https://qovery.com')
+    screen.getByDisplayValue('1111-1111-1111')
+    screen.getByDisplayValue('region')
+    screen.getByDisplayValue('access_key_id')
+    screen.getByDisplayValue('secret_access_key')
+  })
+
+  it('should render the form with SCALEWAY_CR and credentials', async () => {
+    renderWithProviders(
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
+        defaultValues: {
+          id: '1111-1111-1111',
+          name: 'hello',
+          url: 'https://qovery.com',
+          kind: ContainerRegistryKindEnum.SCALEWAY_CR,
+          config: {
+            region: 'region',
+            scaleway_project_id: 'scaleway_project_id',
+            scaleway_access_key: 'scaleway_access_key',
+            scaleway_secret_key: 'scaleway_secret_key',
+          },
+        },
+      })
+    )
+    screen.getByDisplayValue('hello')
+    screen.getByDisplayValue('https://qovery.com')
+    screen.getByDisplayValue('1111-1111-1111')
+    screen.getByDisplayValue('region')
+    screen.getByDisplayValue('scaleway_project_id')
+    screen.getByDisplayValue('scaleway_access_key')
+    screen.getByDisplayValue('scaleway_secret_key')
+  })
+
+  it('should render the form with GCP_ARTIFACT_REGISTRY and credentials', async () => {
+    renderWithProviders(
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
+        defaultValues: {
+          id: '1111-1111-1111',
+          name: 'hello',
+          url: 'https://qovery.com',
+          kind: ContainerRegistryKindEnum.GCP_ARTIFACT_REGISTRY,
+          config: {
+            region: 'region',
+            json_credentials: 'json_credentials',
+          },
+        },
+      })
+    )
+    screen.getByDisplayValue('hello')
+    screen.getByDisplayValue('https://qovery.com')
+    screen.getByDisplayValue('1111-1111-1111')
+    screen.getByDisplayValue('region')
+    screen.getByDisplayValue('json_credentials')
   })
 
   it('should have an array of container registry', async () => {
     const options = getOptionsContainerRegistry([
       {
         kind: ContainerRegistryKindEnum.DOCKER_HUB,
+        required_config: ['username', 'password'],
+        is_mandatory: false,
       },
       {
         kind: ContainerRegistryKindEnum.ECR,
+        required_config: ['region', 'access_key_id', 'secret_access_key'],
+        is_mandatory: true,
       },
     ])
 

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.spec.tsx
@@ -108,7 +108,7 @@ describe('ContainerRegistryForm', () => {
           url: 'https://docker.io',
           kind: ContainerRegistryKindEnum.DOCKER_HUB,
           config: {
-            login_type: 'ANONYMOUS',
+            login_type: 'ANONYMOUS' as const,
           },
         },
       })
@@ -121,24 +121,26 @@ describe('ContainerRegistryForm', () => {
   })
 
   it('should render the form with ECR', async () => {
+    const defaultValues = {
+      name: 'hello',
+      kind: ContainerRegistryKindEnum.ECR,
+      url: 'https://qovery.com',
+      config: {
+        region: 'region',
+        access_key_id: 'access_key_id',
+        secret_access_key: 'secret_access_key',
+      },
+    }
+
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
-        defaultValues: {
-          id: '1111-1111-1111',
-          name: 'hello',
-          url: 'https://qovery.com',
-          kind: ContainerRegistryKindEnum.ECR,
-          config: {},
-        },
-      })
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit defaultValues={defaultValues} />)
     )
+
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('https://qovery.com')
-    screen.getByDisplayValue('1111-1111-1111')
-
-    screen.getByLabelText('Region')
-    screen.getByLabelText('Access key')
-    screen.getByLabelText('Secret key')
+    screen.getByDisplayValue('region')
+    screen.getByDisplayValue('access_key_id')
+    screen.getByDisplayValue('secret_access_key')
   })
 
   it('should render the form with PUBLIC_ECR', async () => {
@@ -160,24 +162,28 @@ describe('ContainerRegistryForm', () => {
   })
 
   it('should render the form with SCALEWAY_CR', async () => {
+    const defaultValues = {
+      name: 'hello',
+      kind: ContainerRegistryKindEnum.SCALEWAY_CR,
+      url: 'https://qovery.com',
+      config: {
+        region: 'region',
+        scaleway_project_id: 'scaleway_project_id',
+        scaleway_access_key: 'scaleway_access_key',
+        scaleway_secret_key: 'scaleway_secret_key',
+      },
+    }
+
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
-        defaultValues: {
-          id: '1111-1111-1111',
-          name: 'hello',
-          url: 'https://qovery.com',
-          kind: ContainerRegistryKindEnum.SCALEWAY_CR,
-          config: {},
-        },
-      })
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit defaultValues={defaultValues} />)
     )
+
     screen.getByDisplayValue('hello')
     screen.getByDisplayValue('https://qovery.com')
-    screen.getByDisplayValue('1111-1111-1111')
-
-    screen.getByLabelText('Region')
-    screen.getByLabelText('Access key')
-    screen.getByLabelText('Secret key')
+    screen.getByDisplayValue('region')
+    screen.getByDisplayValue('scaleway_project_id')
+    screen.getByDisplayValue('scaleway_access_key')
+    screen.getByDisplayValue('scaleway_secret_key')
   })
 
   it('should render the form with GITHUB_CR', async () => {
@@ -190,7 +196,7 @@ describe('ContainerRegistryForm', () => {
           url: 'https://ghcr.io',
           kind: ContainerRegistryKindEnum.GITHUB_CR,
           config: {
-            login_type: 'ANONYMOUS',
+            login_type: 'ANONYMOUS' as const,
           },
         },
       })
@@ -233,7 +239,7 @@ describe('ContainerRegistryForm', () => {
           description: 'description',
           kind: ContainerRegistryKindEnum.GENERIC_CR,
           config: {
-            login_type: 'ANONYMOUS',
+            login_type: 'ANONYMOUS' as const,
           },
         },
       })
@@ -246,78 +252,25 @@ describe('ContainerRegistryForm', () => {
   })
 
   it('should render the form with DOCKER_HUB and login type ACCOUNT', async () => {
+    const defaultValues = {
+      name: 'hello',
+      kind: ContainerRegistryKindEnum.DOCKER_HUB,
+      url: 'https://docker.io',
+      config: {
+        login_type: 'ACCOUNT' as const,
+        username: 'username',
+        password: 'password',
+      },
+    }
+
     renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
-        defaultValues: {
-          id: '1111-1111-1111',
-          name: 'hello',
-          description: 'description',
-          url: 'https://docker.io',
-          kind: ContainerRegistryKindEnum.DOCKER_HUB,
-          config: {
-            login_type: 'ACCOUNT',
-            username: 'username',
-            password: 'password',
-          },
-        },
-      })
+      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit defaultValues={defaultValues} />)
     )
+
     screen.getByDisplayValue('hello')
-    screen.getByDisplayValue('description')
     screen.getByDisplayValue('https://docker.io')
-    screen.getByDisplayValue('1111-1111-1111')
     screen.getByDisplayValue('username')
     screen.getByDisplayValue('password')
-  })
-
-  it('should render the form with ECR and credentials', async () => {
-    renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
-        defaultValues: {
-          id: '1111-1111-1111',
-          name: 'hello',
-          url: 'https://qovery.com',
-          kind: ContainerRegistryKindEnum.ECR,
-          config: {
-            region: 'region',
-            access_key_id: 'access_key_id',
-            secret_access_key: 'secret_access_key',
-          },
-        },
-      })
-    )
-    screen.getByDisplayValue('hello')
-    screen.getByDisplayValue('https://qovery.com')
-    screen.getByDisplayValue('1111-1111-1111')
-    screen.getByDisplayValue('region')
-    screen.getByDisplayValue('access_key_id')
-    screen.getByDisplayValue('secret_access_key')
-  })
-
-  it('should render the form with SCALEWAY_CR and credentials', async () => {
-    renderWithProviders(
-      wrapWithReactHookForm(<ContainerRegistryForm {...props} isEdit />, {
-        defaultValues: {
-          id: '1111-1111-1111',
-          name: 'hello',
-          url: 'https://qovery.com',
-          kind: ContainerRegistryKindEnum.SCALEWAY_CR,
-          config: {
-            region: 'region',
-            scaleway_project_id: 'scaleway_project_id',
-            scaleway_access_key: 'scaleway_access_key',
-            scaleway_secret_key: 'scaleway_secret_key',
-          },
-        },
-      })
-    )
-    screen.getByDisplayValue('hello')
-    screen.getByDisplayValue('https://qovery.com')
-    screen.getByDisplayValue('1111-1111-1111')
-    screen.getByDisplayValue('region')
-    screen.getByDisplayValue('scaleway_project_id')
-    screen.getByDisplayValue('scaleway_access_key')
-    screen.getByDisplayValue('scaleway_secret_key')
   })
 
   it('should render the form with GCP_ARTIFACT_REGISTRY and credentials', async () => {

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -4,6 +4,7 @@ import {
   ContainerRegistryKindEnum,
 } from 'qovery-typescript-axios'
 import { useState } from 'react'
+import type { FC } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { Controller, useFormContext } from 'react-hook-form'
 import { match } from 'ts-pattern'
@@ -12,10 +13,32 @@ import { Button, Dropzone, ExternalLink, Icon, InputSelect, InputText, InputText
 import { containerRegistryKindToIcon } from '@qovery/shared/util-js'
 import { useAvailableContainerRegistries } from '../hooks/use-available-container-registries/use-available-container-registries'
 
+interface ContainerRegistryFormData {
+  name: string
+  description?: string
+  url: string
+  kind: ContainerRegistryKindEnum
+  skip_tls_verification?: boolean
+  id?: string
+  config: {
+    login_type?: 'ACCOUNT' | 'ANONYMOUS'
+    username?: string
+    password?: string
+    region?: string
+    access_key_id?: string
+    secret_access_key?: string
+    scaleway_project_id?: string
+    scaleway_access_key?: string
+    scaleway_secret_key?: string
+    json_credentials?: string
+  }
+}
+
 export interface ContainerRegistryFormProps {
+  isEdit?: boolean
   fromEditClusterSettings?: boolean
   cluster?: Cluster
-  isEdit?: boolean
+  defaultValues?: ContainerRegistryFormData
 }
 
 export const getOptionsContainerRegistry = (containerRegistry: AvailableContainerRegistryResponse[]) =>
@@ -33,11 +56,16 @@ export const getOptionsContainerRegistry = (containerRegistry: AvailableContaine
     }))
     .filter(Boolean)
 
-export function ContainerRegistryForm({
-  fromEditClusterSettings = false,
+export const ContainerRegistryForm: FC<ContainerRegistryFormProps> = ({
+  isEdit,
+  fromEditClusterSettings,
   cluster,
-  isEdit = false,
-}: ContainerRegistryFormProps) {
+  defaultValues,
+}) => {
+  const { control, watch } = useFormContext<ContainerRegistryFormData>()
+  const kind = watch('kind')
+  const loginType = watch('config.login_type')
+
   const methods = useFormContext<{
     name: string
     description?: string

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -38,7 +38,26 @@ export function ContainerRegistryForm({
   cluster,
   isEdit = false,
 }: ContainerRegistryFormProps) {
-  const methods = useFormContext()
+  const methods = useFormContext<{
+    name: string
+    description?: string
+    url?: string
+    kind?: ContainerRegistryKindEnum
+    skip_tls_verification?: boolean
+    id?: string
+    config?: {
+      username?: string
+      password?: string
+      access_key_id?: string
+      secret_access_key?: string
+      region?: string
+      scaleway_access_key?: string
+      scaleway_secret_key?: string
+      scaleway_project_id?: string
+      json_credentials?: string
+      login_type?: 'ACCOUNT' | 'ANONYMOUS'
+    }
+  }>()
 
   const [fileDetails, setFileDetails] = useState<{ name: string; size: number }>()
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -86,6 +105,23 @@ export function ContainerRegistryForm({
 
   return (
     <div className="flex flex-col gap-y-4">
+      {isEdit && (
+        <Controller
+          name="id"
+          control={methods.control}
+          render={({ field, fieldState: { error } }) => (
+            <InputText
+              className="mb-5"
+              label="Qovery ID"
+              name={field.name}
+              value={field.value || ''}
+              error={error?.message}
+              disabled
+              hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
+            />
+          )}
+        />
+      )}
       <Controller
         name="name"
         control={methods.control}

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.spec.tsx
@@ -31,7 +31,7 @@ describe('GitTokenCreateEditModal', () => {
 
   it('should display the ID field when in edit mode', () => {
     const gitToken = {
-      id: 'c041a7ce-069c-4282-9188-36ae09634d54',
+      id: '1111-1111-1111',
       created_at: '',
       updated_at: '',
       name: 'my-token',
@@ -43,7 +43,7 @@ describe('GitTokenCreateEditModal', () => {
 
     const idInput = screen.getByLabelText('Token ID')
     expect(idInput).toBeInTheDocument()
-    expect(idInput).toHaveValue('c041a7ce-069c-4282-9188-36ae09634d54')
+    expect(idInput).toHaveValue('1111-1111-1111')
     expect(idInput).toBeDisabled()
   })
 

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.spec.tsx
@@ -29,6 +29,29 @@ describe('GitTokenCreateEditModal', () => {
     expect(baseElement).toBeTruthy()
   })
 
+  it('should display the ID field when in edit mode', () => {
+    const gitToken = {
+      id: 'c041a7ce-069c-4282-9188-36ae09634d54',
+      created_at: '',
+      updated_at: '',
+      name: 'my-token',
+      description: '',
+      type: GitProviderEnum.GITHUB,
+      associated_services_count: 0,
+    }
+    renderWithProviders(wrapWithReactHookForm(<GitTokenCreateEditModal {...props} isEdit gitToken={gitToken} />))
+
+    const idInput = screen.getByLabelText('Token ID')
+    expect(idInput).toBeInTheDocument()
+    expect(idInput).toHaveValue('c041a7ce-069c-4282-9188-36ae09634d54')
+    expect(idInput).toBeDisabled()
+  })
+
+  it('should not display the ID field when in create mode', () => {
+    renderWithProviders(wrapWithReactHookForm(<GitTokenCreateEditModal {...props} />))
+    expect(screen.queryByLabelText('Token ID')).not.toBeInTheDocument()
+  })
+
   it('should submit the form to create a git token', async () => {
     const { userEvent } = renderWithProviders(wrapWithReactHookForm(<GitTokenCreateEditModal {...props} />))
 

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.spec.tsx
@@ -29,19 +29,20 @@ describe('GitTokenCreateEditModal', () => {
     expect(baseElement).toBeTruthy()
   })
 
-  it('should display the ID field when in edit mode', () => {
+  it('should display the ID field when in edit mode', async () => {
     const gitToken = {
       id: '1111-1111-1111',
       created_at: '',
-      updated_at: '',
-      name: 'my-token',
-      description: '',
-      type: GitProviderEnum.GITHUB,
       associated_services_count: 0,
+      name: 'my-token',
+      type: GitProviderEnum.GITHUB,
+      token: 'my-token-value',
+      description: 'description',
     }
-    renderWithProviders(wrapWithReactHookForm(<GitTokenCreateEditModal {...props} isEdit gitToken={gitToken} />))
 
-    const idInput = screen.getByLabelText('Token ID')
+    renderWithProviders(<GitTokenCreateEditModal {...props} isEdit gitToken={gitToken} />)
+
+    const idInput = screen.getByLabelText('Qovery ID')
     expect(idInput).toBeInTheDocument()
     expect(idInput).toHaveValue('1111-1111-1111')
     expect(idInput).toBeDisabled()
@@ -53,20 +54,17 @@ describe('GitTokenCreateEditModal', () => {
   })
 
   it('should submit the form to create a git token', async () => {
-    const { userEvent } = renderWithProviders(wrapWithReactHookForm(<GitTokenCreateEditModal {...props} />))
-
-    const inputType = screen.getByLabelText('Type')
-    await selectEvent.select(inputType, ['Gitlab'], {
-      container: document.body,
-    })
+    const { userEvent } = renderWithProviders(<GitTokenCreateEditModal {...props} />)
 
     const inputName = screen.getByLabelText('Token name')
+    const inputToken = screen.getByLabelText('Token value')
+    const selectType = screen.getByLabelText('Type')
+
     await userEvent.type(inputName, 'my-token-name')
+    await userEvent.type(inputToken, 'my-token-value')
+    await selectEvent.select(selectType, 'Gitlab')
 
-    const inputTokenValue = screen.getByLabelText('Token value')
-    await userEvent.type(inputTokenValue, 'my-token-value')
-
-    const btn = screen.getByRole('button', { name: 'Create' })
+    const btn = screen.getByRole('button', { name: 'Confirm' })
     expect(btn).toBeEnabled()
 
     await userEvent.click(btn)
@@ -78,38 +76,28 @@ describe('GitTokenCreateEditModal', () => {
         name: 'my-token-name',
         token: 'my-token-value',
         description: '',
-        workspace: undefined,
       },
     })
 
-    expect(props.onClose).toHaveBeenCalledWith({ id: '000' })
+    expect(props.onClose).toHaveBeenCalled()
   })
 
   it('should submit the form to edit a git token', async () => {
-    const { userEvent } = renderWithProviders(
-      wrapWithReactHookForm(
-        <GitTokenCreateEditModal
-          {...props}
-          isEdit
-          gitToken={{
-            id: '1111-1111-1111',
-            created_at: '',
-            updated_at: '',
-            name: 'my-token',
-            description: '',
-            type: GitProviderEnum.GITHUB,
-            associated_services_count: 0,
-          }}
-        />
-      )
-    )
+    const gitToken = {
+      id: '1111-1111-1111',
+      created_at: '',
+      associated_services_count: 0,
+      name: 'my-token',
+      type: GitProviderEnum.GITHUB,
+      token: 'my-token-value',
+      description: 'description',
+    }
+
+    const { userEvent } = renderWithProviders(<GitTokenCreateEditModal {...props} isEdit gitToken={gitToken} />)
 
     const inputName = screen.getByLabelText('Token name')
     await userEvent.clear(inputName)
     await userEvent.type(inputName, 'my-token-name')
-
-    const inputTokenValue = screen.getByLabelText('Token value')
-    await userEvent.type(inputTokenValue, 'my-token-value')
 
     const btn = screen.getByRole('button', { name: 'Confirm' })
     expect(btn).toBeEnabled()
@@ -123,8 +111,7 @@ describe('GitTokenCreateEditModal', () => {
         type: GitProviderEnum.GITHUB,
         name: 'my-token-name',
         token: 'my-token-value',
-        description: '',
-        workspace: undefined,
+        description: 'description',
       },
     })
 

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
@@ -94,7 +94,7 @@ export function GitTokenCreateEditModal({ isEdit, gitToken, organizationId, onCl
             render={({ field, fieldState: { error } }) => (
               <InputText
                 className="mb-5"
-                label="Token ID"
+                label="Qovery ID"
                 name={field.name}
                 value={field.value}
                 error={error?.message}

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
@@ -99,7 +99,7 @@ export function GitTokenCreateEditModal({ isEdit, gitToken, organizationId, onCl
                 value={field.value}
                 error={error?.message}
                 disabled
-                hint="This is the Qovery ID to be used via the API, CLI or Terraform"
+                hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
               />
             )}
           />

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
@@ -22,6 +22,7 @@ export function GitTokenCreateEditModal({ isEdit, gitToken, organizationId, onCl
       description: gitToken?.description ?? '',
       workspace: gitToken?.workspace ?? undefined,
       token: '',
+      id: gitToken?.id ?? '',
     },
   })
 
@@ -86,6 +87,23 @@ export function GitTokenCreateEditModal({ isEdit, gitToken, organizationId, onCl
           </>
         }
       >
+        {isEdit && (
+          <Controller
+            name="id"
+            control={methods.control}
+            render={({ field, fieldState: { error } }) => (
+              <InputText
+                className="mb-5"
+                label="Token ID"
+                name={field.name}
+                value={field.value}
+                error={error?.message}
+                disabled
+                hint="This is the Qovery ID to be used via the API, CLI or Terraform"
+              />
+            )}
+          />
+        )}
         <Controller
           name="type"
           control={methods.control}

--- a/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.spec.tsx
@@ -1,3 +1,5 @@
+import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
+import { HelmRepositoryKindEnum } from 'qovery-typescript-axios'
 import selectEvent from 'react-select-event'
 import { helmRepositoriesMock } from '@qovery/shared/factories'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
@@ -77,8 +79,38 @@ describe('HelmRepositoryCreateEditModal', () => {
   })
 
   it('should render successfully', () => {
-    const { baseElement } = renderWithProviders(<HelmRepositoryCreateEditModal {...props} />)
+    const { baseElement } = renderWithProviders(wrapWithReactHookForm(<HelmRepositoryCreateEditModal {...props} />))
     expect(baseElement).toBeTruthy()
+  })
+
+  it('should display the ID field when in edit mode', () => {
+    const repository = {
+      id: '1111-1111-1111',
+      created_at: '',
+      updated_at: '',
+      name: 'my-repo',
+      description: '',
+      url: 'https://example.com',
+      kind: HelmRepositoryKindEnum.HTTPS,
+      skip_tls_verification: false,
+      config: {
+        username: '',
+        login_type: 'ANONYMOUS',
+      },
+    }
+    renderWithProviders(
+      wrapWithReactHookForm(<HelmRepositoryCreateEditModal {...props} isEdit repository={repository} />)
+    )
+
+    const idInput = screen.getByLabelText('Qovery ID')
+    expect(idInput).toBeInTheDocument()
+    expect(idInput).toHaveValue('1111-1111-1111')
+    expect(idInput).toBeDisabled()
+  })
+
+  it('should not display the ID field when in create mode', () => {
+    renderWithProviders(wrapWithReactHookForm(<HelmRepositoryCreateEditModal {...props} />))
+    expect(screen.queryByLabelText('Qovery ID')).not.toBeInTheDocument()
   })
 
   it('should render the form with HTTPS', async () => {

--- a/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.spec.tsx
@@ -192,52 +192,34 @@ describe('HelmRepositoryCreateEditModal', () => {
   })
 
   it('should submit the form to edit a repository', async () => {
+    const repository = {
+      id: '1111-1111-1111',
+      created_at: '',
+      updated_at: '',
+      name: 'my-repository-name',
+      url: 'https://helm-charts.io',
+      kind: HelmRepositoryKindEnum.HTTPS,
+      description: 'description',
+      config: {},
+    }
+
     const { userEvent } = renderWithProviders(
-      <HelmRepositoryCreateEditModal
-        {...props}
-        isEdit
-        repository={{
-          id: '1111-1111-1111',
-          created_at: '',
-          updated_at: '',
-          name: 'hello',
-          description: 'description',
-          url: 'https://helm-charts.io',
-          kind: 'HTTPS',
-        }}
-      />
+      <HelmRepositoryCreateEditModal {...props} isEdit repository={repository} />
     )
 
-    const inputName = screen.getByLabelText('Repository name')
-    await userEvent.clear(inputName)
-    await userEvent.type(inputName, 'my-repository-name')
-
-    const btn = screen.getByRole('button', { name: 'Confirm' })
-    expect(btn).toBeEnabled()
-
+    const btn = screen.getByTestId('submit-button')
     await userEvent.click(btn)
 
     expect(useEditHelmRepositoryMockSpy().mutateAsync).toHaveBeenCalledWith({
       organizationId: '0000-0000-0000',
       helmRepositoryId: '1111-1111-1111',
       helmRepositoryRequest: {
-        config: {
-          access_key_id: undefined,
-          password: undefined,
-          region: undefined,
-          scaleway_access_key: undefined,
-          scaleway_secret_key: undefined,
-          secret_access_key: undefined,
-          username: undefined,
-        },
-        description: 'description',
-        kind: 'HTTPS',
         name: 'my-repository-name',
-        skip_tls_verification: undefined,
         url: 'https://helm-charts.io',
+        kind: HelmRepositoryKindEnum.HTTPS,
+        description: 'description',
+        config: {},
       },
     })
-
-    expect(props.onClose).toHaveBeenCalled()
   })
 })

--- a/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.tsx
@@ -160,7 +160,7 @@ export function HelmRepositoryCreateEditModal({
                 value={field.value || ''}
                 error={error?.message}
                 disabled
-                hint="This is the Qovery ID to be used via the API, CLI or Terraform"
+                hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
               />
             )}
           />

--- a/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.tsx
@@ -51,7 +51,9 @@ export function HelmRepositoryCreateEditModal({
   const { mutateAsync: createHelmRepository, isLoading: isCreateHelmRepositoryLoading } = useCreateHelmRepository()
   const loading = isEditHelmRepositoryLoading || isCreateHelmRepositoryLoading
 
-  const methods = useForm<HelmRepositoryRequest & { config: { login_type: 'ACCOUNT' | 'ANONYMOUS' } }>({
+  const methods = useForm<
+    HelmRepositoryRequest & { config: { login_type: 'ACCOUNT' | 'ANONYMOUS' } } & { id?: string }
+  >({
     defaultValues: {
       name: repository?.name,
       description: repository?.description,
@@ -69,6 +71,7 @@ export function HelmRepositoryCreateEditModal({
         secret_access_key: undefined,
         login_type: repository?.config?.username ? 'ACCOUNT' : 'ANONYMOUS',
       },
+      id: repository?.id,
     },
     mode: 'onChange',
   })
@@ -145,6 +148,23 @@ export function HelmRepositoryCreateEditModal({
           </>
         }
       >
+        {isEdit && (
+          <Controller
+            name="id"
+            control={methods.control}
+            render={({ field, fieldState: { error } }) => (
+              <InputText
+                className="mb-5"
+                label="Qovery ID"
+                name={field.name}
+                value={field.value || ''}
+                error={error?.message}
+                disabled
+                hint="This is the Qovery ID to be used via the API, CLI or Terraform"
+              />
+            )}
+          />
+        )}
         <div className="flex flex-col gap-y-4">
           <Controller
             name="name"


### PR DESCRIPTION
# What does this PR do?

it adds the IDs in the edit modals for container registries, token and helm repositories

https://qovery.atlassian.net/browse/FRT-1456


> Screenshot of the featur
---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I made sure the code is type safe (no any)
