### PR TITLE
feat(terraform): add "contact us" to Terraform card

### DIFF
--- a/libs/pages/services/src/lib/feature/page-new-feature/page-new-feature.spec.tsx
+++ b/libs/pages/services/src/lib/feature/page-new-feature/page-new-feature.spec.tsx
@@ -1,9 +1,14 @@
+import { IntercomProvider } from 'react-use-intercom'
 import { renderWithProviders } from '@qovery/shared/util-tests'
 import PageNewFeature from './page-new-feature'
 
 describe('General', () => {
   it('should render successfully', () => {
-    const { baseElement } = renderWithProviders(<PageNewFeature />)
+    const { baseElement } = renderWithProviders(
+      <IntercomProvider appId="__test__app__id__" autoBoot={false}>
+        <PageNewFeature />
+      </IntercomProvider>
+    )
     expect(baseElement).toBeTruthy()
   })
 })


### PR DESCRIPTION
# What does this PR do?

[QOV-1157](https://qovery.atlassian.net/browse/QOV-1157)

PR adding a "contact us" button to the Terraform card in the services creation page when FF is disabled, allowing users to request access to the feature by filling out a Pylon form.

<img width="1233" height="713" alt="Screenshot 2025-09-16 at 16 18 44" src="https://github.com/user-attachments/assets/13a5e4a1-da54-4817-b00f-3300b66f829e" />

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1157]: https://qovery.atlassian.net/browse/QOV-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ