### PR TITLE
Fix parent height and format code

### DIFF
--- a/libs/shared/ui/src/lib/components/command-menu/command-menu.tsx
+++ b/libs/shared/ui/src/lib/components/command-menu/command-menu.tsx
@@ -48,7 +48,8 @@ const CommandList = forwardRef<ElementRef<typeof CmdK.List>, CommandListProps>(f
         className
       )}
       style={{
-        height: 'min(400px, var(--cmdk-list-height))',
+        minHeight: '400px',
+        height: 'max(400px, var(--cmdk-list-height))',
       }}
       {...props}
     />


### PR DESCRIPTION
# What does this PR do?

> Link to the JIRA ticket

Fixes a display issue in the search modal where it would appear too small when there were few search results. The `CommandList` component's style was updated to ensure a minimum height of 400px, providing a consistent user experience.

> Screenshot of the feature
> (Refer to the image provided in the Slack thread showing the small search modal)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [ ] I made sure the code is type safe (no any)

---
[Slack Thread](https://qovery.slack.com/archives/C02P2JB4SEM/p1758527230347579?thread_ts=1758527230.347579&cid=C02P2JB4SEM)

<a href="https://cursor.com/background-agent?bcId=bc-424d95d8-aa15-4f4f-8247-029c64f2ec02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-424d95d8-aa15-4f4f-8247-029c64f2ec02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

