### PR TITLE
impr(chart-zoom): global time range reset on double click

### DIFF
--- a/libs/domains/observability/feature/src/lib/service-overview/local-chart/local-chart.tsx
+++ b/libs/domains/observability/feature/src/lib/service-overview/local-chart/local-chart.tsx
@@ -114,6 +114,9 @@ export const ChartContent = memo(function ChartContent({
     handleZoomTimeRangeChange,
     registerZoomReset,
     setIsAnyChartZoomed,
+    setHasCalendarValue,
+    handleTimeRangeChange,
+    lastDropdownTimeRange,
   } = useServiceOverviewContext()
   const [onHoverHideTooltip, setOnHoverHideTooltip] = useState(false)
 
@@ -132,6 +135,10 @@ export const ChartContent = memo(function ChartContent({
     onZoomChange: handleZoomTimeRangeChange,
     onResetRegister: registerZoomReset,
     onZoomStateChange: setIsAnyChartZoomed,
+    onDoubleClick: () => {
+      setHasCalendarValue(false)
+      handleTimeRangeChange(lastDropdownTimeRange)
+    },
   })
 
   function getXDomain(): [number | string, number | string] {

--- a/libs/shared/ui/src/lib/components/chart/use-zoomable-chart.spec.ts
+++ b/libs/shared/ui/src/lib/components/chart/use-zoomable-chart.spec.ts
@@ -248,6 +248,36 @@ describe('useZoomableChart', () => {
       expect(result.current.zoomHistory).toHaveLength(0)
       expect(result.current.isZoomed).toBe(false)
     })
+
+    it('handles double-click with custom onDoubleClick handler', () => {
+      const mockOnDoubleClick = jest.fn()
+      const { result } = renderHook(() => useZoomableChart({ onDoubleClick: mockOnDoubleClick }))
+
+      // Zoom in first
+      act(() => {
+        result.current.handleMouseDown({ activeLabel: '100' })
+      })
+
+      act(() => {
+        result.current.handleMouseMove({ activeLabel: '200' })
+      })
+
+      act(() => {
+        result.current.handleMouseUp()
+      })
+
+      expect(result.current.isZoomed).toBe(true)
+
+      act(() => {
+        result.current.handleChartDoubleClick()
+      })
+
+      // Custom handler should be called instead of default reset
+      expect(mockOnDoubleClick).toHaveBeenCalledTimes(1)
+      // Zoom state should remain unchanged since custom handler was called
+      expect(result.current.isZoomed).toBe(true)
+      expect(result.current.zoomHistory).toHaveLength(1)
+    })
   })
 
   describe('utilities', () => {

--- a/libs/shared/ui/src/lib/components/chart/use-zoomable-chart.ts
+++ b/libs/shared/ui/src/lib/components/chart/use-zoomable-chart.ts
@@ -20,6 +20,7 @@ interface UseZoomableChartProps {
   onZoomChange?: (startTime: number, endTime: number) => void
   onResetRegister?: (resetFn: () => void) => (() => void) | void
   onZoomStateChange?: (isZoomed: boolean) => void
+  onDoubleClick?: () => void
 }
 
 interface UseZoomableChartReturn {
@@ -48,7 +49,7 @@ interface UseZoomableChartReturn {
 }
 
 export function useZoomableChart(props: UseZoomableChartProps = {}): UseZoomableChartReturn {
-  const { onZoomChange, onResetRegister, onZoomStateChange } = props
+  const { onZoomChange, onResetRegister, onZoomStateChange, onDoubleClick } = props
   // Zoom state
   const [zoomState, setZoomState] = useState<ZoomState>({
     left: 'dataMin',
@@ -190,8 +191,12 @@ export function useZoomableChart(props: UseZoomableChartProps = {}): UseZoomable
   }
 
   const handleChartDoubleClick = () => {
-    // Double click: reset zoom completely
-    resetZoom()
+    // Double click: call custom handler if provided, otherwise reset zoom
+    if (onDoubleClick) {
+      onDoubleClick()
+    } else {
+      resetZoom()
+    }
   }
 
   const handleMouseDown = (e?: ChartMouseEvent) => {


### PR DESCRIPTION
# What does this PR do?

Add the ability for the zoom hook to accept a dbl click callback + reset time range globally to fix erratic time range drifts

> Link to the JIRA ticket

Put description here

> Screenshot of the feature

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I made sure the code is type safe (no any)
