### PR TITLE
feat(services): add support for "executing" status

### DIFF
--- a/libs/shared/ui/src/lib/components/status-chip/status-chip.tsx
+++ b/libs/shared/ui/src/lib/components/status-chip/status-chip.tsx
@@ -82,7 +82,7 @@ export function StatusChip({
       'WAITING_STOPPING',
       () => <QueuedIcon />
     )
-    .with('DEPLOYING', 'STARTING', 'ONGOING', 'DRY_RUN', () => <DeployingIcon />)
+    .with('DEPLOYING', 'STARTING', 'ONGOING', 'DRY_RUN', 'EXECUTING', () => <DeployingIcon />)
     .with('RESTARTING', () => <RestartingIcon />)
     .with('BUILDING', () => <BuildingIcon />)
     .with('STOPPING', () => <StoppingIcon />)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mermaid": "^11.6.0",
     "monaco-editor": "^0.44.0",
     "posthog-js": "^1.260.1",
-    "qovery-typescript-axios": "^1.1.672",
+    "qovery-typescript-axios": "^1.1.674",
     "react": "18.3.1",
     "react-country-flag": "^3.0.2",
     "react-datepicker": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,7 +4224,7 @@ __metadata:
     prettier: ^3.2.5
     prettier-plugin-tailwindcss: ^0.5.14
     pretty-quick: ^4.0.0
-    qovery-typescript-axios: ^1.1.672
+    qovery-typescript-axios: ^1.1.674
     qovery-ws-typescript-axios: ^0.1.334
     react: 18.3.1
     react-country-flag: ^3.0.2
@@ -21449,12 +21449,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:^1.1.672":
-  version: 1.1.672
-  resolution: "qovery-typescript-axios@npm:1.1.672"
+"qovery-typescript-axios@npm:^1.1.674":
+  version: 1.1.674
+  resolution: "qovery-typescript-axios@npm:1.1.674"
   dependencies:
     axios: 1.8.2
-  checksum: 5c7bfa4976924a6c0e92a3ed485b4f9b939ff915f8cf3188323e0aa8e20ed9689fe5a21c80dc0cf7b3a63e7b1956929fb4c33abe1c1d74b0af055875ed2d8e10
+  checksum: c7f5dde563f25f4cd05e1b9b4a34ac7cfdc250999da1cfa0cf87d1895d7e73da0819573a0f49951e67252f30edcee83ccefa3d7ea78ea10c493abc498c8dcfe8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What does this PR do?

[QOV-887](https://qovery.atlassian.net/browse/QOV-887)

This PR adds support for the new "executing" status

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-887]: https://qovery.atlassian.net/browse/QOV-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ