### PR TITLE
fix(helm): repo name was missing from summary step of the creation flow

### DIFF
--- a/libs/pages/services/src/lib/feature/page-helm-create-feature/step-summary-feature/step-summary-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-helm-create-feature/step-summary-feature/step-summary-feature.tsx
@@ -193,7 +193,7 @@ export function StepSummaryFeature() {
                 <ul className="list-none space-y-2 text-sm text-neutral-400">
                   <li>
                     <strong className="font-medium">Repository:</strong>{' '}
-                    {helmRepositories.find(({ id }) => id === generalData.git_repository?.name)?.name}
+                    {helmRepositories.find(({ id }) => id === generalData.repository)?.name}
                   </li>
                   <li>
                     <strong className="font-medium">Chart name:</strong> {generalData.chart_name}


### PR DESCRIPTION
# What does this PR do?

[QOV-1160](https://qovery.atlassian.net/browse/QOV-1160)

This PR fixes an issue where the repository name was missing from the "summary" step of the service creation flow.

<img width="790" height="554" alt="image (7)" src="https://github.com/user-attachments/assets/9ca833e0-851d-4a16-8f62-13781aa48b18" />

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1160]: https://qovery.atlassian.net/browse/QOV-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ