### PR TITLE
chore(azure): update container credentials fields

### DIFF
--- a/libs/domains/services/feature/src/lib/select-commit-modal/__snapshots__/select-commit-modal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/select-commit-modal/__snapshots__/select-commit-modal.spec.tsx.snap
@@ -211,7 +211,7 @@ exports[`SelectCommitModal should match snapshot 1`] = `
                   class="text-neutral-350 dark:text-neutral-50"
                 >
                   committed 
-                  1570 years
+                  1571 years
                    ago
                 </span>
               </div>

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mermaid": "^11.6.0",
     "monaco-editor": "^0.44.0",
     "posthog-js": "^1.131.4",
-    "qovery-typescript-axios": "^1.1.632",
+    "qovery-typescript-axios": "^1.1.635",
     "react": "18.3.1",
     "react-country-flag": "^3.0.2",
     "react-datepicker": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,7 +4224,7 @@ __metadata:
     prettier: ^3.2.5
     prettier-plugin-tailwindcss: ^0.5.14
     pretty-quick: ^4.0.0
-    qovery-typescript-axios: ^1.1.632
+    qovery-typescript-axios: ^1.1.635
     qovery-ws-typescript-axios: ^0.1.309
     react: 18.3.1
     react-country-flag: ^3.0.2
@@ -21328,12 +21328,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:^1.1.632":
-  version: 1.1.632
-  resolution: "qovery-typescript-axios@npm:1.1.632"
+"qovery-typescript-axios@npm:^1.1.635":
+  version: 1.1.635
+  resolution: "qovery-typescript-axios@npm:1.1.635"
   dependencies:
     axios: 1.8.2
-  checksum: df9060822adb2cdcbffa11f4bca6bba8bf58dea89fd6c014a0e4f1d7e49d397efcba71b274dc0cccedf4a8d49cbcb8befbfe57319c74cce06ba806468dfab0ee
+  checksum: 95d75b8517390dd25bea1d5952b633bbbd0af9b68428cf4dd5ae90e62f06023848edf967b042b550cb0ba911f9f8f1180c42351dc994a79d9cb746b71694d64a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What does this PR do?

Replace Azure external container registry fields `azure_client_id` and `azure_client_secret` to `azure_tenant_id` and `azure_subscription_id`.

> Link to the JIRA ticket

Put description here

> Screenshot of the feature

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I made sure the code is type safe (no any)
