### PR TITLE
impr: wording of the container registry form for GitHub

### DIFF
--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -295,7 +295,16 @@ export function ContainerRegistryForm({
                     name={field.name}
                     onChange={field.onChange}
                     value={field.value}
-                    label="Username"
+                    label={match(watchKind)
+                      .with(ContainerRegistryKindEnum.GITHUB_CR, () => 'Container registry prefix')
+                      .otherwise(() => 'Username')}
+                    hint={match(watchKind)
+                      .with(
+                        ContainerRegistryKindEnum.GITHUB_CR,
+                        () =>
+                          'The prefix is the part of the URL before the repository name. For example, in ghcr.io/qovery/my-app, the prefix is qovery'
+                      )
+                      .otherwise(() => undefined)}
                     error={error?.message}
                   />
                 )}


### PR DESCRIPTION
# What does this PR do?

[QOV-985](https://qovery.atlassian.net/browse/QOV-985)

This PR simply improves the wording for the `username` field of container registry form for Github.

<img width="769" height="812" alt="Screenshot 2025-07-17 at 14 43 58" src="https://github.com/user-attachments/assets/2838d601-7c19-4f64-8da3-9d40bfe17101" />

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-985]: https://qovery.atlassian.net/browse/QOV-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ