### PR TITLE
Fix dark mode input text styling

### DIFF
--- a/libs/shared/ui/src/lib/components/inputs/input-text-small/input-text-small.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-text-small/input-text-small.tsx
@@ -80,7 +80,7 @@ export const InputTextSmall = forwardRef<HTMLInputElement, InputTextSmallProps>(
         <input
           className={twMerge(
             clsx(
-              'absolute left-0 top-0 h-full w-full rounded px-2 text-sm text-neutral-400 placeholder:text-neutral-350',
+              'absolute left-0 top-0 h-full w-full rounded px-2 text-sm text-neutral-400 placeholder:text-neutral-350 dark:bg-transparent dark:text-neutral-50 dark:placeholder:text-neutral-350',
               {
                 'pr-8': hasShowPasswordButton,
               }
@@ -103,7 +103,7 @@ export const InputTextSmall = forwardRef<HTMLInputElement, InputTextSmallProps>(
           <div
             data-testid="show-password-button"
             onClick={() => setCurrentType(currentType === 'password' ? 'text' : 'password')}
-            className="absolute right-2 -translate-y-0.5 transform text-sm text-neutral-400"
+            className="absolute right-2 -translate-y-0.5 transform text-sm text-neutral-400 dark:text-neutral-50"
           >
             <Icon name={currentType === 'password' ? IconAwesomeEnum.EYE : IconAwesomeEnum.EYE_SLASH} />
           </div>


### PR DESCRIPTION
# What does this PR do?

> Link to the JIRA ticket

This PR fixes the dark mode styling for the `InputTextSmall` component. It ensures the input field has a transparent background and correct text/placeholder color (`dark:text-neutral-50`), and that the "show password" icon is visible in dark mode.

> Screenshot of the feature
> (Refer to the original Slack image for the issue context)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I made sure the code is type safe (no any)

---
[Slack Thread](https://qovery.slack.com/archives/C02PGRVRMD2/p1757944854796959?thread_ts=1757944854.796959&cid=C02PGRVRMD2)

<a href="https://cursor.com/background-agent?bcId=bc-355796ba-f94a-4a69-930e-4d08fee83959">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-355796ba-f94a-4a69-930e-4d08fee83959">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

