### PR TITLE
impr: bump API version and fix TS errors

### DIFF
--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -152,12 +152,19 @@ export function CreateUpdateVariableModal(props: CreateUpdateVariableModalProps)
           }
           throw new Error('Scope mismatch')
         })
-        .with({ scope: 'APPLICATION' }, { scope: 'CONTAINER' }, { scope: 'JOB' }, { scope: 'HELM' }, () => {
-          if ('serviceId' in props) {
-            return props.serviceId
+        .with(
+          { scope: 'APPLICATION' },
+          { scope: 'CONTAINER' },
+          { scope: 'JOB' },
+          { scope: 'HELM' },
+          { scope: 'TERRAFORM' },
+          () => {
+            if ('serviceId' in props) {
+              return props.serviceId
+            }
+            throw new Error('Scope mismatch')
           }
-          throw new Error('Scope mismatch')
-        })
+        )
         .with({ scope: undefined }, () => {
           throw new Error('scope undefined')
         })

--- a/libs/pages/events/src/lib/ui/row-event/row-event.tsx
+++ b/libs/pages/events/src/lib/ui/row-event/row-event.tsx
@@ -76,6 +76,7 @@ export function RowEvent(props: RowEventProps) {
       [OrganizationEventTargetType.CONTAINER]: generateApplicationLink,
       [OrganizationEventTargetType.JOB]: generateApplicationLink,
       [OrganizationEventTargetType.HELM]: generateApplicationLink,
+      [OrganizationEventTargetType.TERRAFORM]: generateApplicationLink,
       [OrganizationEventTargetType.ORGANIZATION]: () => customLink(SETTINGS_URL(organizationId)),
       [OrganizationEventTargetType.MEMBERS_AND_ROLES]: () =>
         customLink(SETTINGS_URL(organizationId) + SETTINGS_MEMBERS_URL),

--- a/libs/pages/services/src/lib/feature/page-job-create-feature/step-summary-feature/step-summary-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-job-create-feature/step-summary-feature/step-summary-feature.tsx
@@ -278,7 +278,7 @@ export function StepSummaryFeature() {
                 .with('JOB', () => service.id)
                 .with('ENVIRONMENT', () => service.environment.id)
                 .with('PROJECT', () => projectId)
-                .with('BUILT_IN', 'APPLICATION', 'CONTAINER', 'HELM', undefined, () => {
+                .with('BUILT_IN', 'APPLICATION', 'CONTAINER', 'HELM', 'TERRAFORM', undefined, () => {
                   throw new Error('Should not be possible')
                 })
                 .exhaustive(),

--- a/libs/shared/util-js/src/lib/compute-available-environment-variable-scope.ts
+++ b/libs/shared/util-js/src/lib/compute-available-environment-variable-scope.ts
@@ -23,7 +23,7 @@ function scopeHierarchy(targetScope: APIVariableScopeEnum) {
     .with('BUILT_IN', () => baseHierarchy.slice(0, 1))
     .with('PROJECT', () => baseHierarchy.slice(0, 2))
     .with('ENVIRONMENT', () => baseHierarchy)
-    .with('APPLICATION', 'CONTAINER', 'HELM', 'JOB', (serviceScope) => [
+    .with('APPLICATION', 'CONTAINER', 'HELM', 'JOB', 'TERRAFORM', (serviceScope) => [
       ...baseHierarchy,
       {
         name: serviceScope,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mermaid": "^11.6.0",
     "monaco-editor": "^0.44.0",
     "posthog-js": "^1.131.4",
-    "qovery-typescript-axios": "^1.1.591",
+    "qovery-typescript-axios": "^1.1.616",
     "react": "18.3.1",
     "react-country-flag": "^3.0.2",
     "react-datepicker": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,7 +4224,7 @@ __metadata:
     prettier: ^3.2.5
     prettier-plugin-tailwindcss: ^0.5.14
     pretty-quick: ^4.0.0
-    qovery-typescript-axios: ^1.1.591
+    qovery-typescript-axios: ^1.1.616
     qovery-ws-typescript-axios: ^0.1.299
     react: 18.3.1
     react-country-flag: ^3.0.2
@@ -21328,12 +21328,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:^1.1.591":
-  version: 1.1.591
-  resolution: "qovery-typescript-axios@npm:1.1.591"
+"qovery-typescript-axios@npm:^1.1.616":
+  version: 1.1.616
+  resolution: "qovery-typescript-axios@npm:1.1.616"
   dependencies:
     axios: 1.8.2
-  checksum: 0b97bfad68af4fbc0f1bdfc562c44dc6c6ea8d17859f0bdb8336a9a117b5b5361655cd91d85fd60d2fd47c6179a83845a57e16c1398789ee76647fb8449258c9
+  checksum: 94a5e579332693bb251c6258ddbd5cd8a4e48ae7af248cc1d8b3544f55214ec2d26bdf63758886e997e76109b06e3cf859fba84934821db8aa95220d7c727cc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What does this PR do?

[QOV-901](https://qovery.atlassian.net/browse/QOV-901)

This PR bumps the `qovery-typescript-axios` package and fixes the TS error brought along.  
It also fixes the `I[t] is not a function` error that shows up in the audit logs.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-901]: https://qovery.atlassian.net/browse/QOV-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ