### PR TITLE
fix(terraform): bulk delete/uninstall/stop of services

### DIFF
--- a/libs/domains/services/feature/src/lib/service-list/service-list-action-bar.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-action-bar.tsx
@@ -203,6 +203,9 @@ export function ServiceListActionBar({ environment, selectedRows, resetRowSelect
                     .map(({ id }) => id),
                   helm_ids: stoppableServices.filter(({ serviceType }) => serviceType === 'HELM').map(({ id }) => id),
                   job_ids: stoppableServices.filter(({ serviceType }) => serviceType === 'JOB').map(({ id }) => id),
+                  terraform_ids: stoppableServices
+                    .filter(({ serviceType }) => serviceType === 'TERRAFORM')
+                    .map(({ id }) => id),
                 },
               })
               resetRowSelection()
@@ -272,6 +275,9 @@ export function ServiceListActionBar({ environment, selectedRows, resetRowSelect
                     .filter(({ serviceType }) => serviceType === 'HELM')
                     .map(({ id }) => id),
                   job_ids: uninstallableServices.filter(({ serviceType }) => serviceType === 'JOB').map(({ id }) => id),
+                  terraform_ids: uninstallableServices
+                    .filter(({ serviceType }) => serviceType === 'TERRAFORM')
+                    .map(({ id }) => id),
                 },
               })
               resetRowSelection()
@@ -321,6 +327,9 @@ export function ServiceListActionBar({ environment, selectedRows, resetRowSelect
                     .map(({ id }) => id),
                   helm_ids: deletableServices.filter(({ serviceType }) => serviceType === 'HELM').map(({ id }) => id),
                   job_ids: deletableServices.filter(({ serviceType }) => serviceType === 'JOB').map(({ id }) => id),
+                  terraform_ids: deletableServices
+                    .filter(({ serviceType }) => serviceType === 'TERRAFORM')
+                    .map(({ id }) => id),
                 },
               })
               resetRowSelection()


### PR DESCRIPTION
# What does this PR do?

[QOV-1145](https://qovery.atlassian.net/browse/QOV-1145)

This PR adds support for bulk delete/uninstall/stop of Terraform services.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1145]: https://qovery.atlassian.net/browse/QOV-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ