### PR TITLE
feat(port): foward public_path and public_path_rewrite values

### DIFF
--- a/libs/pages/application/src/lib/feature/page-settings-ports-feature/crud-modal-feature/crud-modal-feature.spec.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-ports-feature/crud-modal-feature/crud-modal-feature.spec.tsx
@@ -35,6 +35,8 @@ describe('CrudModalFeature', () => {
         publicly_accessible: false,
         name: 'p520',
         protocol: PortProtocolEnum.HTTP,
+        public_path: undefined,
+        public_path_rewrite: undefined,
       },
       application
     )
@@ -50,6 +52,8 @@ describe('CrudModalFeature', () => {
         publicly_accessible: false,
         name: 'p520',
         protocol: PortProtocolEnum.HTTP,
+        public_path: undefined,
+        public_path_rewrite: undefined,
       },
       application,
       application.ports?.[0]
@@ -96,6 +100,8 @@ describe('CrudModalFeature', () => {
             "internal_port": 52,
             "name": "p520",
             "protocol": "HTTP",
+            "public_path": undefined,
+            "public_path_rewrite": undefined,
             "publicly_accessible": false,
           },
         ],
@@ -132,6 +138,8 @@ describe('CrudModalFeature', () => {
         publicly_accessible: false,
         name: 'p520',
         protocol: PortProtocolEnum.TCP,
+        public_path: undefined,
+        public_path_rewrite: undefined,
       },
       application,
       application.ports?.[0]
@@ -184,6 +192,8 @@ describe('CrudModalFeature', () => {
             "internal_port": 52,
             "name": "p520",
             "protocol": "TCP",
+            "public_path": undefined,
+            "public_path_rewrite": undefined,
             "publicly_accessible": false,
           },
         ],
@@ -220,6 +230,8 @@ describe('CrudModalFeature', () => {
         publicly_accessible: false,
         name: 'p520',
         protocol: PortProtocolEnum.HTTP,
+        public_path: undefined,
+        public_path_rewrite: undefined,
       },
       application,
       application.ports?.[0]
@@ -272,6 +284,8 @@ describe('CrudModalFeature', () => {
             "internal_port": 52,
             "name": "p520",
             "protocol": "HTTP",
+            "public_path": undefined,
+            "public_path_rewrite": undefined,
             "publicly_accessible": false,
           },
         ],

--- a/libs/pages/application/src/lib/feature/page-settings-ports-feature/crud-modal-feature/crud-modal-feature.tsx
+++ b/libs/pages/application/src/lib/feature/page-settings-ports-feature/crud-modal-feature/crud-modal-feature.tsx
@@ -36,12 +36,16 @@ export function handleSubmit<
     publicly_accessible,
     protocol,
     name,
+    public_path,
+    public_path_rewrite,
   }: {
     internal_port: string | undefined
     external_port: string | undefined
     publicly_accessible: boolean
     protocol: PortProtocolEnum | undefined
     name: string | undefined
+    public_path: string | undefined
+    public_path_rewrite: string | undefined
   },
   service: T,
   currentPort?: ServicePort
@@ -69,6 +73,8 @@ export function handleSubmit<
     publicly_accessible,
     protocol: currentProtocol,
     name: name,
+    public_path: public_path,
+    public_path_rewrite: public_path_rewrite,
   }
 
   if (currentPort) {
@@ -155,6 +161,8 @@ export function CrudModalFeature({ service, onClose, port, isLastPublicPort }: C
       publicly_accessible: port ? port.publicly_accessible : false,
       protocol: port ? port.protocol : undefined,
       name: port ? port.name : undefined,
+      public_path: port ? port.public_path : undefined,
+      public_path_rewrite: port ? port.public_path_rewrite : undefined,
     },
     mode: 'onChange',
   })

--- a/libs/pages/services/src/lib/feature/page-application-create-feature/step-port-feature/crud-modal-feature/crud-modal-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-application-create-feature/step-port-feature/crud-modal-feature/crud-modal-feature.tsx
@@ -34,6 +34,8 @@ export function CrudModalFeature({
       publicly_accessible: port ? (port as PortData).is_public : false,
       protocol: port ? port.protocol : PortProtocolEnum.HTTP,
       name: port ? port.name : '',
+      public_path: port ? port.public_path : undefined,
+      public_path_rewrite: port ? port.public_path_rewrite : undefined,
     },
     mode: 'onChange',
   })

--- a/libs/pages/services/src/lib/feature/page-terraform-create-feature/step-general-feature/step-general-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-terraform-create-feature/step-general-feature/step-general-feature.tsx
@@ -70,6 +70,9 @@ export function StepGeneralFeature() {
                   icon_uri: 'app://qovery-console/terraform',
                   timeout_sec: 60,
                   auto_approve: false,
+                  backend: {
+                    kubernetes: {},
+                  },
                   terraform_variables_source: {
                     tf_var_file_paths: [],
                   },

--- a/libs/pages/services/src/lib/feature/page-terraform-create-feature/step-summary-feature/step-summary-feature.tsx
+++ b/libs/pages/services/src/lib/feature/page-terraform-create-feature/step-summary-feature/step-summary-feature.tsx
@@ -50,6 +50,9 @@ export function StepSummaryFeature() {
       auto_deploy: generalData.auto_deploy ?? false,
       auto_approve: false,
       provider: 'TERRAFORM',
+      backend: {
+        kubernetes: {},
+      },
       terraform_files_source: {
         git_repository: {
           url: buildGitRepoUrl(generalData.provider ?? '', generalData.repository),

--- a/libs/shared/factories/src/lib/terraform-factory.mock.ts
+++ b/libs/shared/factories/src/lib/terraform-factory.mock.ts
@@ -16,6 +16,9 @@ export const terraformFactoryMock = (howMany: number): Terraform[] =>
     description: chance.sentence(),
     auto_approve: false,
     auto_deploy: false,
+    backend: {
+      kubernetes: {},
+    },
     terraform_files_source: {
       git: {
         git_repository: {

--- a/libs/shared/interfaces/src/lib/common/flow-port-data.interface.ts
+++ b/libs/shared/interfaces/src/lib/common/flow-port-data.interface.ts
@@ -6,6 +6,8 @@ export interface PortData {
   is_public: boolean
   protocol: PortProtocolEnum
   name: string
+  public_path?: string
+  public_path_rewrite?: string
 }
 
 export type ProbeExtended = Probe & {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mermaid": "^11.6.0",
     "monaco-editor": "^0.44.0",
     "posthog-js": "^1.260.1",
-    "qovery-typescript-axios": "^1.1.684",
+    "qovery-typescript-axios": "^1.1.690",
     "react": "18.3.1",
     "react-country-flag": "^3.0.2",
     "react-datepicker": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,7 +4224,7 @@ __metadata:
     prettier: ^3.2.5
     prettier-plugin-tailwindcss: ^0.5.14
     pretty-quick: ^4.0.0
-    qovery-typescript-axios: ^1.1.684
+    qovery-typescript-axios: ^1.1.690
     qovery-ws-typescript-axios: ^0.1.334
     react: 18.3.1
     react-country-flag: ^3.0.2
@@ -21603,12 +21603,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:^1.1.684":
-  version: 1.1.684
-  resolution: "qovery-typescript-axios@npm:1.1.684"
+"qovery-typescript-axios@npm:^1.1.690":
+  version: 1.1.690
+  resolution: "qovery-typescript-axios@npm:1.1.690"
   dependencies:
     axios: 1.12.2
-  checksum: e5ed0ef387d63d597c4f2a92446bae7cec55b980890647aaadbd7a1a3c8cc768076d968789928de16a04bd8e1c39b7ddd8224821a75cf5578a6c1f39640b09f2
+  checksum: f7bef9265c4f6c3b2f1f1576f738fd7ce73345aff3f82ed41c9ebd1911f801a476974e50fc117f8efb7fb294c98ed53cb7fb347c3395ba3292e65310452894e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR does
 * Update qovery-lib and fix breaking changes
 * Forward the field public_path & public_path_rewrite of port when set by the API

It does not change anything in the UI for now. Will discuss how to integrate it properly.