### PR TITLE
fix(github-enterprise): add missing support for Github Enterprise

### DIFF
--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -223,6 +223,10 @@ export function ContainerRegistryForm({
                   () => 'Expected format: https://<region>-docker.pkg.dev'
                 )
                 .with(ContainerRegistryKindEnum.AZURE_CR, () => 'Expected format: https://<registry_name>.azurecr.io')
+                .with(
+                  ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR,
+                  () => 'Expected format: https://containers.<github_enterprise_subdomain>.ghe.com'
+                )
                 .exhaustive()}
               disabled={
                 isClusterManaged ||

--- a/libs/shared/util-js/src/lib/container-registry-kind-to-icon.ts
+++ b/libs/shared/util-js/src/lib/container-registry-kind-to-icon.ts
@@ -8,7 +8,7 @@ export function containerRegistryKindToIcon(
   return match(registryKind)
     .with('DOCKER_HUB', () => IconEnum.DOCKER)
     .with('SCALEWAY_CR', () => IconEnum.SCW)
-    .with('GITHUB_CR', () => IconEnum.GITHUB)
+    .with('GITHUB_CR', 'GITHUB_ENTERPRISE_CR', () => IconEnum.GITHUB)
     .with('GITLAB_CR', () => IconEnum.GITLAB)
     .with('GENERIC_CR', () => IconEnum.GENERIC_REGISTRY)
     .with('ECR', 'PUBLIC_ECR', () => IconEnum.AWS)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mermaid": "^11.6.0",
     "monaco-editor": "^0.44.0",
     "posthog-js": "^1.260.1",
-    "qovery-typescript-axios": "^1.1.691",
+    "qovery-typescript-axios": "^1.1.692",
     "react": "18.3.1",
     "react-country-flag": "^3.0.2",
     "react-datepicker": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,7 +4224,7 @@ __metadata:
     prettier: ^3.2.5
     prettier-plugin-tailwindcss: ^0.5.14
     pretty-quick: ^4.0.0
-    qovery-typescript-axios: ^1.1.691
+    qovery-typescript-axios: ^1.1.692
     qovery-ws-typescript-axios: ^0.1.334
     react: 18.3.1
     react-country-flag: ^3.0.2
@@ -21603,12 +21603,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:^1.1.691":
-  version: 1.1.691
-  resolution: "qovery-typescript-axios@npm:1.1.691"
+"qovery-typescript-axios@npm:^1.1.692":
+  version: 1.1.692
+  resolution: "qovery-typescript-axios@npm:1.1.692"
   dependencies:
     axios: 1.12.2
-  checksum: 89753d44125bd9512568e9fa32691e518605b1800bff90a3c8ef77e3aaa39574fb5511a92c54826bcedd2fc66339805952836154edbb8007620cc22d101547bc
+  checksum: 9935ed741ceb3a089e93f74a1d69f2b1f8a784b747e737b5457a24a185f121389663a8050e9f4a3df8dba427341cb53c09c508f70d0cc4f7fd10c03f3eb25725
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What does this PR do?

[QOV-1189](https://qovery.atlassian.net/browse/QOV-1189)

PR adding the missing TS checks for Github Enterprise

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)


[QOV-1189]: https://qovery.atlassian.net/browse/QOV-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ