### PR TITLE
fix(environment/service-deployment): display cancel deployment queue

### DIFF
--- a/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
@@ -104,146 +104,130 @@ export function EnvironmentDeploymentList({ environmentId }: EnvironmentDeployme
         size: 40,
         cell: (info) => {
           const data = info.row.original
-
-          return match(data)
-            .with(P.when(isDeploymentHistory), (data) => {
-              const state = data.status
-
-              return (
-                <div
-                  className={twMerge(
-                    clsx(
-                      'flex items-center justify-between before:absolute before:-top-[1px] before:left-0 before:block before:h-[calc(100%+2px)] before:w-1',
-                      {
-                        'before:bg-brand-500': [
-                          'DEPLOYING',
-                          'RESTARTING',
-                          'BUILDING',
-                          'DELETING',
-                          'STOPPING',
-                          'CANCELING',
-                        ].includes(state),
-                        'before:bg-neutral-300': [
-                          'QUEUED',
-                          'DEPLOYMENT_QUEUED',
-                          'DELETE_QUEUED',
-                          'STOP_QUEUED',
-                          'RESTART_QUEUED',
-                        ].includes(state),
-                      }
-                    )
-                  )}
-                >
-                  <div className="flex flex-col gap-1">
-                    <span className="text-sm font-medium text-neutral-400">
-                      {dateFullFormat(data.auditing_data.created_at, undefined, 'dd MMM, HH:mm a')}
-                    </span>
-                    <span className="truncate text-ssm text-neutral-350">{data.identifier.execution_id}</span>
-                  </div>
-                  <ActionToolbar.Root className="min-w-28 text-right">
-                    {match(state)
-                      .with(
-                        'DEPLOYING',
-                        'RESTARTING',
-                        'BUILDING',
-                        'DELETING',
-                        'STOPPING',
-                        'DEPLOYMENT_QUEUED',
-                        'DELETE_QUEUED',
-                        'STOP_QUEUED',
-                        'RESTART_QUEUED',
-                        () => (
-                          <DropdownMenu.Root>
-                            <DropdownMenu.Trigger asChild>
-                              <ActionToolbar.Button
-                                aria-label="Manage Deployment"
-                                color="neutral"
-                                size="md"
-                                variant="outline"
-                              >
-                                <Tooltip content="Manage Deployment">
-                                  <div className="flex h-full w-full items-center justify-center">
-                                    {match(state)
-                                      .with(
-                                        'DEPLOYMENT_QUEUED',
-                                        'DELETE_QUEUED',
-                                        'STOP_QUEUED',
-                                        'RESTART_QUEUED',
-                                        () => <Icon iconName="clock" iconStyle="regular" className="mr-3" />
-                                      )
-                                      .otherwise(() => (
-                                        <Icon iconName="loader" className="mr-3 animate-spin" />
-                                      ))}
-                                    <Icon iconName="chevron-down" />
-                                  </div>
-                                </Tooltip>
-                              </ActionToolbar.Button>
-                            </DropdownMenu.Trigger>
-                            <DropdownMenu.Content>
-                              {isCancelBuildAvailable(state) && (
-                                <DropdownMenu.Item
-                                  icon={<Icon iconName="xmark" />}
-                                  onSelect={() =>
-                                    mutationCancelDeployment({
-                                      deploymentRequestId: !isDeploymentHistory(data)
-                                        ? data.identifier.deployment_request_id
-                                        : undefined,
-                                    })
-                                  }
-                                >
-                                  {state === StateEnum.DELETE_QUEUED || state === StateEnum.DELETING
-                                    ? 'Cancel delete'
-                                    : 'Cancel deployment'}
-                                </DropdownMenu.Item>
-                              )}
-                            </DropdownMenu.Content>
-                          </DropdownMenu.Root>
-                        )
-                      )
-                      .otherwise(() => null)}
-                    <Tooltip content="Pipeline">
-                      <ActionToolbar.Button asChild className="justify-center px-2">
-                        <Link
-                          to={
-                            ENVIRONMENT_LOGS_URL(
-                              environment?.organization.id,
-                              environment?.project.id,
-                              environment?.id
-                            ) + ENVIRONMENT_STAGES_URL(data.identifier.execution_id ?? '')
-                          }
-                          state={{ prevUrl: pathname }}
-                        >
-                          <Icon iconName="timeline" />
-                        </Link>
-                      </ActionToolbar.Button>
-                    </Tooltip>
-                  </ActionToolbar.Root>
-                </div>
-              )
-            })
-            .otherwise(() => (
-              <div className="flex items-center justify-between">
+          const state = isDeploymentHistory(data) ? data.status : 'QUEUED'
+          return (
+            <div
+              className={twMerge(
+                clsx(
+                  'flex items-center justify-between before:absolute before:-top-[1px] before:left-0 before:block before:h-[calc(100%+2px)] before:w-1',
+                  {
+                    'before:bg-brand-500': [
+                      'DEPLOYING',
+                      'RESTARTING',
+                      'BUILDING',
+                      'DELETING',
+                      'STOPPING',
+                      'CANCELING',
+                    ].includes(state),
+                    'before:bg-neutral-300': [
+                      'QUEUED',
+                      'DEPLOYMENT_QUEUED',
+                      'DELETE_QUEUED',
+                      'STOP_QUEUED',
+                      'RESTART_QUEUED',
+                    ].includes(state),
+                  }
+                )
+              )}
+            >
+              {state === 'QUEUED' ? (
                 <div className="flex flex-col gap-1 text-sm text-neutral-350">
                   <span className="font-medium">In queue...</span>
                   <span>--</span>
                 </div>
-                <div className="min-w-28 text-right">
-                  <Tooltip content="Logs">
+              ) : (
+                <div className="flex flex-col gap-1">
+                  <span className="text-sm font-medium text-neutral-400">
+                    {dateFullFormat(
+                      isDeploymentHistory(data) ? data.auditing_data.created_at : '',
+                      undefined,
+                      'dd MMM, HH:mm a'
+                    )}
+                  </span>
+                  <span className="truncate text-ssm text-neutral-350">
+                    {isDeploymentHistory(data) ? data.identifier.execution_id : '--'}
+                  </span>
+                </div>
+              )}
+              <ActionToolbar.Root className="min-w-28 text-right">
+                {match(state)
+                  .with(
+                    'DEPLOYING',
+                    'RESTARTING',
+                    'BUILDING',
+                    'DELETING',
+                    'STOPPING',
+                    'DEPLOYMENT_QUEUED',
+                    'DELETE_QUEUED',
+                    'STOP_QUEUED',
+                    'RESTART_QUEUED',
+                    () => (
+                      <DropdownMenu.Root>
+                        <DropdownMenu.Trigger asChild>
+                          <ActionToolbar.Button
+                            aria-label="Manage Deployment"
+                            color="neutral"
+                            size="md"
+                            variant="outline"
+                          >
+                            <Tooltip content="Manage Deployment">
+                              <div className="flex h-full w-full items-center justify-center">
+                                {match(state)
+                                  .with('DEPLOYMENT_QUEUED', 'DELETE_QUEUED', 'STOP_QUEUED', 'RESTART_QUEUED', () => (
+                                    <Icon iconName="clock" iconStyle="regular" className="mr-3" />
+                                  ))
+                                  .otherwise(() => (
+                                    <Icon iconName="loader" className="mr-3 animate-spin" />
+                                  ))}
+                                <Icon iconName="chevron-down" />
+                              </div>
+                            </Tooltip>
+                          </ActionToolbar.Button>
+                        </DropdownMenu.Trigger>
+                        <DropdownMenu.Content>
+                          {isCancelBuildAvailable(state) && (
+                            <DropdownMenu.Item
+                              icon={<Icon iconName="xmark" />}
+                              onSelect={() =>
+                                mutationCancelDeployment({
+                                  deploymentRequestId: !isDeploymentHistory(data)
+                                    ? data.identifier.deployment_request_id
+                                    : undefined,
+                                })
+                              }
+                            >
+                              {state === StateEnum.DELETE_QUEUED || state === StateEnum.DELETING
+                                ? 'Cancel delete'
+                                : 'Cancel deployment'}
+                            </DropdownMenu.Item>
+                          )}
+                        </DropdownMenu.Content>
+                      </DropdownMenu.Root>
+                    )
+                  )
+                  .otherwise(() => null)}
+                <Tooltip content="Pipeline">
+                  <ActionToolbar.Button asChild className="justify-center px-2">
                     <Link
-                      className="w-9 justify-center px-2 text-neutral-350"
-                      as="button"
-                      color="neutral"
-                      variant="outline"
-                      size="md"
-                      to={ENVIRONMENT_LOGS_URL(environment?.organization.id, environment?.project.id, environment?.id)}
+                      to={
+                        state === 'QUEUED'
+                          ? ENVIRONMENT_LOGS_URL(environment?.organization.id, environment?.project.id, environment?.id)
+                          : ENVIRONMENT_LOGS_URL(
+                              environment?.organization.id,
+                              environment?.project.id,
+                              environment?.id
+                            ) +
+                            ENVIRONMENT_STAGES_URL(isDeploymentHistory(data) ? data.identifier.execution_id ?? '' : '')
+                      }
                       state={{ prevUrl: pathname }}
                     >
                       <Icon iconName="timeline" />
                     </Link>
-                  </Tooltip>
-                </div>
-              </div>
-            ))
+                  </ActionToolbar.Button>
+                </Tooltip>
+              </ActionToolbar.Root>
+            </div>
+          )
         },
       }),
       columnHelper.accessor('action_status', {


### PR DESCRIPTION
# What does this PR do?

This pull request includes changes to the `EnvironmentDeploymentList` and `ServiceDeploymentList` components to handle deployment states more effectively. The main improvements involve simplifying the logic for deployment status checks and enhancing the user interface for queued deployments.

Enhancements to deployment status handling:

* [`libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx`](diffhunk://#diff-4042721f2bf31d4d996cd64372e7cc36c9a0ff9228e6f77e50eb2e2345d38623L107-R107): Simplified the logic for checking deployment history and added UI elements to display when a deployment is in the queue. [[1]](diffhunk://#diff-4042721f2bf31d4d996cd64372e7cc36c9a0ff9228e6f77e50eb2e2345d38623L107-R107) [[2]](diffhunk://#diff-4042721f2bf31d4d996cd64372e7cc36c9a0ff9228e6f77e50eb2e2345d38623R133-R151) [[3]](diffhunk://#diff-4042721f2bf31d4d996cd64372e7cc36c9a0ff9228e6f77e50eb2e2345d38623L167-R178) [[4]](diffhunk://#diff-4042721f2bf31d4d996cd64372e7cc36c9a0ff9228e6f77e50eb2e2345d38623L208-R220) [[5]](diffhunk://#diff-4042721f2bf31d4d996cd64372e7cc36c9a0ff9228e6f77e50eb2e2345d38623L223-L246)

* [`libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx`](diffhunk://#diff-d5db076fbec6048bfb16333225bd50cb17c09499e2aed826cda8aef9a34750b4L107-L109): Updated the logic for deployment status and added UI elements to indicate queued deployments. Also, changed the order of deployment history data to prioritize queued deployments. [[1]](diffhunk://#diff-d5db076fbec6048bfb16333225bd50cb17c09499e2aed826cda8aef9a34750b4L107-L109) [[2]](diffhunk://#diff-d5db076fbec6048bfb16333225bd50cb17c09499e2aed826cda8aef9a34750b4R121-R139) [[3]](diffhunk://#diff-d5db076fbec6048bfb16333225bd50cb17c09499e2aed826cda8aef9a34750b4L146-R154) [[4]](diffhunk://#diff-d5db076fbec6048bfb16333225bd50cb17c09499e2aed826cda8aef9a34750b4L180-R188) [[5]](diffhunk://#diff-d5db076fbec6048bfb16333225bd50cb17c09499e2aed826cda8aef9a34750b4L196-L216) [[6]](diffhunk://#diff-d5db076fbec6048bfb16333225bd50cb17c09499e2aed826cda8aef9a34750b4L462-R449)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
