### PR TITLE
feat(cluster-card): add INVALID_CREDENTIALS status

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.spec.tsx
@@ -1,4 +1,5 @@
 import { type Cluster, type ClusterStatus } from 'qovery-typescript-axios'
+import { INFRA_LOGS_URL } from '@qovery/shared/routes'
 import { timeAgo } from '@qovery/shared/util-dates'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { useClusterRunningStatusSocket } from '../hooks/use-cluster-running-status-socket/use-cluster-running-status-socket'
@@ -172,6 +173,6 @@ describe('ClusterCard', () => {
 
     const link = screen.getByText('Invalid cloud credentials')
     expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', `/organization/org-id/cluster/cluster-id/logs`)
+    expect(link).toHaveAttribute('href', INFRA_LOGS_URL(mockCluster.organization.id, mockCluster.id))
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.spec.tsx
@@ -161,4 +161,17 @@ describe('ClusterCard', () => {
       clusterId: 'cluster-id',
     })
   })
+
+  it('should display invalid credentials link', async () => {
+    renderWithProviders(
+      <ClusterCard
+        cluster={mockCluster}
+        clusterDeploymentStatus={{ ...mockClusterDeploymentStatus, status: 'INVALID_CREDENTIALS' }}
+      />
+    )
+
+    const link = screen.getByText('Invalid cloud credentials')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', `/organization/org-id/cluster/cluster-id/logs`)
+  })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.tsx
@@ -82,8 +82,6 @@ export interface ClusterCardProps {
 export function ClusterCard({ cluster, clusterDeploymentStatus }: ClusterCardProps) {
   useClusterRunningStatusSocket({ organizationId: cluster.organization.id, clusterId: cluster.id })
 
-  console.log(clusterDeploymentStatus)
-
   return (
     <Link
       to={CLUSTER_URL(cluster.organization.id, cluster.id) + CLUSTER_SETTINGS_URL}

--- a/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.tsx
@@ -47,6 +47,18 @@ function Subtitle({ cluster, clusterDeploymentStatus }: { cluster: Cluster; clus
         <Icon iconName="arrow-up-right" className="relative top-[1px]" />
       </LinkUI>
     ))
+    .with('INVALID_CREDENTIALS', () => (
+      <LinkUI
+        to={INFRA_LOGS_URL(cluster.organization.id, cluster.id)}
+        color="red"
+        underline
+        size="sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        Invalid cloud credentials
+        <Icon iconName="arrow-up-right" className="relative top-[1px]" />
+      </LinkUI>
+    ))
     .otherwise(
       () =>
         clusterDeploymentStatus?.last_deployment_date && (
@@ -69,6 +81,8 @@ export interface ClusterCardProps {
 
 export function ClusterCard({ cluster, clusterDeploymentStatus }: ClusterCardProps) {
   useClusterRunningStatusSocket({ organizationId: cluster.organization.id, clusterId: cluster.id })
+
+  console.log(clusterDeploymentStatus)
 
   return (
     <Link

--- a/libs/domains/clusters/feature/src/lib/hooks/use-edit-cloud-provider-info/use-edit-cloud-provider-info.ts
+++ b/libs/domains/clusters/feature/src/lib/hooks/use-edit-cloud-provider-info/use-edit-cloud-provider-info.ts
@@ -5,7 +5,7 @@ import { useDeployCluster } from '../use-deploy-cluster/use-deploy-cluster'
 
 export function useEditCloudProviderInfo({ silently = false } = {}) {
   const queryClient = useQueryClient()
-  const { mutateAsync: deployCluster } = useDeployCluster()
+  const { mutate: deployCluster } = useDeployCluster()
 
   return useMutation(mutations.editCloudProviderInfo, {
     onSuccess(_, { organizationId, clusterId }) {

--- a/libs/shared/util-js/src/lib/status-actions-available.ts
+++ b/libs/shared/util-js/src/lib/status-actions-available.ts
@@ -1,4 +1,4 @@
-import { ClusterStateEnum, StateEnum } from 'qovery-typescript-axios'
+import { type ClusterStateEnum, type StateEnum } from 'qovery-typescript-axios'
 import { match } from 'ts-pattern'
 import { RunningState } from '@qovery/shared/enums'
 
@@ -112,45 +112,4 @@ export const isCancelBuildAvailable = (status: keyof typeof StateEnum | keyof ty
       () => true
     )
     .otherwise(() => false)
-}
-
-// TODO: differentiate service state from cluster state
-export const getStatusClusterMessage = (status?: StateEnum | ClusterStateEnum, isAlreadyDeployed?: boolean): string => {
-  switch (status) {
-    case ClusterStateEnum.INVALID_CREDENTIALS:
-      return 'Invalid credentials'
-    case StateEnum.DEPLOYMENT_QUEUED:
-      if (!isAlreadyDeployed) return 'Installation queued'
-      else return 'Update queued'
-    case StateEnum.DEPLOYMENT_ERROR:
-      if (!isAlreadyDeployed) return 'Installation error'
-      else return 'Update error'
-    case StateEnum.DEPLOYING:
-      if (!isAlreadyDeployed) return 'Installing...'
-      else return 'Updating...'
-    case StateEnum.QUEUED:
-      if (!isAlreadyDeployed) return 'Installing queued'
-      else return 'Updating queued'
-    case StateEnum.STOP_QUEUED:
-      return 'Pause queued'
-    case StateEnum.BUILD_ERROR:
-      return 'Build error'
-    case StateEnum.STOP_ERROR:
-      return 'Pause error'
-    case StateEnum.STOPPING:
-      return 'Pausing...'
-    case StateEnum.STOPPED:
-      return 'Paused'
-    case StateEnum.DELETE_QUEUED:
-      return 'Deletion queued'
-    case StateEnum.DELETING:
-      return 'Deleting...'
-    case StateEnum.DELETE_ERROR:
-      return 'Deletion error'
-    case StateEnum.READY:
-    case StateEnum.DELETED:
-    case StateEnum.DEPLOYED:
-    default:
-      return ''
-  }
 }


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/jira/software/c/projects/QOV/boards/56?selectedIssue=QOV-599

- Add `INVALID_CREDENTIALS` status in the cluster card with a link to logs
- Clean-up some deprecated code
- Link to try the feature [remi-test](http://localhost:4200/organization/3d542888-3d2c-474a-b1ad-712556db66da/cluster/dffb9ce6-d3ea-431c-ad09-aa82600e1d5c/settings/general)

<img width="672" alt="Screenshot 2025-04-29 at 15 18 48" src="https://github.com/user-attachments/assets/93893ee7-ae0f-4b0b-b63e-6de94c799add" />

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
