### PR TITLE
fix: redirection to latest logs when clicking on "Deploy now"

### DIFF
--- a/libs/domains/services/feature/src/lib/need-redeploy-flag/need-redeploy-flag.tsx
+++ b/libs/domains/services/feature/src/lib/need-redeploy-flag/need-redeploy-flag.tsx
@@ -36,7 +36,7 @@ export function NeedRedeployFlag() {
       deployService({ serviceId: service.id, serviceType: service.serviceType })
       navigate(
         ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-          DEPLOYMENT_LOGS_VERSION_URL(service.id, serviceDeploymentStatus?.execution_id)
+          DEPLOYMENT_LOGS_VERSION_URL(service.id, 'latest')
       )
     }
   }

--- a/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
+++ b/libs/pages/logs/environment/src/lib/page-environment-logs.tsx
@@ -4,8 +4,8 @@ import {
   type EnvironmentStatus,
   type EnvironmentStatusesWithStagesPreCheckStage,
 } from 'qovery-typescript-axios'
-import { useCallback, useState } from 'react'
-import { Navigate, Route, Routes, matchPath, useLocation, useParams } from 'react-router-dom'
+import { useCallback, useEffect, useState } from 'react'
+import { Navigate, Route, Routes, matchPath, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useDeploymentHistory, useEnvironment } from '@qovery/domains/environments/feature'
 import { ServiceStageIdsProvider } from '@qovery/domains/service-logs/feature'
 import {
@@ -25,8 +25,10 @@ import PodLogsFeature from './feature/pod-logs-feature/pod-logs-feature'
 import PreCheckLogsFeature from './feature/pre-check-logs-feature/pre-check-logs-feature'
 
 export function PageEnvironmentLogs() {
-  const { organizationId = '', projectId = '', environmentId = '' } = useParams()
+  const { organizationId = '', projectId = '', environmentId = '', '*': rest } = useParams()
+  const stageId = rest?.split('/')[0]
   const location = useLocation()
+  const navigate = useNavigate()
   const { data: environment } = useEnvironment({ environmentId })
   const { data: environmentDeploymentHistory = [], isFetched: isFetchedDeploymentHistory } = useDeploymentHistory({
     environmentId,
@@ -63,6 +65,34 @@ export function PageEnvironmentLogs() {
 
   const versionIdUrl = deploymentVersionId || preCheckVersionId || stageVersionId
   const isLatestVersion = environmentDeploymentHistory[0]?.identifier.execution_id === versionIdUrl
+
+  // If the URL contains `/latest` and the deployment is deploying, redirect to the logs page with the correct execution ID
+  useEffect(() => {
+    const latestDeployment = environmentDeploymentHistory[0]
+
+    if (
+      deploymentVersionId === 'latest' &&
+      isFetchedDeploymentHistory &&
+      latestDeployment?.status === 'DEPLOYING' &&
+      latestDeployment.identifier.execution_id &&
+      stageId
+    ) {
+      navigate(
+        ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
+          DEPLOYMENT_LOGS_VERSION_URL(stageId, latestDeployment.identifier.execution_id),
+        { replace: true }
+      )
+    }
+  }, [
+    deploymentVersionId,
+    navigate,
+    stageId,
+    environmentDeploymentHistory,
+    organizationId,
+    projectId,
+    environmentId,
+    isFetchedDeploymentHistory,
+  ])
 
   const messageHandler = useCallback(
     (
@@ -106,26 +136,36 @@ export function PageEnvironmentLogs() {
     return (
       <div className="h-[calc(100vh-64px)] w-full p-1">
         <div className="flex h-full w-full items-center justify-center border border-neutral-500 bg-neutral-600">
-          <div className="flex flex-col items-center justify-center gap-4 text-center">
-            <svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" fill="none" viewBox="0 0 44 44">
-              <g clipPath="url(#clip0_19290_138219)">
-                <path fill="#2A3041" d="M22 44c12.15 0 22-9.85 22-22S34.15 0 22 0 0 9.85 0 22s9.85 22 22 22"></path>
-                <path
-                  fill="#A0AFC5"
-                  d="M30.683 15.933a.45.45 0 0 0 0-.633L28.2 12.817a.45.45 0 0 0-.633 0l-1.246 1.246-4.004 4.004a.45.45 0 0 1-.634 0l-4.004-4.004-1.246-1.246a.45.45 0 0 0-.633 0L13.317 15.3a.45.45 0 0 0 0 .633l1.246 1.246 4.004 4.004a.45.45 0 0 1 0 .634l-4.004 4.004-1.246 1.246a.45.45 0 0 0 0 .633l2.483 2.483a.45.45 0 0 0 .633 0l1.246-1.246 4.004-4.004a.45.45 0 0 1 .634 0l4.004 4.004 1.246 1.246a.45.45 0 0 0 .633 0l2.483-2.483a.45.45 0 0 0 0-.633l-1.246-1.246-4.004-4.004a.45.45 0 0 1 0-.634l4.004-4.004z"
-                ></path>
-              </g>
-              <defs>
-                <clipPath id="clip0_19290_138219">
-                  <path fill="#fff" d="M0 0h44v44H0z"></path>
-                </clipPath>
-              </defs>
-            </svg>
-            <div className="flex flex-col gap-3">
-              <p className="text-neutral-300">Deployment logs are no longer available due to the deployment's age.</p>
-              <span className="text-sm text-neutral-350">No logs to display.</span>
+          {deploymentVersionId === 'latest' ? (
+            <div className="flex flex-col items-center justify-center gap-4 text-center">
+              <LoaderDots />
+              <div className="flex flex-col gap-3">
+                <p className="text-neutral-300">Please wait while we deploy your application.</p>
+                <span className="text-sm text-neutral-350">You will be redirected to the logs shortly.</span>
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center gap-4 text-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" fill="none" viewBox="0 0 44 44">
+                <g clipPath="url(#clip0_19290_138219)">
+                  <path fill="#2A3041" d="M22 44c12.15 0 22-9.85 22-22S34.15 0 22 0 0 9.85 0 22s9.85 22 22 22"></path>
+                  <path
+                    fill="#A0AFC5"
+                    d="M30.683 15.933a.45.45 0 0 0 0-.633L28.2 12.817a.45.45 0 0 0-.633 0l-1.246 1.246-4.004 4.004a.45.45 0 0 1-.634 0l-4.004-4.004-1.246-1.246a.45.45 0 0 0-.633 0L13.317 15.3a.45.45 0 0 0 0 .633l1.246 1.246 4.004 4.004a.45.45 0 0 1 0 .634l-4.004 4.004-1.246 1.246a.45.45 0 0 0 0 .633l2.483 2.483a.45.45 0 0 0 .633 0l1.246-1.246 4.004-4.004a.45.45 0 0 1 .634 0l4.004 4.004 1.246 1.246a.45.45 0 0 0 .633 0l2.483-2.483a.45.45 0 0 0 0-.633l-1.246-1.246-4.004-4.004a.45.45 0 0 1 0-.634l4.004-4.004z"
+                  ></path>
+                </g>
+                <defs>
+                  <clipPath id="clip0_19290_138219">
+                    <path fill="#fff" d="M0 0h44v44H0z"></path>
+                  </clipPath>
+                </defs>
+              </svg>
+              <div className="flex flex-col gap-3">
+                <p className="text-neutral-300">Deployment logs are no longer available due to the deployment's age.</p>
+                <span className="text-sm text-neutral-350">No logs to display.</span>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
# What does this PR do?

[QOV-1090](https://qovery.atlassian.net/browse/QOV-1090)

This PR fixes an issue where the "Deploy now" button was redirecting to the previous deployment and not the ongoing one.
Seeing as it not possible from the back-end to be aware of the `execution_id` when the deployment is triggered, this PR implements a workaround on the front-end side, where the clicking on "Deploy now" will not redirect to a specific `execution_id` but to `/latest` instead. The component will wait for the data of the ongoing deployment to be received to then redirect to its logs.

## Before
https://github.com/user-attachments/assets/3ac40221-8989-47fe-ba3b-b1f0c1566a5f

## After
https://github.com/user-attachments/assets/7133f76a-199f-4246-8b9d-c5f048c9d231


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1090]: https://qovery.atlassian.net/browse/QOV-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ