### PR TITLE
fix(services): ghost 443 external port when adding gRPC port

### DIFF
--- a/libs/shared/console-shared/src/lib/flow-create-port/ui/crud-modal/crud-modal.tsx
+++ b/libs/shared/console-shared/src/lib/flow-create-port/ui/crud-modal/crud-modal.tsx
@@ -51,10 +51,7 @@ export function CrudModal({
           protocol === PortProtocolEnum.TCP || protocol === PortProtocolEnum.UDP ? internal_port : 443
         )
       } else {
-        setValue(
-          'external_port',
-          protocol === PortProtocolEnum.TCP || protocol === PortProtocolEnum.UDP ? undefined : 443
-        )
+        setValue('external_port', undefined)
       }
     }
 


### PR DESCRIPTION
# What does this PR do?

Fixes both [QOV-988](https://qovery.atlassian.net/browse/QOV-988) and [QOV-989](https://qovery.atlassian.net/browse/QOV-989).

Creating a service with a gRPC port was failing because a ghost 443 port was injected even though the port was not supposed to be publicly accessible.

### Before 
https://github.com/user-attachments/assets/22391835-83a8-4012-b28f-206be03a5ae2

### After
https://github.com/user-attachments/assets/27108cae-a411-4078-a20a-c1581660190b

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-988]: https://qovery.atlassian.net/browse/QOV-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QOV-989]: https://qovery.atlassian.net/browse/QOV-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ