### PR TITLE
Revert "fix(terraform): remove Terraform entry from IAC section (#2036)"

### DIFF
--- a/libs/pages/services/src/lib/feature/page-new-feature/service-templates.ts
+++ b/libs/pages/services/src/lib/feature/page-new-feature/service-templates.ts
@@ -239,6 +239,18 @@ export const serviceTemplates: ServiceTemplateType[] = [
   },
   {
     tag: 'IAC',
+    slug: 'terraform',
+    title: 'Terraform',
+    template_id: TemplateIds.TERRAFORM,
+    description: 'Terraform is an open-source infrastructure as code software tool.',
+    icon: Terraform,
+    icon_uri: 'app://qovery-console/terraform',
+    type: 'LIFECYCLE_JOB',
+    dockerfile:
+      'https://raw.githubusercontent.com/Qovery/lifecycle-job-examples/main/examples/aws-lambda-with-serverless/Dockerfile',
+  },
+  {
+    tag: 'IAC',
     slug: 'cloudformation',
     title: 'CloudFormation',
     template_id: TemplateIds.CLOUDFORMATION,


### PR DESCRIPTION
This reverts commit 7e1948d9b4667d7af907087180f4157ab3798acc.

# What does this PR do?

Brings back the Terraform card of the IAC section. This section will need to be removed once the new Terraform feature will be finished.

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
