### PR TITLE
feat(github-enterprise): support GitHub Enterprise

### DIFF
--- a/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.tsx
@@ -50,7 +50,10 @@ export function ContainerRegistryCreateEditModal({
         azure_tenant_id: registry?.config?.azure_tenant_id,
         azure_subscription_id: registry?.config?.azure_subscription_id,
         azure_application_id: registry?.config?.azure_application_id,
-        login_type: registry?.config?.username ? 'ACCOUNT' : 'ANONYMOUS',
+        login_type:
+          registry?.config?.username || registry?.kind === ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR
+            ? 'ACCOUNT'
+            : 'ANONYMOUS',
       },
     },
   })

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -193,12 +193,24 @@ export function ContainerRegistryForm({
               match(watchKind)
                 .with('GENERIC_CR', () =>
                   // eslint-disable-next-line no-useless-escape
-                  input?.match(/^(http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/gm)
+                  !input?.match(/^(http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/gm)
+                    ? 'URL must be valid and start with «http(s)://»'
+                    : undefined
+                )
+                .with(ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR, () =>
+                  !input?.match(
+                    // eslint-disable-next-line no-useless-escape
+                    /^https:\/\/containers\.[\w.-]+\.ghe\.com$/
+                  )
+                    ? 'Expected format: https://containers.<github_enterprise_subdomain>.ghe.com'
+                    : undefined
                 )
                 .otherwise(() =>
                   // eslint-disable-next-line no-useless-escape
-                  input?.match(/^(http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:?#[\]@!\$&'\(\)\*\+,;=.]+$/gm)
-                ) !== null || 'URL must be valid and start with «http(s)://»',
+                  !input?.match(/^(http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:?#[\]@!\$&'\(\)\*\+,;=.]+$/gm)
+                    ? 'URL must be valid and start with «http(s)://»'
+                    : undefined
+                ),
           }}
           render={({ field, fieldState: { error } }) => (
             <InputText
@@ -230,7 +242,7 @@ export function ContainerRegistryForm({
                 .with(ContainerRegistryKindEnum.AZURE_CR, () => 'Expected format: https://<registry_name>.azurecr.io')
                 .with(
                   ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR,
-                  () => 'Expected format: https://<github_enterprise_subdomain>.ghe.com'
+                  () => 'Expected format: https://containers.<github_enterprise_subdomain>.ghe.com'
                 )
                 .exhaustive()}
               disabled={

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -80,7 +80,7 @@ export function ContainerRegistryForm({
   const defaultRegistryUrls = {
     [ContainerRegistryKindEnum.GITLAB_CR]: 'https://registry.gitlab.com',
     [ContainerRegistryKindEnum.GITHUB_CR]: 'https://ghcr.io',
-    [ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR]: 'https://containers.<github_enterprise_subdomain>.ghe.com',
+    [ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR]: '',
     [ContainerRegistryKindEnum.DOCKER_HUB]: 'https://docker.io',
     [ContainerRegistryKindEnum.GENERIC_CR]: '',
     [ContainerRegistryKindEnum.ECR]: '',
@@ -165,6 +165,10 @@ export function ContainerRegistryForm({
               methods.setValue('url', defaultRegistryUrls[value as keyof typeof defaultRegistryUrls])
               methods.resetField('config')
               field.onChange(value)
+              // GitHub Enterprise doesn't support anonymous login, so we set the login type to ACCOUNT
+              if (value === ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR) {
+                methods.setValue('config.login_type', 'ACCOUNT')
+              }
             }}
             value={field.value}
             label="Type"
@@ -249,6 +253,7 @@ export function ContainerRegistryForm({
         .with(
           ContainerRegistryKindEnum.DOCKER_HUB,
           ContainerRegistryKindEnum.GITHUB_CR,
+          ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR,
           ContainerRegistryKindEnum.GITLAB_CR,
           ContainerRegistryKindEnum.GENERIC_CR,
           () => true
@@ -269,7 +274,7 @@ export function ContainerRegistryForm({
                 }}
                 value={field.value}
                 label="Login type"
-                disabled={cluster?.is_demo}
+                disabled={cluster?.is_demo || watchKind === ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR} // GitHub Enterprise doesn't support anonymous login
                 error={error?.message}
                 options={[
                   {

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -80,6 +80,7 @@ export function ContainerRegistryForm({
   const defaultRegistryUrls = {
     [ContainerRegistryKindEnum.GITLAB_CR]: 'https://registry.gitlab.com',
     [ContainerRegistryKindEnum.GITHUB_CR]: 'https://ghcr.io',
+    [ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR]: 'https://containers.<github_enterprise_subdomain>.ghe.com',
     [ContainerRegistryKindEnum.DOCKER_HUB]: 'https://docker.io',
     [ContainerRegistryKindEnum.GENERIC_CR]: '',
     [ContainerRegistryKindEnum.ECR]: '',
@@ -225,7 +226,7 @@ export function ContainerRegistryForm({
                 .with(ContainerRegistryKindEnum.AZURE_CR, () => 'Expected format: https://<registry_name>.azurecr.io')
                 .with(
                   ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR,
-                  () => 'Expected format: https://containers.<github_enterprise_subdomain>.ghe.com'
+                  () => 'Expected format: https://<github_enterprise_subdomain>.ghe.com'
                 )
                 .exhaustive()}
               disabled={

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -318,15 +318,32 @@ export function ContainerRegistryForm({
                     onChange={field.onChange}
                     value={field.value}
                     label={match(watchKind)
-                      .with(ContainerRegistryKindEnum.GITHUB_CR, () => 'Container registry prefix')
-                      .otherwise(() => 'Username')}
-                    hint={match(watchKind)
                       .with(
                         ContainerRegistryKindEnum.GITHUB_CR,
-                        () =>
-                          'The prefix is the part of the URL before the repository name. For example, in ghcr.io/qovery/my-app, the prefix is qovery'
+                        ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR,
+                        () => 'Container registry prefix'
                       )
-                      .otherwise(() => undefined)}
+                      .otherwise(() => 'Username')}
+                    hint={
+                      <span>
+                        {match(watchKind)
+                          .with(ContainerRegistryKindEnum.GITHUB_CR, () => (
+                            <>
+                              The prefix is the part of the URL before the repository name.For example, in{' '}
+                              <code className="rounded bg-neutral-100 px-1">ghcr.io/qovery/my-app</code>, the prefix is{' '}
+                              <code className="rounded bg-neutral-100 px-1">qovery</code>
+                            </>
+                          ))
+                          .with(ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR, () => (
+                            <>
+                              The prefix is the part of the URL before the repository name. For example, in{' '}
+                              <code className="rounded bg-neutral-100 px-1">host.ghe.com/qovery/my-app</code>, the
+                              prefix is <code className="rounded bg-neutral-100 px-1">qovery</code>
+                            </>
+                          ))
+                          .otherwise(() => undefined)}
+                      </span>
+                    }
                     error={error?.message}
                   />
                 )}
@@ -337,7 +354,8 @@ export function ContainerRegistryForm({
                   <hr />
                   <span className="text-sm text-neutral-350">
                     {watchKind === ContainerRegistryKindEnum.GITHUB_CR ||
-                    watchKind === ContainerRegistryKindEnum.GITLAB_CR
+                    watchKind === ContainerRegistryKindEnum.GITLAB_CR ||
+                    watchKind === ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR
                       ? 'Confirm your personal access token'
                       : 'Confirm your password'}
                   </span>
@@ -350,7 +368,8 @@ export function ContainerRegistryForm({
                   rules={{
                     required:
                       watchKind === ContainerRegistryKindEnum.GITHUB_CR ||
-                      watchKind === ContainerRegistryKindEnum.GITLAB_CR
+                      watchKind === ContainerRegistryKindEnum.GITLAB_CR ||
+                      watchKind === ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR
                         ? 'Please enter a personal access token.'
                         : 'Please enter a password.',
                   }}
@@ -364,7 +383,8 @@ export function ContainerRegistryForm({
                         value={field.value}
                         label={
                           watchKind === ContainerRegistryKindEnum.GITHUB_CR ||
-                          watchKind === ContainerRegistryKindEnum.GITLAB_CR
+                          watchKind === ContainerRegistryKindEnum.GITLAB_CR ||
+                          watchKind === ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR
                             ? 'Personal Access Token'
                             : 'Password'
                         }

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
@@ -298,6 +298,7 @@ export function GitTokenCreateEditModal({ isEdit, gitToken, organizationId, onCl
           render={({ field, fieldState: { error } }) => (
             <InputText
               className="mb-5"
+              type="password"
               label="Token value"
               name={field.name}
               onChange={field.onChange}

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
@@ -162,7 +162,7 @@ export function GitTokenCreateEditModal({ isEdit, gitToken, organizationId, onCl
                   error={error?.message}
                   options={[
                     {
-                      label: 'GitHub.com',
+                      label: 'GitHub',
                       value: 'PUBLIC',
                       icon: <Icon name="GITHUB" width="16px" height="16px" />,
                     },

--- a/libs/domains/organizations/feature/src/lib/hooks/use-available-container-registries/use-available-container-registries.ts
+++ b/libs/domains/organizations/feature/src/lib/hooks/use-available-container-registries/use-available-container-registries.ts
@@ -13,6 +13,7 @@ export function useAvailableContainerRegistries() {
         'DOCKER_HUB',
         'GENERIC_CR',
         'GITHUB_CR',
+        'GITHUB_ENTERPRISE_CR',
         'GITLAB_CR',
         'PUBLIC_ECR',
         'DOCR',

--- a/libs/domains/organizations/feature/src/lib/hooks/use-container-images/use-container-images.ts
+++ b/libs/domains/organizations/feature/src/lib/hooks/use-container-images/use-container-images.ts
@@ -6,13 +6,21 @@ export interface UseContainerImagesProps {
   containerRegistryId: string
   search: string
   enabled?: boolean
+  retry?: boolean
 }
 
-export function useContainerImages({ organizationId, containerRegistryId, search, enabled }: UseContainerImagesProps) {
+export function useContainerImages({
+  organizationId,
+  containerRegistryId,
+  search,
+  enabled,
+  retry = true,
+}: UseContainerImagesProps) {
   return useQuery({
     ...queries.organizations.containerImages({ organizationId, containerRegistryId, search }),
     enabled,
     keepPreviousData: true,
+    retry,
   })
 }
 

--- a/libs/shared/console-shared/src/lib/general-container-settings/ui/image-name.tsx
+++ b/libs/shared/console-shared/src/lib/general-container-settings/ui/image-name.tsx
@@ -45,6 +45,7 @@ export function ImageName({
     containerRegistryId,
     search: debouncedImageName || watchImageName,
     enabled: (debouncedImageName || watchImageName).length > 2,
+    retry: false,
   })
 
   // XXX: Available only for this kind of registry: https://qovery.atlassian.net/browse/FRT-1307?focusedCommentId=13219
@@ -54,9 +55,9 @@ export function ImageName({
       { kind: 'GCP_ARTIFACT_REGISTRY' },
       { kind: 'DOCKER_HUB' },
       { kind: 'GENERIC_CR' },
-      () => true
+      (r) => true
     )
-    .with({ kind: 'GITHUB_CR' }, (r) => r.config && Object.keys(r.config).length > 0)
+    .with({ kind: 'GITHUB_CR' }, { kind: 'GITHUB_ENTERPRISE_CR' }, (r) => r.config && Object.keys(r.config).length > 0)
     .otherwise(() => false)
 
   // Refetch when debounced value changes
@@ -120,7 +121,7 @@ export function ImageName({
           isLoading={isFetching || searchParams !== debouncedImageName}
           formatCreateLabel={(inputValue) => `Select "${inputValue.toLowerCase()}" - not found in registry`}
           isValidNewOption={isValidNewOption}
-          filterOption="startsWith"
+          filterOption="fuzzy"
           isCreatable
           isSearchable
         />

--- a/libs/shared/console-shared/src/lib/general-container-settings/ui/image-name.tsx
+++ b/libs/shared/console-shared/src/lib/general-container-settings/ui/image-name.tsx
@@ -55,7 +55,7 @@ export function ImageName({
       { kind: 'GCP_ARTIFACT_REGISTRY' },
       { kind: 'DOCKER_HUB' },
       { kind: 'GENERIC_CR' },
-      (r) => true
+      () => true
     )
     .with({ kind: 'GITHUB_CR' }, { kind: 'GITHUB_ENTERPRISE_CR' }, (r) => r.config && Object.keys(r.config).length > 0)
     .otherwise(() => false)


### PR DESCRIPTION
# What does this PR do?

[JIRA ticket](https://qovery.atlassian.net/browse/QOV-1189)

PR implementing the support for GitHub Enterprise. 
Changes include:
- Adding a dropdown to the "git token" update/creation modal so users can choose between GitHub and Github Enterprise. If GitHub Enterprise is selected, a new text input is displayed, asking users to enter the URL to their GHE instance.
- Adding support for the new `GITHUB_ENTERPRISE_CR` container registry type in the Container Registry creation/update modal. _Please note that GHE does not support anonymous sign in and users will thus need to specify some credentials._
- Getting rid of the `gitlab-self-hosted` feature flag.

--- 

🎥  [Demo here](https://qovery.slack.com/archives/C0910JC1N9G/p1759242823163199)

---

## PR Checklist

- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] This PR introduces new store changes
- [x] I made sure the code is type safe (no any)
