### PR TITLE
feat(cluster-scw-control-plane): add description specs for options

### DIFF
--- a/libs/domains/cloud-providers/feature/src/lib/cluster-scw-control-plane-feature/cluster-scw-control-plane-feature.spec.tsx
+++ b/libs/domains/cloud-providers/feature/src/lib/cluster-scw-control-plane-feature/cluster-scw-control-plane-feature.spec.tsx
@@ -77,7 +77,7 @@ describe('ClusterSCWControlPlaneFeature', () => {
       )
     )
 
-    expect(screen.getByText('Dedicated 4')).toBeInTheDocument()
+    expect(screen.getByText('Dedicated 4: 4 GB / 2vCPU / 250 nodes')).toBeInTheDocument()
   })
 
   it('shows downgrade warning when selecting a lower stier after a higher one', async () => {
@@ -125,5 +125,23 @@ describe('ClusterSCWControlPlaneFeature', () => {
 
     expect(screen.queryByText(/additional costs will be incurred/)).not.toBeInTheDocument()
     expect(screen.queryByText(/30-day commitment period/)).not.toBeInTheDocument()
+  })
+
+  it('displays the correct specifications when selecting different control plane types', async () => {
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <Section>
+          <ClusterSCWControlPlaneFeature production={false} />
+        </Section>
+      )
+    )
+
+    const selectInput = screen.getByLabelText('Type')
+
+    await selectEvent.select(selectInput, 'Dedicated 8', {
+      container: document.body,
+    })
+
+    expect(screen.getByText('Dedicated 8: 8 GB / 2vCPU / 500 nodes')).toBeInTheDocument()
   })
 })

--- a/libs/domains/cloud-providers/feature/src/lib/cluster-scw-control-plane-feature/cluster-scw-control-plane-feature.tsx
+++ b/libs/domains/cloud-providers/feature/src/lib/cluster-scw-control-plane-feature/cluster-scw-control-plane-feature.tsx
@@ -1,5 +1,6 @@
 import { Controller, useFormContext } from 'react-hook-form'
 import { type SCWControlPlaneFeatureType } from '@qovery/shared/interfaces'
+import { type Value } from '@qovery/shared/interfaces'
 import { Callout, ExternalLink, Heading, Icon, InputSelect, Tooltip } from '@qovery/shared/ui'
 import { useCloudProviderFeatures } from '../hooks/use-cloud-provider-features/use-cloud-provider-features'
 
@@ -12,6 +13,13 @@ export const CONTROL_PLANE_LABELS = {
   KAPSULE_DEDICATED16: 'Dedicated 16',
 }
 
+export const CONTROL_PLANE_SPECS = {
+  KAPSULE: '4 GB / 1vCPU / 150 nodes',
+  KAPSULE_DEDICATED4: '4 GB / 2vCPU / 250 nodes',
+  KAPSULE_DEDICATED8: '8 GB / 2vCPU / 500 nodes',
+  KAPSULE_DEDICATED16: '16 GB / 4vCPU / 500 nodes',
+}
+
 export interface ClusterSCWControlPlaneFeatureInterface {
   production: boolean
 }
@@ -22,10 +30,11 @@ export function ClusterSCWControlPlaneFeature({ production }: ClusterSCWControlP
   })
   const controlPlane = features?.find((feature) => feature.id === SCW_CONTROL_PLANE_FEATURE_ID)
 
-  const options =
+  const options: Value[] =
     controlPlane?.accepted_values?.map((value) => ({
       label: CONTROL_PLANE_LABELS[value as keyof typeof CONTROL_PLANE_LABELS],
       value: value as string,
+      description: CONTROL_PLANE_SPECS[value as keyof typeof CONTROL_PLANE_SPECS],
     })) || []
 
   const { control, formState, watch } = useFormContext<{ scw_control_plane: SCWControlPlaneFeatureType }>()
@@ -53,7 +62,7 @@ export function ClusterSCWControlPlaneFeature({ production }: ClusterSCWControlP
 
   return (
     <div className="flex flex-col gap-4">
-      <Heading className="flex items-center gap-1">
+      <Heading className="flex items-center gap-1.5">
         Control plane type
         <Tooltip
           content={
@@ -68,7 +77,7 @@ export function ClusterSCWControlPlaneFeature({ production }: ClusterSCWControlP
             </span>
           }
         >
-          <span>
+          <span className="relative top-0.5">
             <Icon iconName="circle-info" iconStyle="regular" />
           </span>
         </Tooltip>

--- a/libs/pages/services/src/lib/feature/page-job-create-feature/step-dockerfile-feature/__snapshots__/step-dockerfile-feature.spec.tsx.snap
+++ b/libs/pages/services/src/lib/feature/page-job-create-feature/step-dockerfile-feature/__snapshots__/step-dockerfile-feature.spec.tsx.snap
@@ -63,7 +63,7 @@ exports[`DockerfileSettings should match snapshot 1`] = `
                         class="input-select__value-container input-select__value-container--has-value css-1fdsijx-ValueContainer"
                       >
                         <span
-                          class="mr-1 text-sm text-neutral-400"
+                          class="mr-1 text-ssm text-neutral-400"
                         >
                           Raw Dockerfile
                         </span>

--- a/libs/pages/services/src/lib/feature/page-job-create-feature/step-dockerfile-feature/__snapshots__/step-dockerfile-feature.spec.tsx.snap
+++ b/libs/pages/services/src/lib/feature/page-job-create-feature/step-dockerfile-feature/__snapshots__/step-dockerfile-feature.spec.tsx.snap
@@ -63,7 +63,7 @@ exports[`DockerfileSettings should match snapshot 1`] = `
                         class="input-select__value-container input-select__value-container--has-value css-1fdsijx-ValueContainer"
                       >
                         <span
-                          class="mr-1 text-ssm text-neutral-400"
+                          class="mr-1 text-sm text-neutral-400"
                         >
                           Raw Dockerfile
                         </span>

--- a/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
@@ -165,7 +165,7 @@ export function InputSelect({
           ) : (
             <Icon iconName="check" className="opacity-0" />
           )}
-          <label id={id} className="ml-2 flex flex-col gap-0.5 truncate text-ssm">
+          <label id={id} className="ml-2 flex flex-col gap-0.5 truncate text-sm">
             {props.label}
             {props.data.description && <span className="font-normal">{props.data.description}</span>}
           </label>
@@ -175,14 +175,14 @@ export function InputSelect({
   }
 
   const MultiValue = (props: MultiValueProps<Value, true, GroupBase<Value>>) => (
-    <span className="mr-1 flex text-ssm text-neutral-400">
+    <span className="mr-1 flex text-sm text-neutral-400">
       {props.data.label}
       {props.index + 1 !== (selectedItems as MultiValue<Value>).length && ', '}
     </span>
   )
 
   const SingleValue = (props: SingleValueProps<Value>) => (
-    <span className="mr-1 text-ssm text-neutral-400">
+    <span className="mr-1 text-sm text-neutral-400">
       {props.data.label}
       {props.data.description ? `: ${props.data.description}` : ''}
     </span>

--- a/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
@@ -175,14 +175,14 @@ export function InputSelect({
   }
 
   const MultiValue = (props: MultiValueProps<Value, true, GroupBase<Value>>) => (
-    <span className="mr-1 flex text-sm text-neutral-400">
+    <span className="mr-1 flex text-ssm text-neutral-400">
       {props.data.label}
       {props.index + 1 !== (selectedItems as MultiValue<Value>).length && ', '}
     </span>
   )
 
   const SingleValue = (props: SingleValueProps<Value>) => (
-    <span className="mr-1 text-sm text-neutral-400">
+    <span className="mr-1 text-ssm text-neutral-400">
       {props.data.label}
       {props.data.description ? `: ${props.data.description}` : ''}
     </span>

--- a/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
@@ -165,8 +165,9 @@ export function InputSelect({
           ) : (
             <Icon iconName="check" className="opacity-0" />
           )}
-          <label id={id} className="ml-2 truncate">
+          <label id={id} className="ml-2 flex flex-col gap-0.5 truncate text-ssm">
             {props.label}
+            {props.data.description && <span className="font-normal">{props.data.description}</span>}
           </label>
         </components.Option>
       </div>
@@ -181,7 +182,10 @@ export function InputSelect({
   )
 
   const SingleValue = (props: SingleValueProps<Value>) => (
-    <span className="mr-1 text-sm text-neutral-400">{props.data.label}</span>
+    <span className="mr-1 text-sm text-neutral-400">
+      {props.data.label}
+      {props.data.description ? `: ${props.data.description}` : ''}
+    </span>
   )
 
   const NoOptionsMessage = (props: NoticeProps<Value>) => {


### PR DESCRIPTION
# What does this PR do?

https://qovery.atlassian.net/jira/software/c/projects/QOV/boards/56?selectedIssue=QOV-46

- Update `input-select` to support `description` inside label
- Add description for each control plane option

<img width="697" alt="Screenshot 2025-05-12 at 14 51 22" src="https://github.com/user-attachments/assets/2e9c01e6-c64c-472b-b135-5cce0e9ed4be" />

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
