### PR TITLE
fix(ws-subscription): allow unlimited reconnect for environment and service statuses

### DIFF
--- a/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
+++ b/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
@@ -34,6 +34,7 @@ export function useStatusWebSockets({
       version: versionId,
     },
     enabled: Boolean(organizationId) && Boolean(clusterId) && Boolean(projectId),
+    shouldReconnect: true,
     onMessage(queryClient, message: WSDeploymentStatus) {
       if (environmentId) {
         queryClient.setQueryData(

--- a/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.ts
+++ b/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.ts
@@ -96,7 +96,7 @@ export function useReactQueryWsSubscription({
         onError?.(queryClient, event)
       }
       websocket.onclose = async (event) => {
-        if (shouldReconnect && reconnectCount.current < MAX_RECONNECT_ATTEMPTS) {
+        if (shouldReconnect || reconnectCount.current < MAX_RECONNECT_ATTEMPTS) {
           timeout = setTimeout(
             function () {
               reconnectCount.current++


### PR DESCRIPTION
# What does this PR do?

Allow two possibility unlimited possibility with `shouldReconnect` or limited by `MAX_RECONNECT_ATTEMPTS`

https://qovery.slack.com/archives/C038JMN9GUE/p1745582480355459?thread_ts=1743822753.789379&cid=C038JMN9GUE

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
