### PR TITLE
fix(logs): make older env logs accessible

### DIFF
--- a/libs/domains/environments/data-access/src/lib/domains-environments-data-access.ts
+++ b/libs/domains/environments/data-access/src/lib/domains-environments-data-access.ts
@@ -102,10 +102,10 @@ export const environments = createQueryKeys('environments', {
       return result.data.results
     },
   }),
-  deploymentHistoryV2: ({ environmentId }: { environmentId: string }) => ({
+  deploymentHistoryV2: ({ environmentId, pageSize }: { environmentId: string; pageSize?: number }) => ({
     queryKey: [environmentId],
     async queryFn() {
-      const result = await environmentDeploymentsApi.listEnvironmentDeploymentHistoryV2(environmentId)
+      const result = await environmentDeploymentsApi.listEnvironmentDeploymentHistoryV2(environmentId, pageSize)
       return result.data.results
     },
   }),

--- a/libs/domains/environments/feature/src/lib/hooks/use-deployment-history/use-deployment-history.ts
+++ b/libs/domains/environments/feature/src/lib/hooks/use-deployment-history/use-deployment-history.ts
@@ -3,11 +3,12 @@ import { queries } from '@qovery/state/util-queries'
 
 export interface UseDeploymentHistoryProps {
   environmentId: string
+  pageSize?: number
 }
 
-export function useDeploymentHistory({ environmentId }: UseDeploymentHistoryProps) {
+export function useDeploymentHistory({ environmentId, pageSize = 100 }: UseDeploymentHistoryProps) {
   return useQuery({
-    ...queries.environments.deploymentHistoryV2({ environmentId }),
+    ...queries.environments.deploymentHistoryV2({ environmentId, pageSize }),
     refetchInterval: 5000,
     retryOnMount: true,
     staleTime: 4500,

--- a/libs/domains/services/data-access/src/lib/domains-services-data-access.ts
+++ b/libs/domains/services/data-access/src/lib/domains-services-data-access.ts
@@ -366,29 +366,41 @@ export const services = createQueryKeys('services', {
       return commits
     },
   }),
-  deploymentHistory: ({ serviceId, serviceType }: { serviceId: string; serviceType: ServiceType }) => ({
+  deploymentHistory: ({
+    serviceId,
+    serviceType,
+    pageSize,
+  }: {
+    serviceId: string
+    serviceType: ServiceType
+    pageSize?: number
+  }) => ({
     queryKey: [serviceId],
     async queryFn() {
       return await match(serviceType)
         .with(
           'APPLICATION',
-          async () => (await applicationDeploymentsApi.listApplicationDeploymentHistoryV2(serviceId)).data.results
+          async () =>
+            (await applicationDeploymentsApi.listApplicationDeploymentHistoryV2(serviceId, pageSize)).data.results
         )
         .with(
           'CONTAINER',
-          async () => (await containerDeploymentsApi.listContainerDeploymentHistoryV2(serviceId)).data.results
+          async () => (await containerDeploymentsApi.listContainerDeploymentHistoryV2(serviceId, pageSize)).data.results
         )
         .with(
           'DATABASE',
-          async () => (await databaseDeploymentsApi.listDatabaseDeploymentHistoryV2(serviceId)).data.results
+          async () => (await databaseDeploymentsApi.listDatabaseDeploymentHistoryV2(serviceId, pageSize)).data.results
         )
         .with(
           'JOB',
           'CRON_JOB',
           'LIFECYCLE_JOB',
-          async () => (await jobDeploymentsApi.listJobDeploymentHistoryV2(serviceId)).data.results
+          async () => (await jobDeploymentsApi.listJobDeploymentHistoryV2(serviceId, pageSize)).data.results
         )
-        .with('HELM', async () => (await helmDeploymentsApi.listHelmDeploymentHistoryV2(serviceId)).data.results)
+        .with(
+          'HELM',
+          async () => (await helmDeploymentsApi.listHelmDeploymentHistoryV2(serviceId, pageSize)).data.results
+        )
         .with('TERRAFORM', async () => undefined) // TODO [QOV-821] to be implemented
         .exhaustive()
     },

--- a/libs/domains/services/feature/src/lib/hooks/use-deployment-history/use-deployment-history.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-deployment-history/use-deployment-history.ts
@@ -5,12 +5,13 @@ import { queries } from '@qovery/state/util-queries'
 export interface UseDeploymentHistoryProps {
   serviceId: string
   serviceType?: ServiceType
+  pageSize?: number
 }
 
-export function useDeploymentHistory({ serviceId, serviceType }: UseDeploymentHistoryProps) {
+export function useDeploymentHistory({ serviceId, serviceType, pageSize = 100 }: UseDeploymentHistoryProps) {
   return useQuery({
     // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
-    ...queries.services.deploymentHistory({ serviceId, serviceType: serviceType!! }),
+    ...queries.services.deploymentHistory({ serviceId, serviceType: serviceType!!, pageSize }),
     enabled: Boolean(serviceId) && Boolean(serviceType),
     refetchInterval: 5000,
     retryOnMount: true,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mermaid": "^11.6.0",
     "monaco-editor": "^0.44.0",
     "posthog-js": "^1.131.4",
-    "qovery-typescript-axios": "^1.1.644",
+    "qovery-typescript-axios": "^1.1.646",
     "react": "18.3.1",
     "react-country-flag": "^3.0.2",
     "react-datepicker": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,7 +4224,7 @@ __metadata:
     prettier: ^3.2.5
     prettier-plugin-tailwindcss: ^0.5.14
     pretty-quick: ^4.0.0
-    qovery-typescript-axios: ^1.1.644
+    qovery-typescript-axios: ^1.1.646
     qovery-ws-typescript-axios: ^0.1.334
     react: 18.3.1
     react-country-flag: ^3.0.2
@@ -21328,12 +21328,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:^1.1.644":
-  version: 1.1.644
-  resolution: "qovery-typescript-axios@npm:1.1.644"
+"qovery-typescript-axios@npm:^1.1.646":
+  version: 1.1.646
+  resolution: "qovery-typescript-axios@npm:1.1.646"
   dependencies:
     axios: 1.8.2
-  checksum: 7af73ad3eea60479d24e83bc68ce5752cf94c598fbe36bc096711bc2c31324c2ded42bfd44bd6e1f06bb73616fff2d0f074dae87e861266a5118c77ec10eb1ab
+  checksum: d477b8fdc536b083c770691058e036d31da0970bd1bfe9f1355b531d9de93d9e1f1cdd90af1fc37b618f7fafdaf064358844993c077d791c20181abb6a0e3ee9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Make the older env logs accessible

[QOV-937](https://qovery.atlassian.net/browse/QOV-937)


At the moment older env logs cannot be accessed. This PR fixes that.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I made sure the code is type safe (no any)
