### PR TITLE
fix(invoices): display banner if some invoices have the payment_due status

### DIFF
--- a/libs/domains/organizations/feature/src/lib/invoice-banner/invoice-banner.tsx
+++ b/libs/domains/organizations/feature/src/lib/invoice-banner/invoice-banner.tsx
@@ -13,7 +13,9 @@ export const InvoiceBanner = () => {
   const hideInvoiceBanner = useFeatureFlagEnabled('hide_invoice_banner')
   const { roles } = useUserRole()
   const { data: invoices, isLoading } = useInvoices({ organizationId })
-  const unpaidInvoices = invoices?.filter((invoice) => invoice.status === InvoiceStatusEnum.NOT_PAID)
+  const unpaidInvoices = invoices?.filter(
+    ({ status }) => status === InvoiceStatusEnum.NOT_PAID || status === InvoiceStatusEnum.PAYMENT_DUE
+  )
 
   const isAdminOrOwnerOfCompany = useMemo(
     () =>


### PR DESCRIPTION
# What does this PR do?

[QOV-1168](https://qovery.atlassian.net/browse/QOV-1168)

PR fixing the condition to display the "invoice overdue" banner. Invoices with the `PAYMENT_DUE` status will now also be considered as not paid.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1168]: https://qovery.atlassian.net/browse/QOV-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ