### PR TITLE
impr(db): update default storage value for GP3

### DIFF
--- a/libs/pages/services/src/lib/feature/page-database-create-feature/page-database-create-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-database-create-feature/page-database-create-feature.tsx
@@ -49,7 +49,7 @@ export function PageDatabaseCreateFeature() {
   const [resourcesData, setResourcesData] = useState<ResourcesData | undefined>({
     memory: 512,
     cpu: 500,
-    storage: 10,
+    storage: 20,
   })
 
   const navigate = useNavigate()

--- a/libs/pages/services/src/lib/feature/page-database-create-feature/step-resources-feature/step-resources-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-database-create-feature/step-resources-feature/step-resources-feature.spec.tsx
@@ -41,7 +41,7 @@ const ContextWrapper = (props: { children: ReactNode }) => {
         },
         setGeneralData: jest.fn(),
         resourcesData: {
-          storage: 1,
+          storage: 20,
           cpu: [100],
           memory: 100,
         },
@@ -75,7 +75,7 @@ describe('PageDatabaseCreateResourcesFeature', () => {
     await userEvent.click(button)
 
     expect(mockSetResourcesData).toHaveBeenCalledWith({
-      storage: 1,
+      storage: 20,
       cpu: [100],
       memory: 100,
     })

--- a/libs/shared/console-shared/src/lib/database-settings-resources/ui/database-settings-resources/database-settings-resources.tsx
+++ b/libs/shared/console-shared/src/lib/database-settings-resources/ui/database-settings-resources/database-settings-resources.tsx
@@ -27,7 +27,10 @@ export function DatabaseSettingsResources({
   displayStorageWarning = false,
   isSetting = false,
 }: DatabaseSettingsResourcesProps) {
-  const { control } = useFormContext()
+  const {
+    control,
+    formState: { defaultValues },
+  } = useFormContext()
   const { organizationId = '', environmentId } = useParams()
   const { data: environment } = useEnvironment({ environmentId })
 
@@ -45,6 +48,9 @@ export function DatabaseSettingsResources({
   const minMemory = match(cloudProvider)
     .with('GCP', () => 512)
     .otherwise(() => 1)
+
+  // For GP3 DBs, the minimum storage is 20 GiB, whereas for GP2 it's 10 GiB.
+  const minStorageValue = defaultValues?.['storage'] !== 10 ? 20 : 10
 
   return (
     <>
@@ -153,6 +159,10 @@ export function DatabaseSettingsResources({
           pattern: {
             value: /^[0-9]+$/,
             message: 'Please enter a number.',
+          },
+          min: {
+            value: minStorageValue,
+            message: `Storage must be at least ${minStorageValue} GiB.`,
           },
         }}
         render={({ field, fieldState: { error } }) => (


### PR DESCRIPTION
# What does this PR do?

[QOV-1133](https://qovery.atlassian.net/browse/QOV-1133)

This PR updates:
- the DB creation flow (default storage value is now `20`)
- the form validation of the "storage" section of the settings (validation will depend on the existing value)


https://github.com/user-attachments/assets/570817c7-4aa9-4f11-a111-3ed2a988d298


https://github.com/user-attachments/assets/b8187695-a00a-4091-a2bf-149cb3c33625


---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1133]: https://qovery.atlassian.net/browse/QOV-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ