### PR TITLE
fix(service-monitoring): add default retry params to 3 for use-metrics

### DIFF
--- a/libs/domains/observability/feature/src/lib/hooks/use-metrics/use-metrics.ts
+++ b/libs/domains/observability/feature/src/lib/hooks/use-metrics/use-metrics.ts
@@ -97,6 +97,7 @@ export function useMetrics({
     keepPreviousData: true,
     refetchInterval: finalLiveUpdateEnabled ? 15_000 : false, // Refetch every 15 seconds only if live update is enabled
     refetchIntervalInBackground: finalLiveUpdateEnabled,
+    retry: 3,
   })
 
   // Custom isLoading: true on first load and when timeRange changes, false on live refetch


### PR DESCRIPTION
# What does this PR do?

Added a `retry: 3` option to the `useQuery` call in `use-metrics.ts`, enabling up to three automatic retries on failed requests.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
