### PR TITLE
Add read-only / read-write tooltip and fix chat switch issue

### DIFF
--- a/libs/shared/devops-copilot/data-access/src/lib/domains-devops-copilot-data-access.ts
+++ b/libs/shared/devops-copilot/data-access/src/lib/domains-devops-copilot-data-access.ts
@@ -26,6 +26,14 @@ export const devopsCopilot = createQueryKeys('devopsCopilot', {
       return response.data
     },
   }),
+  config: ({ organizationId }: { organizationId: string }) => ({
+    queryKey: [organizationId],
+    async queryFn() {
+      const response = await devopsCopilotAxios.get(`/organization/${organizationId}/config`)
+
+      return response.data
+    },
+  }),
 })
 
 export const mutations = {

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-history.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-history.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import React from 'react'
 import { Button, Icon, LoaderSpinner, Tooltip, truncateText } from '@qovery/shared/ui'
 import { type Thread } from '../hooks/use-threads/use-threads'
 import { isToday, isWithinLastSevenDays, isWithinLastThirtyDays, isYesterday } from '../utils/date-utils/date-utils'
@@ -125,4 +126,13 @@ export const DevopsCopilotHistory = ({
   )
 }
 
-export default DevopsCopilotHistory
+export default React.memo(DevopsCopilotHistory, (prev, next) => {
+  const propsChanged = {
+    threadIdChanged: prev.threadId !== next.threadId,
+    orgIdChanged: prev.organizationId !== next.organizationId,
+    threadsRefChanged: prev.data.threads !== next.data.threads,
+    isLoadingChanged: prev.data.isLoading !== next.data.isLoading,
+    errorChanged: prev.data.error !== next.data.error,
+  }
+  return !Object.values(propsChanged).some(Boolean)
+})

--- a/libs/shared/devops-copilot/feature/src/lib/hooks/use-config/use-config.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/hooks/use-config/use-config.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query'
+import { queries } from '@qovery/state/util-queries'
+
+export interface Config {
+  id: string
+  title: string
+  created_at: string
+  updated_at: string
+  organization_id: string
+}
+
+interface UseConfigReturn {
+  enabled: boolean
+  readOnly: boolean
+  instructions: string
+  isLoading: boolean
+  error: string | null
+  refetchConfig: () => Promise<void>
+}
+
+export const useConfig = ({ organizationId }: { organizationId: string }): UseConfigReturn => {
+  const { data, isLoading, error, refetch } = useQuery({
+    ...queries.devopsCopilot.config({ organizationId }),
+    enabled: !!organizationId,
+  })
+
+  return {
+    enabled: data?.org_config?.enabled ?? false,
+    readOnly: data?.org_config?.read_only ?? true,
+    instructions: data?.org_config?.instructions ?? '',
+    isLoading,
+    error: error instanceof Error ? error.message : null,
+    refetchConfig: async () => {
+      await refetch()
+    },
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,6 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@qovery/shared/devops-copilot/data-access": ["libs/shared/devops-copilot/data-access/src/index.ts"],
       "@qovery/domains/cloud-providers/data-access": ["libs/domains/cloud-providers/data-access/src/index.ts"],
       "@qovery/domains/cloud-providers/feature": ["libs/domains/cloud-providers/feature/src/index.ts"],
       "@qovery/domains/cluster-metrics/feature": ["libs/domains/cluster-metrics/feature/src/index.ts"],
@@ -60,6 +59,7 @@
       "@qovery/shared/assistant/feature": ["libs/shared/assistant/feature/src/index.ts"],
       "@qovery/shared/auth": ["libs/shared/auth/src/index.ts"],
       "@qovery/shared/console-shared": ["libs/shared/console-shared/src/index.ts"],
+      "@qovery/shared/devops-copilot/data-access": ["libs/shared/devops-copilot/data-access/src/index.ts"],
       "@qovery/shared/devops-copilot/feature": ["libs/shared/devops-copilot/feature/src/index.ts"],
       "@qovery/shared/enums": ["libs/shared/enums/src/index.ts"],
       "@qovery/shared/factories": ["libs/shared/factories/src/index.ts"],


### PR DESCRIPTION
# What does this PR do?

This PR adds tooltip and UI fixes to improve clarity and user experience.
- Added a tooltip to display the copilot status (read-only or read-write)
- Fixed the UI issue where the text generation indicator remained visible when switching chats

> Screenshot of the feature

<img width="524" height="740" alt="image" src="https://github.com/user-attachments/assets/63f8841b-78b9-4b64-b8aa-31039a9f4b38" />

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
