### PR TITLE
feat(service-monitoring): dropdown timerange tracking

### DIFF
--- a/libs/domains/observability/feature/src/lib/service-overview/card-http-errors/card-http-errors.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service-overview/card-http-errors/card-http-errors.spec.tsx
@@ -170,7 +170,6 @@ describe('CardHTTPErrors', () => {
       clusterId: 'test-cluster-id',
       query: expect.stringContaining('nginx_ingress_controller_requests{status=~"499|5.."}'),
       queryRange: 'query',
-      timeRange: '1h',
     })
 
     const calledQuery = mockUseMetrics.mock.calls[0][0].query

--- a/libs/domains/observability/feature/src/lib/service-overview/card-instance-status/card-instance-status.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service-overview/card-instance-status/card-instance-status.spec.tsx
@@ -177,7 +177,6 @@ describe('CardInstanceStatus', () => {
       clusterId: 'test-cluster-id',
       query: expect.stringContaining('kube_pod_container_status_restarts_total'),
       queryRange: 'query',
-      timeRange: '1h',
     })
 
     const call = useMetrics.mock.calls[0][0].query

--- a/libs/domains/observability/feature/src/lib/service-overview/card-log-errors/card-log-errors.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service-overview/card-log-errors/card-log-errors.spec.tsx
@@ -161,7 +161,6 @@ describe('CardLogErrors', () => {
       clusterId: 'test-cluster-id',
       query: 'sum (increase(promtail_custom_q_log_errors_total{qovery_com_service_id=~"test-service-id"}[1h]))',
       queryRange: 'query',
-      timeRange: '1h',
     })
   })
 })

--- a/libs/domains/observability/feature/src/lib/service-overview/card-percentile-99/card-percentile-99.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service-overview/card-percentile-99/card-percentile-99.spec.tsx
@@ -147,7 +147,6 @@ describe('CardPercentile99', () => {
       clusterId: 'test-cluster-id',
       query: expect.stringContaining('histogram_quantile'),
       queryRange: 'query',
-      timeRange: '1h',
     })
 
     const call = useMetrics.mock.calls[0][0].query

--- a/libs/domains/observability/feature/src/lib/service-overview/card-storage/card-storage.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service-overview/card-storage/card-storage.spec.tsx
@@ -167,7 +167,6 @@ describe('CardStorage', () => {
       clusterId: 'test-cluster-id',
       query: expect.stringContaining('kubelet_volume_stats_used_bytes'),
       queryRange: 'query',
-      timeRange: '1h',
     })
 
     const call = useMetrics.mock.calls[0][0].query

--- a/libs/domains/observability/feature/src/lib/service-overview/service-overview.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service-overview/service-overview.spec.tsx
@@ -66,7 +66,7 @@ describe('Zoom and DatePicker Integration', () => {
 
     // Switch back to preset time range
     act(() => {
-      result.current.handleTimeRangeChange('30m')
+      result.current.handleTimeRangeChange('1h')
     })
 
     // Should reset zoom again but not clear calendar value

--- a/libs/domains/observability/feature/src/lib/service-overview/util-filter/service-overview-context.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service-overview/util-filter/service-overview-context.spec.tsx
@@ -137,7 +137,7 @@ describe('ServiceOverviewContext queryTimeRange', () => {
       wrapper: ServiceOverviewProvider,
     })
 
-    expect(result.current.queryTimeRange).toBe('30m') // default timeRange
+    expect(result.current.queryTimeRange).toBe('1h') // default timeRange
     expect(result.current.isAnyChartZoomed).toBe(false)
   })
 
@@ -169,7 +169,7 @@ describe('ServiceOverviewContext queryTimeRange', () => {
     })
 
     expect(result.current.queryTimeRange).toBe('5m') // 5 minutes calculated from timestamps
-    expect(result.current.timeRange).toBe('30m') // Original timeRange unchanged
+    expect(result.current.timeRange).toBe('1h') // Original timeRange unchanged
     expect(result.current.isAnyChartZoomed).toBe(true)
   })
 
@@ -256,7 +256,7 @@ describe('ServiceOverviewContext queryTimeRange', () => {
       result.current.setIsAnyChartZoomed(true) // Zoomed but no timestamps set
     })
 
-    expect(result.current.queryTimeRange).toBe('30m') // Falls back to original timeRange
+    expect(result.current.queryTimeRange).toBe('60m') // Calculates from default timestamps (1h = 60m)
   })
 })
 


### PR DESCRIPTION
# What does this PR do?

Adds dropdown timerange tracking and updates default timerange.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I made sure the code is type safe (no any)
