### PR TITLE
fix: remove deploy-qovery pipeline step

### DIFF
--- a/.github/workflows/test-build-and-deploy.yml
+++ b/.github/workflows/test-build-and-deploy.yml
@@ -159,22 +159,3 @@ jobs:
       - name: Copy index.html to S3 last
         run: |
           AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/index.html s3://${{ secrets.s3-bucket-name }}/
-
-  deploy-qovery:
-    name: Deploy to Qovery
-    runs-on: ubuntu-latest
-    needs: [nx-main]
-    if: ${{ inputs.flow != 'pull-request' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Deploy on Qovery
-        uses: Qovery/qovery-action@v0.14.7
-        id: qovery
-        with:
-          qovery-organization-id: ${{ secrets.organization-id }}
-          qovery-project-name: ${{ inputs.project-name }}
-          qovery-environment-name: ${{ inputs.environment-name }}
-          qovery-application-names: ${{ inputs.application-names }}
-          qovery-application-commit-id: ${{ inputs.application-commit-id }}
-          qovery-api-token: ${{ secrets.api-token }}


### PR DESCRIPTION
# What does this PR do?

[QOV-1069](https://qovery.atlassian.net/browse/QOV-1069)

This PR removes the outdated `deploy-qovery` pipeline step

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1069]: https://qovery.atlassian.net/browse/QOV-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ