### PR TITLE
feat(cluster): redirect to logs when selecting dry-run

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-update-modal/cluster-update-modal.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-update-modal/cluster-update-modal.spec.tsx
@@ -1,8 +1,15 @@
+import { INFRA_LOGS_URL } from '@qovery/shared/routes'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import * as useDeployCluster from '../hooks/use-deploy-cluster/use-deploy-cluster'
 import { ClusterUpdateModal } from './cluster-update-modal'
 
 const useDeployClusterMockSpy = jest.spyOn(useDeployCluster, 'useDeployCluster') as jest.Mock
+
+const mockNavigate = jest.fn()
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}))
 
 describe('ClusterUpdateModal', () => {
   const mockCluster = {
@@ -48,5 +55,31 @@ describe('ClusterUpdateModal', () => {
 
     await userEvent.click(checkbox)
     expect(checkbox).toBeChecked()
+  })
+
+  it('should not redirect to cluster logs page when dry-run is not selected', async () => {
+    const { userEvent } = renderWithProviders(<ClusterUpdateModal cluster={mockCluster} />)
+
+    const submitButton = screen.getByTestId('submit-button')
+    await userEvent.click(submitButton)
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('should redirect to cluster logs page when dry-run is selected', async () => {
+    const { userEvent } = renderWithProviders(<ClusterUpdateModal cluster={mockCluster} />)
+
+    const input = screen.getByTestId('input-value')
+    await userEvent.type(input, 'Test Cluster')
+
+    const checkbox = screen.getByRole('checkbox', { name: /dry-run/i })
+    await userEvent.click(checkbox)
+
+    const submitButton = screen.getByTestId('submit-button')
+    await userEvent.click(submitButton)
+
+    expect(mockNavigate).toHaveBeenCalledWith(INFRA_LOGS_URL(mockCluster.organization.id, mockCluster.id), {
+      state: { prevUrl: '/' },
+    })
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-update-modal/cluster-update-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-update-modal/cluster-update-modal.tsx
@@ -1,5 +1,7 @@
 import { type Cluster } from 'qovery-typescript-axios'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { INFRA_LOGS_URL } from '@qovery/shared/routes'
 import { Checkbox, Icon, InputTextSmall, ModalCrud, Tooltip, useModal } from '@qovery/shared/ui'
 import { useCopyToClipboard } from '@qovery/shared/util-hooks'
 import { useDeployCluster } from '../hooks/use-deploy-cluster/use-deploy-cluster'
@@ -12,7 +14,8 @@ export function ClusterUpdateModal({ cluster }: ClusterUpdateModalProps) {
   const { closeModal } = useModal()
   const { mutateAsync: deployCluster, isLoading } = useDeployCluster()
   const [, copyToClipboard] = useCopyToClipboard()
-
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
   const methods = useForm<{ name: string; dryRun: boolean }>({
     mode: 'onChange',
     defaultValues: {
@@ -28,6 +31,12 @@ export function ClusterUpdateModal({ cluster }: ClusterUpdateModalProps) {
         dryRun: data['dryRun'],
       })
       closeModal()
+      // Redirecting to cluster's logs page if dry-run was selected
+      if (data['dryRun']) {
+        navigate(INFRA_LOGS_URL(cluster.organization.id, cluster.id), {
+          state: { prevUrl: pathname },
+        })
+      }
     } catch (error) {
       console.error(error)
     }


### PR DESCRIPTION
# What does this PR do?

[> Link to the JIRA ticket](https://qovery.atlassian.net/browse/QOV-627)

PR adding a redirection to the cluster's logs when updating a cluster with "dry run" selected:

https://github.com/user-attachments/assets/51eae15e-1ae0-4c8d-8879-0b709dbca465

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
