### PR TITLE
feat(devops-copilot): add handling and display for the replanning

### DIFF
--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-panel.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-panel.tsx
@@ -334,8 +334,7 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
                 } else if (parsed.content.includes('__step__:')) {
                   const stepDescription = parsed.content.replace('__step__:', '').replaceAll('_', ' ')
                   setLoadingText(stepDescription.charAt(0).toUpperCase() + stepDescription.slice(1))
-                }
-                else if (parsed.content.includes('__stepPlan__:generating_a_new_plan')) {
+                } else if (parsed.content.includes('__stepPlan__:generating_a_new_plan')) {
                   setPlan([])
                   setLoadingText('Generating a new plan...')
                 } else if (parsed.content.includes('__stepPlan__:')) {

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-panel.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-panel.tsx
@@ -320,21 +320,24 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
                 if (parsed.content.includes('__plan__:')) {
                   try {
                     const planArray = JSON.parse(parsed.content.replace('__plan__:', ''))
-                    setPlan((prev) => [
-                      ...prev,
-                      ...planArray.map((step: { description: string; tool_name: string }) => ({
+                    setPlan(
+                      planArray.map((step: { description: string; tool_name: string }) => ({
                         messageId: 'temp',
                         description: step.description,
                         toolName: step.tool_name,
                         status: 'not_started',
-                      })),
-                    ])
+                      }))
+                    )
                   } catch (e) {
                     console.error(e)
                   }
                 } else if (parsed.content.includes('__step__:')) {
                   const stepDescription = parsed.content.replace('__step__:', '').replaceAll('_', ' ')
                   setLoadingText(stepDescription.charAt(0).toUpperCase() + stepDescription.slice(1))
+                }
+                else if (parsed.content.includes('__stepPlan__:generating_a_new_plan')) {
+                  setPlan([])
+                  setLoadingText('Generating a new plan...')
                 } else if (parsed.content.includes('__stepPlan__:')) {
                   try {
                     const stepObj = JSON.parse(parsed.content.replace('__stepPlan__:', ''))


### PR DESCRIPTION
# What does this PR do?
- Detection of a replanning
- Display of a message for the user
- Replacement of the plan

> Link to the JIRA ticket

> Screenshot of the feature

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
