### PR TITLE
fix: Enable Karpenter by default on prod cluster + enable continue bu…

### DIFF
--- a/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/page-clusters-create-feature.tsx
+++ b/libs/pages/clusters/src/lib/feature/page-clusters-create-feature/page-clusters-create-feature.tsx
@@ -77,7 +77,7 @@ export const steps = (clusterGeneralData?: ClusterGeneralData) => {
 }
 
 export const defaultResourcesData: ClusterResourcesData = {
-  cluster_type: '',
+  cluster_type: 'MANAGED',
   disk_size: 50,
   instance_type: '',
   nodes: [3, 10],

--- a/libs/shared/console-shared/src/lib/cluster-settings/ui/cluster-resources-settings/cluster-resources-settings.tsx
+++ b/libs/shared/console-shared/src/lib/cluster-settings/ui/cluster-resources-settings/cluster-resources-settings.tsx
@@ -127,6 +127,22 @@ export function ClusterResourcesSettings(props: ClusterResourcesSettingsProps) {
   const hasExistingVPC = Boolean(props.cluster?.features?.find((f) => f.id === 'EXISTING_VPC')?.value_object?.value)
   const hasStaticIP = props.cluster?.features?.find((f) => f.id === 'STATIC_IP')?.value_object?.value
 
+  useEffect(() => {
+    if (!props.fromDetail && props.isProduction && props.cloudProvider === 'AWS') {
+      setValue('karpenter', {
+        enabled: true,
+        spot_enabled: false,
+        disk_size_in_gib: 50,
+        default_service_architecture: 'AMD64',
+        qovery_node_pools: {
+          requirements: cloudProviderInstanceTypesKarpenter
+            ? convertToKarpenterRequirements(cloudProviderInstanceTypesKarpenter)
+            : [],
+        },
+      })
+    }
+  }, [props.fromDetail, props.isProduction, props.cloudProvider, cloudProviderInstanceTypesKarpenter, setValue])
+
   return (
     <div className="flex flex-col gap-10">
       {props.cloudProvider === 'AWS' && watchClusterType === KubernetesEnum.MANAGED && (


### PR DESCRIPTION
# What does this PR do?

[> Link to the JIRA ticket](https://qovery.atlassian.net/browse/QOV-1087)

* Enable Karpenter by default on new prod cluster
* Fix Continue button to be enables directly when Karpenter is enabled

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
