### PR TITLE
fix: old logs are not accessible

### DIFF
--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -6,8 +6,10 @@ import {
 } from 'qovery-typescript-axios'
 import { useCallback, useState } from 'react'
 import { Navigate, Route, Routes, matchPath, useLocation, useParams } from 'react-router-dom'
-import { useDeploymentHistory, useEnvironment } from '@qovery/domains/environments/feature'
+import { useEnvironment } from '@qovery/domains/environments/feature'
 import { ServiceStageIdsProvider } from '@qovery/domains/service-logs/feature'
+import { useService } from '@qovery/domains/services/feature'
+import { useDeploymentHistory } from '@qovery/domains/services/feature'
 import {
   DEPLOYMENT_LOGS_VERSION_URL,
   ENVIRONMENT_LOGS_URL,
@@ -28,9 +30,6 @@ export function PageEnvironmentLogs() {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams()
   const location = useLocation()
   const { data: environment } = useEnvironment({ environmentId })
-  const { data: environmentDeploymentHistory = [], isFetched: isFetchedDeploymentHistory } = useDeploymentHistory({
-    environmentId,
-  })
 
   useDocumentTitle(`Environment logs ${environment ? `- ${environment?.name}` : '- Loading...'}`)
 
@@ -62,6 +61,13 @@ export function PageEnvironmentLogs() {
   const [preCheckStage, setPreCheckStage] = useState<EnvironmentStatusesWithStagesPreCheckStage>()
 
   const versionIdUrl = deploymentVersionId || preCheckVersionId || stageVersionId
+
+  const { data: service } = useService({ environmentId: environment?.id, serviceId: versionIdUrl })
+  const { data: environmentDeploymentHistory = [], isFetched: isFetchedDeploymentHistory } = useDeploymentHistory({
+    serviceId: service?.id ?? '',
+    serviceType: service?.service_type,
+  })
+
   const isLatestVersion = environmentDeploymentHistory[0]?.identifier.execution_id === versionIdUrl
 
   const messageHandler = useCallback(


### PR DESCRIPTION
# Old logs are not accessible

[QOV-937](https://qovery.atlassian.net/browse/QOV-937)

This PR fixes an issue where old logs were not accessible.

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-937]: https://qovery.atlassian.net/browse/QOV-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ