### PR TITLE
fix(container-registry): rename password field for Github/Gilab CRs to personal access token

### DIFF
--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -289,7 +289,12 @@ export function ContainerRegistryForm({
               {isEditDirty && (
                 <>
                   <hr />
-                  <span className="text-sm text-neutral-350">Confirm your password</span>
+                  <span className="text-sm text-neutral-350">
+                    {watchKind === ContainerRegistryKindEnum.GITHUB_CR ||
+                    watchKind === ContainerRegistryKindEnum.GITLAB_CR
+                      ? 'Confirm your personal access token'
+                      : 'Confirm your password'}
+                  </span>
                 </>
               )}
               {(!isEdit || isEditDirty) && (
@@ -297,7 +302,11 @@ export function ContainerRegistryForm({
                   name="config.password"
                   control={methods.control}
                   rules={{
-                    required: 'Please enter a password.',
+                    required:
+                      watchKind === ContainerRegistryKindEnum.GITHUB_CR ||
+                      watchKind === ContainerRegistryKindEnum.GITLAB_CR
+                        ? 'Please enter a personal access token.'
+                        : 'Please enter a password.',
                   }}
                   render={({ field, fieldState: { error } }) => (
                     <>
@@ -307,7 +316,12 @@ export function ContainerRegistryForm({
                         name={field.name}
                         onChange={field.onChange}
                         value={field.value}
-                        label="Password"
+                        label={
+                          watchKind === ContainerRegistryKindEnum.GITHUB_CR ||
+                          watchKind === ContainerRegistryKindEnum.GITLAB_CR
+                            ? 'Personal Access Token'
+                            : 'Password'
+                        }
                         error={error?.message}
                       />
                       {watchKind === ContainerRegistryKindEnum.DOCKER_HUB && (

--- a/libs/domains/services/feature/src/lib/select-commit-modal/__snapshots__/select-commit-modal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/select-commit-modal/__snapshots__/select-commit-modal.spec.tsx.snap
@@ -96,7 +96,7 @@ exports[`SelectCommitModal should match snapshot 1`] = `
                   class="text-neutral-350 dark:text-neutral-50"
                 >
                   committed 
-                  1903 years
+                  1904 years
                    ago
                 </span>
               </div>


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/browse/QOV-102
---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
