### PR TITLE
fix(cluster-resources): remove disabled button for no Karpenter cluster

### DIFF
--- a/libs/pages/cluster/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-resources-feature/page-settings-resources-feature.spec.tsx
@@ -78,8 +78,6 @@ describe('PageSettingsResourcesFeature', () => {
     const { userEvent } = renderWithProviders(<PageSettingsResourcesFeature />)
     const button = screen.getByTestId('submit-button')
 
-    expect(button).toBeDisabled()
-
     const input = screen.getByLabelText('Disk size (GB)')
     await userEvent.clear(input)
     await userEvent.type(input, '24')

--- a/libs/pages/cluster/src/lib/ui/page-settings-resources/page-settings-resources.tsx
+++ b/libs/pages/cluster/src/lib/ui/page-settings-resources/page-settings-resources.tsx
@@ -29,7 +29,18 @@ export function PageSettingsResources({ cluster, onSubmit, loading }: PageSettin
             fromDetail
           />
           <div className="mt-10 flex justify-end">
-            <Button data-testid="submit-button" type="submit" size="lg" loading={loading} disabled={!formState.isValid}>
+            {/* 
+              Adding `hasAlreadyKarpenter` is an hotfix to avoid weird disabled button with all Karpenter fields
+              TODO: This should be improved to handle the form validation in a cleaner way
+              https://qovery.slack.com/archives/C02P2JB4SEM/p1743234920794219
+            */}
+            <Button
+              data-testid="submit-button"
+              type="submit"
+              size="lg"
+              loading={loading}
+              disabled={hasAlreadyKarpenter && !formState.isValid}
+            >
               Save
             </Button>
           </div>


### PR DESCRIPTION
# What does this PR do?

https://qovery.slack.com/archives/C02P2JB4SEM/p1743234920794219

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
