### PR TITLE
fix(terraform): hide "run plan" action when it cannot be performed

### DIFF
--- a/libs/domains/services/feature/src/lib/service-action-toolbar/service-action-toolbar.tsx
+++ b/libs/domains/services/feature/src/lib/service-action-toolbar/service-action-toolbar.tsx
@@ -355,7 +355,7 @@ function MenuManageDeployment({
             {state === StateEnum.DELETE_QUEUED || state === StateEnum.DELETING ? 'Cancel delete' : 'Cancel deployment'}
           </DropdownMenu.Item>
         )}
-        {isDryRunAvailable(service.serviceType) && (
+        {isDryRunAvailable(service.serviceType, state) && (
           <DropdownMenu.Item icon={<Icon iconName="play" iconStyle="regular" />} onSelect={mutationDryRun}>
             Run plan
           </DropdownMenu.Item>

--- a/libs/shared/util-js/src/lib/status-actions-available.ts
+++ b/libs/shared/util-js/src/lib/status-actions-available.ts
@@ -115,8 +115,11 @@ export const isCancelBuildAvailable = (status: keyof typeof StateEnum | keyof ty
     .otherwise(() => false)
 }
 
-export const isDryRunAvailable = (serviceType: ServiceType): boolean => {
+export const isDryRunAvailable = (
+  serviceType: ServiceType,
+  status: keyof typeof StateEnum | keyof typeof ClusterStateEnum
+): boolean => {
   return match(serviceType)
-    .with('TERRAFORM', () => true)
+    .with('TERRAFORM', () => !isCancelBuildAvailable(status))
     .otherwise(() => false)
 }


### PR DESCRIPTION
# What does this PR do?

[QOV-1146](https://qovery.atlassian.net/browse/QOV-1146)

This PR fixes an issue where the "run plan" action was present even though it shouldn't be (for instance when a service is already deploying)

### Before

https://github.com/user-attachments/assets/1585c624-78db-49ac-b7b6-ebf32102a624

### After

https://github.com/user-attachments/assets/b4381aaf-9fa8-44e7-b92d-8b8056f280a4

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1146]: https://qovery.atlassian.net/browse/QOV-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ