### PR TITLE
fix(service-running-status): display unavailable if agent error

### DIFF
--- a/libs/domains/environments/data-access/src/lib/domains-environments-data-access.ts
+++ b/libs/domains/environments/data-access/src/lib/domains-environments-data-access.ts
@@ -59,6 +59,14 @@ export const environments = createQueryKeys('environments', {
       return new Promise<{ state: RunningState } | null>(() => {})
     },
   }),
+  // NOTE: Value is set by WebSocket
+  checkRunningStatusClosed: (clusterId: string) => ({
+    queryKey: [clusterId],
+    queryFn() {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return new Promise<{ clusterId: string; reason: string }>(() => {})
+    },
+  }),
   details: ({ environmentId }: { environmentId: string }) => ({
     queryKey: [environmentId],
     async queryFn() {

--- a/libs/domains/environments/feature/src/lib/environment-list/environment-list.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-list/environment-list.tsx
@@ -40,7 +40,7 @@ import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
 import { CreateCloneEnvironmentModal } from '../create-clone-environment-modal/create-clone-environment-modal'
 import { EnvironmentActionToolbar } from '../environment-action-toolbar/environment-action-toolbar'
 import { EnvironmentMode } from '../environment-mode/environment-mode'
-import { usecheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
+import { useCheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
 import { useEnvironments } from '../hooks/use-environments/use-environments'
 import { EnvironmentListSkeleton } from './environment-list-skeleton'
 
@@ -88,7 +88,7 @@ function EnvironmentStatusCell({
   runningStatus?: RunningState
   value?: string
 }) {
-  const { data: checkRunningStatusClosed } = usecheckRunningStatusClosed({
+  const { data: checkRunningStatusClosed } = useCheckRunningStatusClosed({
     clusterId: environment.cluster_id,
   })
 

--- a/libs/domains/environments/feature/src/lib/environment-list/environment-list.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-list/environment-list.tsx
@@ -13,6 +13,7 @@ import { type Environment, type Project } from 'qovery-typescript-axios'
 import { type ComponentProps, Fragment, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { match } from 'ts-pattern'
+import { type RunningState } from '@qovery/shared/enums'
 import {
   CLUSTERS_NEW_URL,
   CLUSTERS_URL,
@@ -39,6 +40,7 @@ import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
 import { CreateCloneEnvironmentModal } from '../create-clone-environment-modal/create-clone-environment-modal'
 import { EnvironmentActionToolbar } from '../environment-action-toolbar/environment-action-toolbar'
 import { EnvironmentMode } from '../environment-mode/environment-mode'
+import { usecheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
 import { useEnvironments } from '../hooks/use-environments/use-environments'
 import { EnvironmentListSkeleton } from './environment-list-skeleton'
 
@@ -74,6 +76,60 @@ function EnvironmentNameCell({ environment }: { environment: Environment }) {
         </div>
       </div>
     </div>
+  )
+}
+
+function EnvironmentStatusCell({
+  environment,
+  runningStatus,
+  value,
+}: {
+  environment: Pick<Environment, 'id' | 'organization' | 'project' | 'cluster_id'>
+  runningStatus?: RunningState
+  value?: string
+}) {
+  const { data: checkRunningStatusClosed } = usecheckRunningStatusClosed({
+    clusterId: environment.cluster_id,
+  })
+
+  if (checkRunningStatusClosed) {
+    return (
+      <Tooltip content="See my cluster">
+        <Link
+          as="button"
+          to={CLUSTER_URL(environment.organization.id, environment.cluster_id)}
+          onClick={(e) => e.stopPropagation()}
+          className="gap-2 whitespace-nowrap text-sm"
+          size="md"
+          color="neutral"
+          variant="outline"
+          radius="full"
+        >
+          <StatusChip status={runningStatus} />
+          Status unavailable
+        </Link>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Skeleton width={102} height={34} show={!value}>
+      <Tooltip content="See overview">
+        <Link
+          as="button"
+          to={SERVICES_URL(environment.organization.id, environment.project.id, environment.id) + SERVICES_GENERAL_URL}
+          onClick={(e) => e.stopPropagation()}
+          className="gap-2 whitespace-nowrap text-sm"
+          size="md"
+          color="neutral"
+          variant="outline"
+          radius="full"
+        >
+          <StatusChip status={runningStatus} />
+          {value}
+        </Link>
+      </Tooltip>
+    </Skeleton>
   )
 }
 
@@ -122,26 +178,11 @@ export function EnvironmentList({ project, clusterAvailable, className, ...props
           const value = info.getValue()
           const environment = info.row.original
           return (
-            <Skeleton width={102} height={34} show={!value}>
-              <Tooltip content="See overview">
-                <Link
-                  as="button"
-                  to={
-                    SERVICES_URL(environment.organization.id, environment.project.id, environment.id) +
-                    SERVICES_GENERAL_URL
-                  }
-                  onClick={(e) => e.stopPropagation()}
-                  className="gap-2 whitespace-nowrap text-sm"
-                  size="md"
-                  color="neutral"
-                  variant="outline"
-                  radius="full"
-                >
-                  <StatusChip status={environment.runningStatus?.state} />
-                  {value}
-                </Link>
-              </Tooltip>
-            </Skeleton>
+            <EnvironmentStatusCell
+              environment={environment}
+              runningStatus={environment.runningStatus?.state}
+              value={value}
+            />
           )
         },
       }),

--- a/libs/domains/environments/feature/src/lib/environment-list/environment-list.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-list/environment-list.tsx
@@ -94,7 +94,7 @@ function EnvironmentStatusCell({
 
   if (checkRunningStatusClosed) {
     return (
-      <Tooltip content="See my cluster">
+      <Tooltip content="See cluster">
         <Link
           as="button"
           to={CLUSTER_URL(environment.organization.id, environment.cluster_id)}

--- a/libs/domains/environments/feature/src/lib/environment-state-chip/environment-state-chip.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-state-chip/environment-state-chip.tsx
@@ -1,5 +1,7 @@
 import { Skeleton, StatusChip, type StatusChipProps } from '@qovery/shared/ui'
+import { usecheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
 import { useDeploymentStatus } from '../hooks/use-deployment-status/use-deployment-status'
+import { useEnvironment } from '../hooks/use-environment/use-environment'
 import { useRunningStatus } from '../hooks/use-running-status/use-running-status'
 
 /**
@@ -43,7 +45,16 @@ function DeploymentStateChip({ environmentId, mode, ...props }: DeploymentStateC
 type RunningStateChipProps = Omit<EnvironmentStateChipProps, 'mode'>
 
 function RunningStateChip({ environmentId, ...props }: RunningStateChipProps) {
+  const { data: environment } = useEnvironment({ environmentId })
   const { data: runningStatus } = useRunningStatus({ environmentId })
+  const { data: checkRunningStatusClosed } = usecheckRunningStatusClosed({
+    clusterId: environment?.cluster_id ?? '',
+  })
+
+  if (checkRunningStatusClosed) {
+    return <StatusChip status="STOPPED" {...props} />
+  }
+
   return (
     <Skeleton width={16} height={16} show={!runningStatus?.state} rounded>
       <StatusChip status={runningStatus?.state} {...props} />

--- a/libs/domains/environments/feature/src/lib/environment-state-chip/environment-state-chip.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-state-chip/environment-state-chip.tsx
@@ -1,5 +1,5 @@
 import { Skeleton, StatusChip, type StatusChipProps } from '@qovery/shared/ui'
-import { usecheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
+import { useCheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
 import { useDeploymentStatus } from '../hooks/use-deployment-status/use-deployment-status'
 import { useEnvironment } from '../hooks/use-environment/use-environment'
 import { useRunningStatus } from '../hooks/use-running-status/use-running-status'
@@ -47,7 +47,7 @@ type RunningStateChipProps = Omit<EnvironmentStateChipProps, 'mode'>
 function RunningStateChip({ environmentId, ...props }: RunningStateChipProps) {
   const { data: environment } = useEnvironment({ environmentId })
   const { data: runningStatus } = useRunningStatus({ environmentId })
-  const { data: checkRunningStatusClosed } = usecheckRunningStatusClosed({
+  const { data: checkRunningStatusClosed } = useCheckRunningStatusClosed({
     clusterId: environment?.cluster_id ?? '',
   })
 

--- a/libs/domains/environments/feature/src/lib/hooks/use-check-running-status-closed/use-check-running-status-closed.ts
+++ b/libs/domains/environments/feature/src/lib/hooks/use-check-running-status-closed/use-check-running-status-closed.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { queries } from '@qovery/state/util-queries'
 
-export interface UsecheckRunningStatusClosedProps {
+export interface UseCheckRunningStatusClosedProps {
   clusterId: string
 }
 
-export function usecheckRunningStatusClosed({ clusterId }: UsecheckRunningStatusClosedProps) {
+export function useCheckRunningStatusClosed({ clusterId }: UseCheckRunningStatusClosedProps) {
   return useQuery({
     ...queries.environments.checkRunningStatusClosed(clusterId),
     refetchOnMount: false,
@@ -15,4 +15,4 @@ export function usecheckRunningStatusClosed({ clusterId }: UsecheckRunningStatus
   })
 }
 
-export default usecheckRunningStatusClosed
+export default useCheckRunningStatusClosed

--- a/libs/domains/environments/feature/src/lib/hooks/use-check-running-status-closed/use-check-running-status-closed.ts
+++ b/libs/domains/environments/feature/src/lib/hooks/use-check-running-status-closed/use-check-running-status-closed.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { queries } from '@qovery/state/util-queries'
+
+export interface UsecheckRunningStatusClosedProps {
+  clusterId: string
+}
+
+export function usecheckRunningStatusClosed({ clusterId }: UsecheckRunningStatusClosedProps) {
+  return useQuery({
+    ...queries.environments.checkRunningStatusClosed(clusterId),
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+  })
+}
+
+export default usecheckRunningStatusClosed

--- a/libs/domains/services/data-access/src/lib/domains-services-data-access.ts
+++ b/libs/domains/services/data-access/src/lib/domains-services-data-access.ts
@@ -199,6 +199,14 @@ export const services = createQueryKeys('services', {
       return new Promise<ApplicationStatusDto | DatabaseStatusDto | null>(() => {})
     },
   }),
+  checkRunningStatusClosed: (clusterId: string, environmentId: string) => ({
+    queryKey: [clusterId, environmentId],
+    // NOTE: Value is set by WebSocket
+    queryFn() {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return new Promise<{ clusterId: string; environmentId: string; reason: string }>(() => {})
+    },
+  }),
   metrics: (environmentId: string, serviceId: string) => ({
     queryKey: [environmentId, serviceId],
     // NOTE: Value is set by WebSocket

--- a/libs/domains/services/feature/src/lib/hooks/use-check-running-status-closed/use-check-running-status-closed.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-check-running-status-closed/use-check-running-status-closed.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { queries } from '@qovery/state/util-queries'
+
+export interface UsecheckRunningStatusClosedProps {
+  clusterId: string
+  environmentId: string
+}
+
+export function usecheckRunningStatusClosed({ clusterId, environmentId }: UsecheckRunningStatusClosedProps) {
+  return useQuery({
+    ...queries.services.checkRunningStatusClosed(clusterId, environmentId),
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+  })
+}
+
+export default usecheckRunningStatusClosed

--- a/libs/domains/services/feature/src/lib/hooks/use-check-running-status-closed/use-check-running-status-closed.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-check-running-status-closed/use-check-running-status-closed.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { queries } from '@qovery/state/util-queries'
 
-export interface UsecheckRunningStatusClosedProps {
+export interface UseCheckRunningStatusClosedProps {
   clusterId: string
   environmentId: string
 }
 
-export function usecheckRunningStatusClosed({ clusterId, environmentId }: UsecheckRunningStatusClosedProps) {
+export function useCheckRunningStatusClosed({ clusterId, environmentId }: UseCheckRunningStatusClosedProps) {
   return useQuery({
     ...queries.services.checkRunningStatusClosed(clusterId, environmentId),
     refetchOnMount: false,
@@ -16,4 +16,4 @@ export function usecheckRunningStatusClosed({ clusterId, environmentId }: Useche
   })
 }
 
-export default usecheckRunningStatusClosed
+export default useCheckRunningStatusClosed

--- a/libs/domains/services/feature/src/lib/service-list/service-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list.tsx
@@ -67,7 +67,7 @@ import {
   twMerge,
   upperCaseFirstLetter,
 } from '@qovery/shared/util-js'
-import { usecheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
+import { useCheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
 import { useServices } from '../hooks/use-services/use-services'
 import { LastCommit } from '../last-commit/last-commit'
 import LastVersion from '../last-version/last-version'
@@ -325,7 +325,7 @@ export function ServiceList({ environment, className, ...props }: ServiceListPro
     organization: { id: organizationId },
   } = environment
   const { data: services = [], isLoading: isServicesLoading } = useServices({ environmentId })
-  const { data: checkRunningStatusClosed } = usecheckRunningStatusClosed({
+  const { data: checkRunningStatusClosed } = useCheckRunningStatusClosed({
     clusterId,
     environmentId,
   })

--- a/libs/domains/services/feature/src/lib/service-list/service-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list.tsx
@@ -33,16 +33,12 @@ import {
 import {
   APPLICATION_GENERAL_URL,
   APPLICATION_URL,
+  CLUSTER_URL,
   DATABASE_GENERAL_URL,
   DATABASE_URL,
   DEPLOYMENT_LOGS_VERSION_URL,
   ENVIRONMENT_LOGS_URL,
-  SERVICES_APPLICATION_CREATION_URL,
-  SERVICES_CRONJOB_CREATION_URL,
-  SERVICES_DATABASE_CREATION_URL,
   SERVICES_GENERAL_URL,
-  SERVICES_HELM_CREATION_URL,
-  SERVICES_LIFECYCLE_CREATION_URL,
   SERVICES_NEW_URL,
   SERVICES_URL,
 } from '@qovery/shared/routes'
@@ -55,7 +51,6 @@ import {
   ExternalLink,
   Icon,
   Link,
-  type MenuData,
   Skeleton,
   StatusChip,
   TableFilter,
@@ -72,6 +67,7 @@ import {
   twMerge,
   upperCaseFirstLetter,
 } from '@qovery/shared/util-js'
+import { usecheckRunningStatusClosed } from '../hooks/use-check-running-status-closed/use-check-running-status-closed'
 import { useServices } from '../hooks/use-services/use-services'
 import { LastCommit } from '../last-commit/last-commit'
 import LastVersion from '../last-version/last-version'
@@ -324,10 +320,15 @@ export interface ServiceListProps extends ComponentProps<typeof Table.Root> {
 export function ServiceList({ environment, className, ...props }: ServiceListProps) {
   const {
     id: environmentId,
+    cluster_id: clusterId,
     project: { id: projectId },
     organization: { id: organizationId },
   } = environment
   const { data: services = [], isLoading: isServicesLoading } = useServices({ environmentId })
+  const { data: checkRunningStatusClosed } = usecheckRunningStatusClosed({
+    clusterId,
+    environmentId,
+  })
   const [sorting, setSorting] = useState<SortingState>([])
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
   const navigate = useNavigate()
@@ -421,6 +422,27 @@ export function ServiceList({ environment, className, ...props }: ServiceListPro
               ({ id }) => DATABASE_URL(organizationId, projectId, environmentId, id) + DATABASE_GENERAL_URL
             )
             .otherwise(({ id }) => APPLICATION_URL(organizationId, projectId, environmentId, id) + SERVICES_GENERAL_URL)
+
+          if (checkRunningStatusClosed) {
+            return (
+              <Tooltip content="See my cluster">
+                <Link
+                  as="button"
+                  to={CLUSTER_URL(organizationId, environment.cluster_id)}
+                  onClick={(e) => e.stopPropagation()}
+                  className="gap-2 whitespace-nowrap text-sm"
+                  size="md"
+                  color="neutral"
+                  variant="outline"
+                  radius="full"
+                >
+                  <StatusChip status="STOPPED" />
+                  Status unavailable
+                </Link>
+              </Tooltip>
+            )
+          }
+
           return (
             <Skeleton width={102} height={34} show={!value}>
               <Tooltip content="See overview">
@@ -703,52 +725,6 @@ export function ServiceList({ environment, className, ...props }: ServiceListPro
       maxSize: Number.MAX_SAFE_INTEGER,
     },
   })
-
-  const newServicesMenu: MenuData = [
-    {
-      items: [
-        {
-          name: 'Create application',
-          contentLeft: <Icon iconName="layer-group" className="text-sm text-brand-500" />,
-          onClick: () => {
-            navigate(`${SERVICES_URL(organizationId, projectId, environmentId)}${SERVICES_APPLICATION_CREATION_URL}`)
-          },
-        },
-        {
-          name: 'Create database',
-          contentLeft: <Icon iconName="database" className="text-sm text-brand-500" />,
-          onClick: () => {
-            navigate(`${SERVICES_URL(organizationId, projectId, environmentId)}${SERVICES_DATABASE_CREATION_URL}`)
-          },
-        },
-        {
-          name: 'Create lifecycle job',
-          contentLeft: (
-            <Icon name={IconEnum.LIFECYCLE_JOB_STROKE} width="14" height="16" className="text-sm text-brand-500" />
-          ),
-          onClick: () => {
-            navigate(`${SERVICES_URL(organizationId, projectId, environmentId)}${SERVICES_LIFECYCLE_CREATION_URL}`)
-          },
-        },
-        {
-          name: 'Create cronjob',
-          contentLeft: (
-            <Icon name={IconEnum.CRON_JOB_STROKE} width="14" height="16" className="text-sm text-brand-500" />
-          ),
-          onClick: () => {
-            navigate(`${SERVICES_URL(organizationId, projectId, environmentId)}${SERVICES_CRONJOB_CREATION_URL}`)
-          },
-        },
-        {
-          name: 'Create helm',
-          contentLeft: <Icon name={IconEnum.HELM_OFFICIAL} width="14" height="16" className="text-sm text-brand-500" />,
-          onClick: () => {
-            navigate(`${SERVICES_URL(organizationId, projectId, environmentId)}${SERVICES_HELM_CREATION_URL}`)
-          },
-        },
-      ],
-    },
-  ]
 
   if (services.length === 0 && isServicesLoading) {
     return <ServiceListSkeleton />

--- a/libs/domains/services/feature/src/lib/service-list/service-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list.tsx
@@ -425,7 +425,7 @@ export function ServiceList({ environment, className, ...props }: ServiceListPro
 
           if (checkRunningStatusClosed) {
             return (
-              <Tooltip content="See my cluster">
+              <Tooltip content="See cluster">
                 <Link
                   as="button"
                   to={CLUSTER_URL(organizationId, environment.cluster_id)}


### PR DESCRIPTION
# What does this PR do?

- Added new hook `useCheckRunningStatusClosed` to have the possibility to add a custom message when the service running status is closed/unavailable
- For now, I used it only for displaying `status unavailable` when we don't have a status for running status in the service and environment list

https://qovery.slack.com/archives/C02P2JB4SEM/p1750664192989659

<img width="1464" alt="Screenshot 2025-06-24 at 14 56 06" src="https://github.com/user-attachments/assets/cb0f75d5-5591-40ec-8a01-fbde00f1d802" />

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
