### PR TITLE
feat(services): add counter for queued deployments

### DIFF
--- a/libs/domains/services/feature/src/lib/service-list/service-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list.tsx
@@ -48,6 +48,7 @@ import {
 } from '@qovery/shared/routes'
 import {
   AnimatedGradientText,
+  Badge,
   Button,
   Checkbox,
   EmptyState,
@@ -68,6 +69,7 @@ import { buildGitProviderUrl } from '@qovery/shared/util-git'
 import {
   containerRegistryKindToIcon,
   formatCronExpression,
+  pluralize,
   twMerge,
   upperCaseFirstLetter,
 } from '@qovery/shared/util-js'
@@ -93,6 +95,8 @@ function ServiceNameCell({
   deploymentStatus?: Status
 }) {
   const navigate = useNavigate()
+
+  const deploymentRequestsCount = Number(deploymentStatus?.deployment_requests_count)
 
   const serviceLink = match(service)
     .with(
@@ -236,6 +240,17 @@ function ServiceNameCell({
               <LinkDeploymentStatus />
             </span>
           ))}
+
+        {deploymentRequestsCount > 0 && (
+          <Tooltip
+            content={`This service has ${deploymentRequestsCount} queued ${pluralize(deploymentRequestsCount, 'deployment')}`}
+          >
+            <Badge className="flex items-center gap-1">
+              <Icon iconName="clock-eight" iconStyle="regular" />
+              {deploymentRequestsCount}
+            </Badge>
+          </Tooltip>
+        )}
       </span>
       <div className="flex shrink-0 items-center gap-5">
         <div className="flex items-center">


### PR DESCRIPTION
# What does this PR do?

[> Link to the JIRA ticket](https://qovery.atlassian.net/browse/QOV-38)

This PR adds a counter for the queued deployments for a given service.

https://github.com/user-attachments/assets/46bd3514-7206-4ee7-94cb-933577764117

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
