### PR TITLE
feat(clusters): add confirmation modal when removing a credential

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-credentials-modal/cluster-credentials-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-credentials-modal/cluster-credentials-modal.tsx
@@ -19,6 +19,7 @@ import {
   InputText,
   ModalCrud,
   useModal,
+  useModalConfirmation,
 } from '@qovery/shared/ui'
 import CopyButton from '../cluster-setup/copy-button/copy-button'
 import { useClusterCloudProviderInfo } from '../hooks/use-cluster-cloud-provider-info/use-cluster-cloud-provider-info'
@@ -136,6 +137,7 @@ export function ClusterCredentialsModal({
   cloudProvider = 'AWS',
 }: ClusterCredentialsModalProps) {
   const { enableAlertClickOutside } = useModal()
+  const { openModalConfirmation } = useModalConfirmation()
 
   const { data: cloudProviderInfo } = useClusterCloudProviderInfo({
     organizationId,
@@ -237,18 +239,30 @@ export function ClusterCredentialsModal({
   })
 
   const onDelete = async () => {
-    if (credential?.id) {
-      try {
-        await deleteCloudProviderCredential({
-          organizationId,
-          cloudProvider: cloudProviderLocal,
-          credentialId: credential.id,
-        })
-        onClose()
-      } catch (error) {
-        console.error(error)
-      }
-    }
+    openModalConfirmation({
+      title: 'Delete credential',
+      description: (
+        <p>
+          To confirm the deletion of <strong>{credential?.name}</strong>, please type "delete"
+        </p>
+      ),
+      name: credential?.name,
+      isDelete: true,
+      action: async () => {
+        if (credential?.id) {
+          try {
+            await deleteCloudProviderCredential({
+              organizationId,
+              cloudProvider: cloudProviderLocal,
+              credentialId: credential.id,
+            })
+            onClose()
+          } catch (error) {
+            console.error(error)
+          }
+        }
+      },
+    })
   }
 
   const watchType = methods.watch('type')

--- a/libs/shared/ui/src/lib/components/modals/modal-crud/modal-crud.tsx
+++ b/libs/shared/ui/src/lib/components/modals/modal-crud/modal-crud.tsx
@@ -87,7 +87,14 @@ export function ModalCrud(props: ModalCrudProps) {
             Cancel
           </Button>
           {isEdit && onDelete && (
-            <Button data-testid="delete-button" variant="outline" color="red" size="lg" onClick={() => onDelete()}>
+            <Button
+              data-testid="delete-button"
+              type="button"
+              variant="outline"
+              color="red"
+              size="lg"
+              onClick={() => onDelete()}
+            >
               {deleteButtonLabel || 'Delete'}
             </Button>
           )}


### PR DESCRIPTION
# What does this PR do?

[QOV-782](https://qovery.atlassian.net/browse/QOV-782)

This PR adds a confirmation modal when user attempts to delete a credential.

https://github.com/user-attachments/assets/e40d4973-7c4e-4209-91d6-d1269542fe28


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-782]: https://qovery.atlassian.net/browse/QOV-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ