### PR TITLE
fix(cluster-running-status): remove deprecated filter

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-terminal/cluster-terminal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-terminal/cluster-terminal.tsx
@@ -48,7 +48,7 @@ export function ClusterTerminal({ organizationId, clusterId }: ClusterTerminalPr
   // Hack to avoid having connection delay with server
   useEffect(() => {
     if (!isTerminalLoading) {
-      const timer = setTimeout(() => setShowDelayedLoader(false), 6_000)
+      const timer = setTimeout(() => setShowDelayedLoader(false), 4_000)
       return () => clearTimeout(timer)
     }
     return () => null

--- a/libs/domains/clusters/feature/src/lib/hooks/use-cluster-running-status-socket/use-cluster-running-status-socket.ts
+++ b/libs/domains/clusters/feature/src/lib/hooks/use-cluster-running-status-socket/use-cluster-running-status-socket.ts
@@ -15,12 +15,7 @@ export function useClusterRunningStatusSocket({ organizationId, clusterId }: Use
       cluster: clusterId,
     },
     onMessage(queryClient, message: ClusterStatusDto) {
-      // XXX: Filter out Fargate nodes (nodes without instance_type)
-      const filteredMessage = {
-        ...message,
-        nodes: message.nodes.filter((node) => node.instance_type !== undefined),
-      }
-      queryClient.setQueryData(queries.clusters.runningStatus({ organizationId, clusterId }).queryKey, filteredMessage)
+      queryClient.setQueryData(queries.clusters.runningStatus({ organizationId, clusterId }).queryKey, message)
     },
     onClose(queryClient, event: CloseEvent) {
       // XXX: API returns a string for the reason, which allows us to know if the status is available or not


### PR DESCRIPTION
# What does this PR do?

- Remove useless filter in running status
- Decrease loader timing for Cluster terminal

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
