### PR TITLE
feat(services): improve toast for env variable creation or update in case of conflict

### DIFF
--- a/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
+++ b/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
@@ -1,5 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
 import { mutations } from '@qovery/domains/variables/data-access'
+import { SERVICES_URL, SERVICES_VARIABLES_URL } from '@qovery/shared/routes'
+import { toastError } from '@qovery/shared/ui'
 import { queries } from '@qovery/state/util-queries'
 
 export function useCreateVariable() {
@@ -10,8 +13,32 @@ export function useCreateVariable() {
         queryKey: queries.variables.list._def,
       })
     },
+    onError(
+      error: AxiosError<{ existing_variable: { organization_id: string; project_id: string; environment_id: string } }>,
+      variables,
+      context
+    ) {
+      if (error.code === '409') {
+        if (error.response?.data) {
+          const {
+            organization_id: orgId,
+            project_id: projectId,
+            environment_id: envId,
+          } = error.response.data.existing_variable
+          toastError(
+            error,
+            'Conflict',
+            error.message,
+            undefined,
+            undefined,
+            'Go to the conflicting variable',
+            `${SERVICES_URL(orgId, projectId, envId)}${SERVICES_VARIABLES_URL}`
+          )
+        }
+      }
+    },
     meta: {
-      notifyOnError: true,
+      notifyOnError: false,
     },
   })
 }

--- a/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
+++ b/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
@@ -23,9 +23,7 @@ export function useCreateVariable() {
     onError(
       error: AxiosError<{
         existing_variable: { organization_id: string; project_id: string; environment_id: string; service_id: string }
-      }>,
-      variables,
-      context
+      }>
     ) {
       if (error.code === '409') {
         if (error.response?.data) {
@@ -42,6 +40,8 @@ export function useCreateVariable() {
               : `${ENVIRONMENTS_URL(orgId, projectId)}${ENVIRONMENTS_VARIABLES_URL}`
           toastError(error, 'Conflict', error.message, undefined, undefined, 'Go to the conflicting variable', url)
         }
+      } else {
+        toastError(error)
       }
     },
     meta: {

--- a/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
+++ b/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
@@ -1,7 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { AxiosError } from 'axios'
 import { mutations } from '@qovery/domains/variables/data-access'
-import { SERVICES_URL, SERVICES_VARIABLES_URL } from '@qovery/shared/routes'
+import {
+  APPLICATION_URL,
+  APPLICATION_VARIABLES_URL,
+  ENVIRONMENTS_URL,
+  ENVIRONMENTS_VARIABLES_URL,
+  SERVICES_URL,
+  SERVICES_VARIABLES_URL,
+} from '@qovery/shared/routes'
 import { toastError } from '@qovery/shared/ui'
 import { queries } from '@qovery/state/util-queries'
 
@@ -14,7 +21,9 @@ export function useCreateVariable() {
       })
     },
     onError(
-      error: AxiosError<{ existing_variable: { organization_id: string; project_id: string; environment_id: string } }>,
+      error: AxiosError<{
+        existing_variable: { organization_id: string; project_id: string; environment_id: string; service_id: string }
+      }>,
       variables,
       context
     ) {
@@ -24,16 +33,14 @@ export function useCreateVariable() {
             organization_id: orgId,
             project_id: projectId,
             environment_id: envId,
+            service_id: serviceId,
           } = error.response.data.existing_variable
-          toastError(
-            error,
-            'Conflict',
-            error.message,
-            undefined,
-            undefined,
-            'Go to the conflicting variable',
-            `${SERVICES_URL(orgId, projectId, envId)}${SERVICES_VARIABLES_URL}`
-          )
+          const url = serviceId
+            ? `${APPLICATION_URL(orgId, projectId, envId, serviceId)}${APPLICATION_VARIABLES_URL}`
+            : envId
+              ? `${SERVICES_URL(orgId, projectId, envId)}${SERVICES_VARIABLES_URL}`
+              : `${ENVIRONMENTS_URL(orgId, projectId)}${ENVIRONMENTS_VARIABLES_URL}`
+          toastError(error, 'Conflict', error.message, undefined, undefined, 'Go to the conflicting variable', url)
         }
       }
     },

--- a/libs/shared/ui/src/lib/utils/toast-error.spec.tsx
+++ b/libs/shared/ui/src/lib/utils/toast-error.spec.tsx
@@ -11,7 +11,7 @@ describe('error toaster', () => {
     const title = 'error title'
 
     toastError(null, title, message)
-    expect(toast).toHaveBeenCalledWith(ToastEnum.ERROR, title, message)
+    expect(toast).toHaveBeenCalledWith(ToastEnum.ERROR, title, message, undefined, undefined, undefined, undefined)
   })
 
   it('should call error toaster with error name and error message', () => {
@@ -21,12 +21,42 @@ describe('error toaster', () => {
     }
 
     toastError(error)
-    expect(toast).toHaveBeenCalledWith(ToastEnum.ERROR, 'error', 'error message')
+    expect(toast).toHaveBeenCalledWith(
+      ToastEnum.ERROR,
+      'error',
+      'error message',
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
   })
 
   it('should call error toaster with default error name', () => {
     const error = {}
     toastError(error)
-    expect(toast).toHaveBeenCalledWith(ToastEnum.ERROR, 'Error', 'No message found')
+    expect(toast).toHaveBeenCalledWith(
+      ToastEnum.ERROR,
+      'Error',
+      'No message found',
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
+  })
+
+  it('should call error toaster with label and external link', () => {
+    const error = {}
+    toastError(error, undefined, undefined, undefined, undefined, 'label', 'https://www.google.com')
+    expect(toast).toHaveBeenCalledWith(
+      ToastEnum.ERROR,
+      'Error',
+      'No message found',
+      undefined,
+      undefined,
+      'label',
+      'https://www.google.com'
+    )
   })
 })

--- a/libs/shared/ui/src/lib/utils/toast-error.tsx
+++ b/libs/shared/ui/src/lib/utils/toast-error.tsx
@@ -1,6 +1,23 @@
+import { type IconName } from '@fortawesome/fontawesome-common-types'
 import { type SerializedError } from '@qovery/shared/utils'
 import toast, { ToastEnum } from './toast'
 
-export function toastError(error: SerializedError | Error, title?: string, message?: string): void {
-  toast(ToastEnum.ERROR, title || error.name || 'Error', message || error.message || 'No message found')
+export function toastError(
+  error: SerializedError | Error,
+  title?: string,
+  description?: string,
+  callback?: () => void,
+  iconAction?: IconName,
+  labelAction?: string,
+  externalLink?: string
+): void {
+  toast(
+    ToastEnum.ERROR,
+    title || error.name || 'Error',
+    description || error.message || 'No message found',
+    callback,
+    iconAction,
+    labelAction,
+    externalLink
+  )
 }

--- a/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.tsx
+++ b/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
-import { type AxiosInstance } from 'axios'
+import { type AxiosInstance, type AxiosResponse } from 'axios'
 import { useEffect } from 'react'
 import { NODE_ENV } from '@qovery/shared/util-node-env'
 
@@ -8,6 +8,8 @@ export interface SerializedError {
   message?: string
   stack?: string
   code?: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  response?: AxiosResponse
 }
 
 export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string) {
@@ -52,6 +54,7 @@ export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string)
           message: error.response?.data?.detail,
           name: error.response?.data?.error,
           code: error.response?.data?.status?.toString(),
+          response: error.response,
         }
         return Promise.reject(err)
       }

--- a/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.tsx
+++ b/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.tsx
@@ -8,7 +8,6 @@ export interface SerializedError {
   message?: string
   stack?: string
   code?: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response?: AxiosResponse
 }
 


### PR DESCRIPTION
# What does this PR do?

[Link to the JIRA ticket](https://qovery.atlassian.net/browse/QOV-76)

This PR improves how we deal with conflicts when updating or creating an env variable by allowing the user to directly go to the conflicting variable from the warning toast.


https://github.com/user-attachments/assets/0fad037c-379f-4670-b2e4-f7d38ecb03c5



---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
