### PR TITLE
feat(announcement-banner): support multiple banners with carousel nav…

### DIFF
--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.spec.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.spec.tsx
@@ -16,7 +16,8 @@ describe('AnnouncementBanner', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    ;(useLocalStorage as jest.Mock).mockReturnValue([[], mockSetDismissedMessages])
+    const localStorageMock = useLocalStorage as jest.Mock
+    localStorageMock.mockReturnValue([[], mockSetDismissedMessages])
   })
 
   it('should render nothing when banner list is empty', () => {
@@ -143,7 +144,8 @@ describe('AnnouncementBanner', () => {
   })
 
   it('should not show a banner already dismissed by id', () => {
-    ;(useLocalStorage as jest.Mock).mockReturnValue([['banner-id-already'], mockSetDismissedMessages])
+    const localStorageMock = useLocalStorage as jest.Mock
+    localStorageMock.mockReturnValue([['banner-id-already'], mockSetDismissedMessages])
     mockUseAnnouncementBanner.mockReturnValue([
       { id: 'banner-id-already', message: 'Already dismissed', variant: 'info', dismissible: true },
       { message: 'Still visible', variant: 'warning', dismissible: false },
@@ -156,7 +158,8 @@ describe('AnnouncementBanner', () => {
   })
 
   it('should not show a banner already dismissed by message in new localStorage key', () => {
-    ;(useLocalStorage as jest.Mock).mockReturnValue([['Already dismissed'], mockSetDismissedMessages])
+    const localStorageMock = useLocalStorage as jest.Mock
+    localStorageMock.mockReturnValue([['Already dismissed'], mockSetDismissedMessages])
     mockUseAnnouncementBanner.mockReturnValue([
       { message: 'Already dismissed', variant: 'info', dismissible: true },
       { message: 'Still visible', variant: 'warning', dismissible: true },
@@ -184,7 +187,8 @@ describe('AnnouncementBanner', () => {
   })
 
   it('should always show non-dismissible banners regardless of localStorage', () => {
-    ;(useLocalStorage as jest.Mock).mockReturnValue([['Non-dismissible message'], mockSetDismissedMessages])
+    const localStorageMock = useLocalStorage as jest.Mock
+    localStorageMock.mockReturnValue([['Non-dismissible message'], mockSetDismissedMessages])
     mockUseAnnouncementBanner.mockReturnValue([
       { message: 'Non-dismissible message', variant: 'warning', dismissible: false },
     ])
@@ -233,7 +237,8 @@ describe('AnnouncementBanner', () => {
   })
 
   it('should render nothing when all banners are dismissed', () => {
-    ;(useLocalStorage as jest.Mock).mockReturnValue([['banner-1', 'banner-2'], mockSetDismissedMessages])
+    const localStorageMock = useLocalStorage as jest.Mock
+    localStorageMock.mockReturnValue([['banner-1', 'banner-2'], mockSetDismissedMessages])
     mockUseAnnouncementBanner.mockReturnValue([
       { id: 'banner-1', message: 'Banner 1', variant: 'info', dismissible: true },
       { id: 'banner-2', message: 'Banner 2', variant: 'warning', dismissible: true },

--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.spec.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.spec.tsx
@@ -12,28 +12,25 @@ describe('AnnouncementBanner', () => {
   const mockUseAnnouncementBanner = useAnnouncementBannerModule.useAnnouncementBanner as jest.MockedFunction<
     typeof useAnnouncementBannerModule.useAnnouncementBanner
   >
-  const mockSetDismissedMessage = jest.fn()
+  const mockSetDismissedMessages = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
-    ;(useLocalStorage as jest.Mock).mockReturnValue([null, mockSetDismissedMessage])
+    ;(useLocalStorage as jest.Mock).mockReturnValue([[], mockSetDismissedMessages])
   })
 
-  it('should render nothing when banner data is null', () => {
-    mockUseAnnouncementBanner.mockReturnValue(null)
+  it('should render nothing when banner list is empty', () => {
+    mockUseAnnouncementBanner.mockReturnValue([])
 
     const { container } = renderWithProviders(<AnnouncementBanner />)
 
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('should render info banner with brand color', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      title: 'Info Title',
-      message: 'This is an info message',
-      variant: 'info',
-      dismissible: false,
-    })
+  it('should render the first banner', () => {
+    mockUseAnnouncementBanner.mockReturnValue([
+      { title: 'Info Title', message: 'This is an info message', variant: 'info', dismissible: false },
+    ])
 
     renderWithProviders(<AnnouncementBanner />)
 
@@ -41,157 +38,209 @@ describe('AnnouncementBanner', () => {
     expect(screen.getByText('This is an info message')).toBeInTheDocument()
   })
 
-  it('should render warning banner with yellow color', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'This is a warning message',
-      variant: 'warning',
-      dismissible: false,
-    })
+  it('should display error banners before warning before info', () => {
+    mockUseAnnouncementBanner.mockReturnValue([
+      { message: 'Info banner', variant: 'info', dismissible: false },
+      { message: 'Error banner', variant: 'error', dismissible: false },
+      { message: 'Warning banner', variant: 'warning', dismissible: false },
+    ])
 
     renderWithProviders(<AnnouncementBanner />)
 
-    expect(screen.getByText('This is a warning message')).toBeInTheDocument()
+    expect(screen.getByText('Error banner')).toBeInTheDocument()
+    expect(screen.queryByText('Info banner')).not.toBeInTheDocument()
+    expect(screen.queryByText('Warning banner')).not.toBeInTheDocument()
   })
 
-  it('should render error banner with red color', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      title: 'Error',
-      message: 'This is an error message',
-      variant: 'error',
-      dismissible: false,
-    })
+  it('should show navigation controls when there are multiple banners', () => {
+    mockUseAnnouncementBanner.mockReturnValue([
+      { message: 'First banner', variant: 'info', dismissible: false },
+      { message: 'Second banner', variant: 'warning', dismissible: false },
+    ])
 
     renderWithProviders(<AnnouncementBanner />)
 
-    expect(screen.getByText('Error')).toBeInTheDocument()
-    expect(screen.getByText('This is an error message')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
+    expect(screen.getByText('1/2')).toBeInTheDocument()
   })
 
-  it('should render dismiss icon when dismissible is true', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'Dismissible message',
-      variant: 'info',
-      dismissible: true,
-    })
+  it('should not show navigation controls for a single banner', () => {
+    mockUseAnnouncementBanner.mockReturnValue([{ message: 'Only banner', variant: 'info', dismissible: false }])
 
     renderWithProviders(<AnnouncementBanner />)
 
-    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Previous' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument()
   })
 
-  it('should not render dismiss button when dismissible is false', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'Non-dismissible message',
-      variant: 'info',
-      dismissible: false,
-    })
+  it('should navigate to next banner when Next is clicked', async () => {
+    mockUseAnnouncementBanner.mockReturnValue([
+      { message: 'First banner', variant: 'error', dismissible: false },
+      { message: 'Second banner', variant: 'warning', dismissible: false },
+    ])
 
-    renderWithProviders(<AnnouncementBanner />)
+    const { userEvent } = renderWithProviders(<AnnouncementBanner />)
 
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('First banner')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(screen.getByText('Second banner')).toBeInTheDocument()
+    expect(screen.queryByText('First banner')).not.toBeInTheDocument()
+    expect(screen.getByText('2/2')).toBeInTheDocument()
   })
 
-  it('should call setDismissedMessage with banner message when dismiss button is clicked', async () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'Dismissible message',
-      variant: 'warning',
-      dismissible: true,
-    })
+  it('should navigate to previous banner when Prev is clicked', async () => {
+    mockUseAnnouncementBanner.mockReturnValue([
+      { message: 'First banner', variant: 'error', dismissible: false },
+      { message: 'Second banner', variant: 'warning', dismissible: false },
+    ])
+
+    const { userEvent } = renderWithProviders(<AnnouncementBanner />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Previous' }))
+
+    expect(screen.getByText('First banner')).toBeInTheDocument()
+    expect(screen.getByText('1/2')).toBeInTheDocument()
+  })
+
+  it('should wrap around to last banner when clicking Previous from first', async () => {
+    mockUseAnnouncementBanner.mockReturnValue([
+      { message: 'First banner', variant: 'error', dismissible: false },
+      { message: 'Second banner', variant: 'warning', dismissible: false },
+    ])
+
+    const { userEvent } = renderWithProviders(<AnnouncementBanner />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Previous' }))
+
+    expect(screen.getByText('Second banner')).toBeInTheDocument()
+    expect(screen.getByText('2/2')).toBeInTheDocument()
+  })
+
+  it('should use banner id as dismiss key when available', async () => {
+    mockUseAnnouncementBanner.mockReturnValue([
+      { id: 'banner-id-1', message: 'Banner A', variant: 'info', dismissible: true },
+    ])
 
     const { userEvent } = renderWithProviders(<AnnouncementBanner />)
 
     await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
 
-    expect(mockSetDismissedMessage).toHaveBeenCalledWith('Dismissible message')
+    expect(mockSetDismissedMessages).toHaveBeenCalledWith(['banner-id-1'])
   })
 
-  it('should not show banner when already dismissed in localStorage', () => {
-    const localStorageMock = useLocalStorage as jest.Mock
-    localStorageMock.mockReturnValue(['Already dismissed message', jest.fn()])
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'Already dismissed message',
-      variant: 'info',
-      dismissible: true,
-    })
+  it('should fall back to message as dismiss key when id is absent', async () => {
+    mockUseAnnouncementBanner.mockReturnValue([{ message: 'Banner A', variant: 'info', dismissible: true }])
 
-    const { container } = renderWithProviders(<AnnouncementBanner />)
+    const { userEvent } = renderWithProviders(<AnnouncementBanner />)
 
-    expect(container).toBeEmptyDOMElement()
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+
+    expect(mockSetDismissedMessages).toHaveBeenCalledWith(['Banner A'])
   })
 
-  it('should render banner without title', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'Message only',
-      variant: 'info',
-      dismissible: false,
-    })
+  it('should not show a banner already dismissed by id', () => {
+    (useLocalStorage as jest.Mock).mockReturnValue([['banner-id-already'], mockSetDismissedMessages])
+    mockUseAnnouncementBanner.mockReturnValue([
+      { id: 'banner-id-already', message: 'Already dismissed', variant: 'info', dismissible: true },
+      { message: 'Still visible', variant: 'warning', dismissible: false },
+    ])
 
     renderWithProviders(<AnnouncementBanner />)
 
-    expect(screen.getByText('Message only')).toBeInTheDocument()
-    expect(screen.queryByRole('strong')).not.toBeInTheDocument()
+    expect(screen.queryByText('Already dismissed')).not.toBeInTheDocument()
+    expect(screen.getByText('Still visible')).toBeInTheDocument()
   })
 
-  it('should render action button when buttonUrl and buttonLabel are provided', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'New feature available',
-      variant: 'info',
-      dismissible: false,
-      buttonLabel: 'Learn more',
-      buttonUrl: 'https://docs.qovery.com',
-    })
+  it('should not show a banner already dismissed by message in new localStorage key', () => {
+    (useLocalStorage as jest.Mock).mockReturnValue([['Already dismissed'], mockSetDismissedMessages])
+    mockUseAnnouncementBanner.mockReturnValue([
+      { message: 'Already dismissed', variant: 'info', dismissible: true },
+      { message: 'Still visible', variant: 'warning', dismissible: true },
+    ])
 
     renderWithProviders(<AnnouncementBanner />)
 
-    expect(screen.getByRole('button', { name: 'Learn more' })).toBeInTheDocument()
+    expect(screen.queryByText('Already dismissed')).not.toBeInTheDocument()
+    expect(screen.getByText('Still visible')).toBeInTheDocument()
+  })
+
+  it('should not show a banner dismissed via the legacy localStorage key', () => {
+    localStorage.setItem('announcement_banner_dismissed', JSON.stringify('Legacy dismissed message'))
+    mockUseAnnouncementBanner.mockReturnValue([
+      { message: 'Legacy dismissed message', variant: 'info', dismissible: true },
+      { message: 'New visible banner', variant: 'warning', dismissible: false },
+    ])
+
+    renderWithProviders(<AnnouncementBanner />)
+
+    expect(screen.queryByText('Legacy dismissed message')).not.toBeInTheDocument()
+    expect(screen.getByText('New visible banner')).toBeInTheDocument()
+
+    localStorage.removeItem('announcement_banner_dismissed')
+  })
+
+  it('should always show non-dismissible banners regardless of localStorage', () => {
+    (useLocalStorage as jest.Mock).mockReturnValue([['Non-dismissible message'], mockSetDismissedMessages])
+    mockUseAnnouncementBanner.mockReturnValue([
+      { message: 'Non-dismissible message', variant: 'warning', dismissible: false },
+    ])
+
+    renderWithProviders(<AnnouncementBanner />)
+
+    expect(screen.getByText('Non-dismissible message')).toBeInTheDocument()
+  })
+
+  it('should render action button when buttonLabel and buttonUrl are provided', () => {
+    mockUseAnnouncementBanner.mockReturnValue([
+      {
+        message: 'New feature',
+        variant: 'info',
+        dismissible: false,
+        buttonLabel: 'Have a look',
+        buttonUrl: 'https://docs.qovery.com',
+      },
+    ])
+
+    renderWithProviders(<AnnouncementBanner />)
+
+    expect(screen.getByRole('button', { name: 'Have a look' })).toBeInTheDocument()
   })
 
   it('should open URL in new tab when action button is clicked', async () => {
     const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation()
 
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'New feature available',
-      variant: 'info',
-      dismissible: false,
-      buttonLabel: 'Learn more',
-      buttonUrl: 'https://docs.qovery.com',
-    })
+    mockUseAnnouncementBanner.mockReturnValue([
+      {
+        message: 'New feature',
+        variant: 'info',
+        dismissible: false,
+        buttonLabel: 'Learn more',
+        buttonUrl: 'https://docs.qovery.com',
+      },
+    ])
 
     const { userEvent } = renderWithProviders(<AnnouncementBanner />)
 
-    const actionButton = screen.getByRole('button', { name: 'Learn more' })
-    await userEvent.click(actionButton)
+    await userEvent.click(screen.getByRole('button', { name: 'Learn more' }))
 
     expect(windowOpenSpy).toHaveBeenCalledWith('https://docs.qovery.com', '_blank', 'noopener,noreferrer')
 
     windowOpenSpy.mockRestore()
   })
 
-  it('should show both action button and dismiss icon when both are enabled', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'New feature available',
-      variant: 'info',
-      dismissible: true,
-      buttonLabel: 'Learn more',
-      buttonUrl: 'https://docs.qovery.com',
-    })
+  it('should render nothing when all banners are dismissed', () => {
+    (useLocalStorage as jest.Mock).mockReturnValue([['banner-1', 'banner-2'], mockSetDismissedMessages])
+    mockUseAnnouncementBanner.mockReturnValue([
+      { id: 'banner-1', message: 'Banner 1', variant: 'info', dismissible: true },
+      { id: 'banner-2', message: 'Banner 2', variant: 'warning', dismissible: true },
+    ])
 
-    renderWithProviders(<AnnouncementBanner />)
+    const { container } = renderWithProviders(<AnnouncementBanner />)
 
-    expect(screen.getByRole('button', { name: 'Learn more' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument()
-  })
-
-  it('should not render action button when buttonUrl is provided without buttonLabel', () => {
-    mockUseAnnouncementBanner.mockReturnValue({
-      message: 'Test message',
-      variant: 'info',
-      dismissible: false,
-      buttonUrl: 'https://docs.qovery.com',
-    })
-
-    renderWithProviders(<AnnouncementBanner />)
-
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.spec.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.spec.tsx
@@ -143,7 +143,7 @@ describe('AnnouncementBanner', () => {
   })
 
   it('should not show a banner already dismissed by id', () => {
-    (useLocalStorage as jest.Mock).mockReturnValue([['banner-id-already'], mockSetDismissedMessages])
+    ;(useLocalStorage as jest.Mock).mockReturnValue([['banner-id-already'], mockSetDismissedMessages])
     mockUseAnnouncementBanner.mockReturnValue([
       { id: 'banner-id-already', message: 'Already dismissed', variant: 'info', dismissible: true },
       { message: 'Still visible', variant: 'warning', dismissible: false },
@@ -156,7 +156,7 @@ describe('AnnouncementBanner', () => {
   })
 
   it('should not show a banner already dismissed by message in new localStorage key', () => {
-    (useLocalStorage as jest.Mock).mockReturnValue([['Already dismissed'], mockSetDismissedMessages])
+    ;(useLocalStorage as jest.Mock).mockReturnValue([['Already dismissed'], mockSetDismissedMessages])
     mockUseAnnouncementBanner.mockReturnValue([
       { message: 'Already dismissed', variant: 'info', dismissible: true },
       { message: 'Still visible', variant: 'warning', dismissible: true },
@@ -184,7 +184,7 @@ describe('AnnouncementBanner', () => {
   })
 
   it('should always show non-dismissible banners regardless of localStorage', () => {
-    (useLocalStorage as jest.Mock).mockReturnValue([['Non-dismissible message'], mockSetDismissedMessages])
+    ;(useLocalStorage as jest.Mock).mockReturnValue([['Non-dismissible message'], mockSetDismissedMessages])
     mockUseAnnouncementBanner.mockReturnValue([
       { message: 'Non-dismissible message', variant: 'warning', dismissible: false },
     ])
@@ -233,7 +233,7 @@ describe('AnnouncementBanner', () => {
   })
 
   it('should render nothing when all banners are dismissed', () => {
-    (useLocalStorage as jest.Mock).mockReturnValue([['banner-1', 'banner-2'], mockSetDismissedMessages])
+    ;(useLocalStorage as jest.Mock).mockReturnValue([['banner-1', 'banner-2'], mockSetDismissedMessages])
     mockUseAnnouncementBanner.mockReturnValue([
       { id: 'banner-1', message: 'Banner 1', variant: 'info', dismissible: true },
       { id: 'banner-2', message: 'Banner 2', variant: 'warning', dismissible: true },

--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
@@ -1,5 +1,7 @@
-import { Banner } from '@qovery/shared/ui'
+import { useCallback, useState } from 'react'
+import { Banner, Button, Icon } from '@qovery/shared/ui'
 import { useLocalStorage } from '@qovery/shared/util-hooks'
+import { twMerge } from '@qovery/shared/util-js'
 import {
   type AnnouncementBannerPayload,
   useAnnouncementBanner,
@@ -11,29 +13,71 @@ const VARIANT_TO_COLOR_MAP: Record<AnnouncementBannerPayload['variant'], 'brand'
   error: 'red',
 }
 
+const VARIANT_PRIORITY: Record<AnnouncementBannerPayload['variant'], number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+}
+
+const LEGACY_DISMISSED_KEY = 'announcement_banner_dismissed'
+const DISMISSED_MESSAGES_KEY = 'announcement_banners_dismissed'
+
+function isLegacyDismissed(message: string): boolean {
+  const raw = localStorage.getItem(LEGACY_DISMISSED_KEY)
+  if (!raw) return false
+  try {
+    return JSON.parse(raw) === message
+  } catch {
+    return false
+  }
+}
+
+function getBannerKey(banner: AnnouncementBannerPayload): string {
+  return banner.id ?? banner.message
+}
+
 export function AnnouncementBanner() {
-  const bannerData = useAnnouncementBanner()
-  const [dismissedMessage, setDismissedMessage] = useLocalStorage<string | null>('announcement_banner_dismissed', null)
+  const banners = useAnnouncementBanner()
+  const [dismissedMessages, setDismissedMessages] = useLocalStorage<string[]>(DISMISSED_MESSAGES_KEY, [])
+  const [currentIndex, setCurrentIndex] = useState(0)
 
-  const isDismissed = Boolean(bannerData && dismissedMessage === bannerData.message)
+  const isBannerDismissed = useCallback(
+    (banner: AnnouncementBannerPayload): boolean => {
+      const key = getBannerKey(banner)
+      if (dismissedMessages?.includes(key)) return true
+      return isLegacyDismissed(banner.message)
+    },
+    [dismissedMessages]
+  )
 
-  if (!bannerData || isDismissed) {
-    return null
-  }
+  const visibleBanners = banners
+    .filter((b) => !b.dismissible || !isBannerDismissed(b))
+    .sort((a, b) => VARIANT_PRIORITY[a.variant] - VARIANT_PRIORITY[b.variant])
 
-  const { title, message, variant, dismissible, buttonLabel, buttonUrl } = bannerData
+  const safeIndex = Math.min(currentIndex, Math.max(0, visibleBanners.length - 1))
+
+  if (visibleBanners.length === 0) return null
+
+  const banner = visibleBanners[safeIndex]
+  const { title, message, variant, dismissible, buttonLabel, buttonUrl } = banner
   const color = VARIANT_TO_COLOR_MAP[variant]
-
   const hasActionButton = buttonLabel && buttonUrl
+  const hasMultiple = visibleBanners.length > 1
 
-  const handleActionButtonClick = () => {
-    if (hasActionButton) {
-      window.open(buttonUrl, '_blank', 'noopener,noreferrer')
-    }
-  }
+  const buttonColorClass = {
+    brand: '!bg-brand-400/50 hover:!bg-brand-400/75 !text-white',
+    yellow: '!bg-yellow-600/50 hover:!bg-yellow-600/75 !text-yellow-900',
+    red: '!bg-red-400 hover:!bg-red-600 !text-white',
+  }[color]
+
+  const handlePrev = () => setCurrentIndex((i) => (i - 1 + visibleBanners.length) % visibleBanners.length)
+  const handleNext = () => setCurrentIndex((i) => (i + 1) % visibleBanners.length)
 
   const handleDismiss = () => {
-    setDismissedMessage(bannerData.message)
+    setDismissedMessages([...(dismissedMessages ?? []), getBannerKey(banner)])
+    if (safeIndex >= visibleBanners.length - 1) {
+      setCurrentIndex(Math.max(0, safeIndex - 1))
+    }
   }
 
   return (
@@ -41,10 +85,33 @@ export function AnnouncementBanner() {
       color={color}
       buttonLabel={hasActionButton ? buttonLabel : undefined}
       buttonIconRight={hasActionButton ? 'arrow-up-right-from-square' : undefined}
-      onClickButton={hasActionButton ? handleActionButtonClick : undefined}
+      onClickButton={hasActionButton ? () => window.open(buttonUrl, '_blank', 'noopener,noreferrer') : undefined}
       dismissible={dismissible}
       onDismiss={handleDismiss}
     >
+      {hasMultiple && (
+        <div className="absolute left-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+          <Button
+            type="button"
+            className={twMerge('!ml-0 flex h-6 w-6 items-center justify-center !p-0', buttonColorClass)}
+            onClick={handlePrev}
+            aria-label="Previous"
+          >
+            <Icon iconName="chevron-left" iconStyle="solid" />
+          </Button>
+          <span className="min-w-[28px] text-center text-xs">
+            {safeIndex + 1}/{visibleBanners.length}
+          </span>
+          <Button
+            type="button"
+            className={twMerge('!ml-0 flex h-6 w-6 items-center justify-center !p-0', buttonColorClass)}
+            onClick={handleNext}
+            aria-label="Next"
+          >
+            <Icon iconName="chevron-right" iconStyle="solid" />
+          </Button>
+        </div>
+      )}
       {title && <strong className="mr-2">{title}</strong>}
       {message}
     </Banner>

--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 import { Banner, Button, Icon } from '@qovery/shared/ui'
 import { useLocalStorage } from '@qovery/shared/util-hooks'
 import { twMerge } from '@qovery/shared/util-js'
@@ -19,10 +19,19 @@ const VARIANT_PRIORITY: Record<AnnouncementBannerPayload['variant'], number> = {
   info: 2,
 }
 
+const CONTROL_BUTTON_CLASSNAME = 'flex h-7 w-7 items-center justify-center p-0'
+const CONTROL_BUTTON_COLOR_CLASSNAME: Record<'brand' | 'yellow' | 'red', string> = {
+  brand: 'bg-brand-400/50 hover:bg-brand-400/75 text-white',
+  yellow: 'bg-yellow-600/50 hover:bg-yellow-600/75 text-yellow-900',
+  red: 'bg-red-400 hover:bg-red-600 text-white',
+}
+
 const LEGACY_DISMISSED_KEY = 'announcement_banner_dismissed'
 const DISMISSED_MESSAGES_KEY = 'announcement_banners_dismissed'
 
 function isLegacyDismissed(message: string): boolean {
+  if (typeof window === 'undefined') return false
+
   const raw = localStorage.getItem(LEGACY_DISMISSED_KEY)
   if (!raw) return false
   try {
@@ -41,14 +50,11 @@ export function AnnouncementBanner() {
   const [dismissedMessages, setDismissedMessages] = useLocalStorage<string[]>(DISMISSED_MESSAGES_KEY, [])
   const [currentIndex, setCurrentIndex] = useState(0)
 
-  const isBannerDismissed = useCallback(
-    (banner: AnnouncementBannerPayload): boolean => {
-      const key = getBannerKey(banner)
-      if (dismissedMessages?.includes(key)) return true
-      return isLegacyDismissed(banner.message)
-    },
-    [dismissedMessages]
-  )
+  function isBannerDismissed(banner: AnnouncementBannerPayload): boolean {
+    const key = getBannerKey(banner)
+    if (dismissedMessages?.includes(key)) return true
+    return isLegacyDismissed(banner.message)
+  }
 
   const visibleBanners = banners
     .filter((b) => !b.dismissible || !isBannerDismissed(b))
@@ -61,20 +67,21 @@ export function AnnouncementBanner() {
   const banner = visibleBanners[safeIndex]
   const { title, message, variant, dismissible, buttonLabel, buttonUrl } = banner
   const color = VARIANT_TO_COLOR_MAP[variant]
-  const hasActionButton = buttonLabel && buttonUrl
+  const hasActionButton = Boolean(buttonLabel && buttonUrl)
   const hasMultiple = visibleBanners.length > 1
-
-  const buttonColorClass = {
-    brand: '!bg-brand-400/50 hover:!bg-brand-400/75 !text-white',
-    yellow: '!bg-yellow-600/50 hover:!bg-yellow-600/75 !text-yellow-900',
-    red: '!bg-red-400 hover:!bg-red-600 !text-white',
-  }[color]
+  const usesBannerDismissButton = dismissible && !hasMultiple
+  const buttonColorClass = CONTROL_BUTTON_COLOR_CLASSNAME[color]
 
   const handlePrev = () => setCurrentIndex((i) => (i - 1 + visibleBanners.length) % visibleBanners.length)
   const handleNext = () => setCurrentIndex((i) => (i + 1) % visibleBanners.length)
 
   const handleDismiss = () => {
-    setDismissedMessages([...(dismissedMessages ?? []), getBannerKey(banner)])
+    const bannerKey = getBannerKey(banner)
+
+    if (!dismissedMessages?.includes(bannerKey)) {
+      setDismissedMessages([...(dismissedMessages ?? []), bannerKey])
+    }
+
     if (safeIndex >= visibleBanners.length - 1) {
       setCurrentIndex(Math.max(0, safeIndex - 1))
     }
@@ -86,40 +93,37 @@ export function AnnouncementBanner() {
       buttonLabel={hasActionButton ? buttonLabel : undefined}
       buttonIconRight={hasActionButton ? 'arrow-up-right-from-square' : undefined}
       onClickButton={hasActionButton ? () => window.open(buttonUrl, '_blank', 'noopener,noreferrer') : undefined}
-      dismissible={false}
+      dismissible={usesBannerDismissButton}
+      onDismiss={usesBannerDismissButton ? handleDismiss : undefined}
     >
       {title && <strong className="mr-2">{title}</strong>}
       {message}
-      {(hasMultiple || dismissible) && (
+      {hasMultiple && (
         <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
-          {hasMultiple && (
-            <>
-              <Button
-                type="button"
-                className={twMerge('!ml-0 flex h-7 w-7 items-center justify-center !p-0', buttonColorClass)}
-                onClick={handlePrev}
-                aria-label="Previous"
-              >
-                <Icon iconName="chevron-left" iconStyle="solid" />
-              </Button>
-              <span className="min-w-[28px] text-center text-xs">{safeIndex + 1}/{visibleBanners.length}</span>
-              <Button
-                type="button"
-                className={twMerge('!ml-0 flex h-7 w-7 items-center justify-center !p-0', buttonColorClass)}
-                onClick={handleNext}
-                aria-label="Next"
-              >
-                <Icon iconName="chevron-right" iconStyle="solid" />
-              </Button>
-            </>
-          )}
-          {hasMultiple && dismissible && (
-            <div className="mx-3 h-4 w-px opacity-20" style={{ backgroundColor: 'currentColor' }} />
-          )}
+          <Button
+            type="button"
+            className={twMerge(CONTROL_BUTTON_CLASSNAME, buttonColorClass)}
+            onClick={handlePrev}
+            aria-label="Previous"
+          >
+            <Icon iconName="chevron-left" iconStyle="solid" />
+          </Button>
+          <span className="min-w-[28px] text-center text-xs">
+            {safeIndex + 1}/{visibleBanners.length}
+          </span>
+          <Button
+            type="button"
+            className={twMerge(CONTROL_BUTTON_CLASSNAME, buttonColorClass)}
+            onClick={handleNext}
+            aria-label="Next"
+          >
+            <Icon iconName="chevron-right" iconStyle="solid" />
+          </Button>
+          {dismissible && <div className="mx-3 h-4 w-px bg-current opacity-20" />}
           {dismissible && (
             <Button
               type="button"
-              className={twMerge('!ml-0 flex h-7 w-7 items-center justify-center !p-0', buttonColorClass)}
+              className={twMerge(CONTROL_BUTTON_CLASSNAME, buttonColorClass)}
               onClick={handleDismiss}
               aria-label="Dismiss"
             >

--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Banner, Button, Icon } from '@qovery/shared/ui'
+import { BANNER_ICON_BUTTON_CLASSNAME, Banner, Button, Icon, bannerButtonVariants } from '@qovery/shared/ui'
 import { useLocalStorage } from '@qovery/shared/util-hooks'
 import { twMerge } from '@qovery/shared/util-js'
 import {
@@ -17,13 +17,6 @@ const VARIANT_PRIORITY: Record<AnnouncementBannerPayload['variant'], number> = {
   error: 0,
   warning: 1,
   info: 2,
-}
-
-const CONTROL_BUTTON_CLASSNAME = 'flex h-7 w-7 items-center justify-center p-0'
-const CONTROL_BUTTON_COLOR_CLASSNAME: Record<'brand' | 'yellow' | 'red', string> = {
-  brand: 'bg-brand-400/50 hover:bg-brand-400/75 text-white',
-  yellow: 'bg-yellow-600/50 hover:bg-yellow-600/75 text-yellow-900',
-  red: 'bg-red-400 hover:bg-red-600 text-white',
 }
 
 const LEGACY_DISMISSED_KEY = 'announcement_banner_dismissed'
@@ -48,7 +41,7 @@ function getBannerKey(banner: AnnouncementBannerPayload): string {
 export function AnnouncementBanner() {
   const banners = useAnnouncementBanner()
   const [dismissedMessages, setDismissedMessages] = useLocalStorage<string[]>(DISMISSED_MESSAGES_KEY, [])
-  const [currentIndex, setCurrentIndex] = useState(0)
+  const [selectedBannerKey, setSelectedBannerKey] = useState<string>()
 
   function isBannerDismissed(banner: AnnouncementBannerPayload): boolean {
     const key = getBannerKey(banner)
@@ -60,30 +53,42 @@ export function AnnouncementBanner() {
     .filter((b) => !b.dismissible || !isBannerDismissed(b))
     .sort((a, b) => VARIANT_PRIORITY[a.variant] - VARIANT_PRIORITY[b.variant])
 
-  const safeIndex = Math.min(currentIndex, Math.max(0, visibleBanners.length - 1))
-
   if (visibleBanners.length === 0) return null
 
-  const banner = visibleBanners[safeIndex]
+  const selectedBannerIndex =
+    selectedBannerKey === undefined
+      ? -1
+      : visibleBanners.findIndex((visibleBanner) => getBannerKey(visibleBanner) === selectedBannerKey)
+  const currentIndex = selectedBannerIndex === -1 ? 0 : selectedBannerIndex
+  const banner = visibleBanners[currentIndex]
   const { title, message, variant, dismissible, buttonLabel, buttonUrl } = banner
+  const currentBannerKey = getBannerKey(banner)
   const color = VARIANT_TO_COLOR_MAP[variant]
   const hasActionButton = Boolean(buttonLabel && buttonUrl)
   const hasMultiple = visibleBanners.length > 1
   const usesBannerDismissButton = dismissible && !hasMultiple
-  const buttonColorClass = CONTROL_BUTTON_COLOR_CLASSNAME[color]
 
-  const handlePrev = () => setCurrentIndex((i) => (i - 1 + visibleBanners.length) % visibleBanners.length)
-  const handleNext = () => setCurrentIndex((i) => (i + 1) % visibleBanners.length)
+  const handlePrev = () => {
+    const previousIndex = (currentIndex - 1 + visibleBanners.length) % visibleBanners.length
+    setSelectedBannerKey(getBannerKey(visibleBanners[previousIndex]))
+  }
+
+  const handleNext = () => {
+    const nextIndex = (currentIndex + 1) % visibleBanners.length
+    setSelectedBannerKey(getBannerKey(visibleBanners[nextIndex]))
+  }
 
   const handleDismiss = () => {
-    const bannerKey = getBannerKey(banner)
-
-    if (!dismissedMessages?.includes(bannerKey)) {
-      setDismissedMessages([...(dismissedMessages ?? []), bannerKey])
+    if (visibleBanners.length === 1) {
+      setSelectedBannerKey(undefined)
+    } else if (currentIndex >= visibleBanners.length - 1) {
+      setSelectedBannerKey(getBannerKey(visibleBanners[currentIndex - 1]))
+    } else {
+      setSelectedBannerKey(getBannerKey(visibleBanners[currentIndex + 1]))
     }
 
-    if (safeIndex >= visibleBanners.length - 1) {
-      setCurrentIndex(Math.max(0, safeIndex - 1))
+    if (!dismissedMessages?.includes(currentBannerKey)) {
+      setDismissedMessages([...(dismissedMessages ?? []), currentBannerKey])
     }
   }
 
@@ -102,32 +107,32 @@ export function AnnouncementBanner() {
         <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
           <Button
             type="button"
-            className={twMerge(CONTROL_BUTTON_CLASSNAME, buttonColorClass)}
+            className={twMerge(BANNER_ICON_BUTTON_CLASSNAME, bannerButtonVariants({ color }))}
             onClick={handlePrev}
             aria-label="Previous"
           >
-            <Icon iconName="chevron-left" iconStyle="solid" />
+            <Icon iconName="chevron-left" />
           </Button>
           <span className="min-w-[28px] text-center text-xs">
-            {safeIndex + 1}/{visibleBanners.length}
+            {currentIndex + 1}/{visibleBanners.length}
           </span>
           <Button
             type="button"
-            className={twMerge(CONTROL_BUTTON_CLASSNAME, buttonColorClass)}
+            className={twMerge(BANNER_ICON_BUTTON_CLASSNAME, bannerButtonVariants({ color }))}
             onClick={handleNext}
             aria-label="Next"
           >
-            <Icon iconName="chevron-right" iconStyle="solid" />
+            <Icon iconName="chevron-right" />
           </Button>
           {dismissible && <div className="mx-3 h-4 w-px bg-current opacity-20" />}
           {dismissible && (
             <Button
               type="button"
-              className={twMerge(CONTROL_BUTTON_CLASSNAME, buttonColorClass)}
+              className={twMerge(BANNER_ICON_BUTTON_CLASSNAME, bannerButtonVariants({ color }))}
               onClick={handleDismiss}
               aria-label="Dismiss"
             >
-              <Icon iconName="xmark" iconStyle="solid" />
+              <Icon iconName="xmark" />
             </Button>
           )}
         </div>

--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
@@ -86,34 +86,48 @@ export function AnnouncementBanner() {
       buttonLabel={hasActionButton ? buttonLabel : undefined}
       buttonIconRight={hasActionButton ? 'arrow-up-right-from-square' : undefined}
       onClickButton={hasActionButton ? () => window.open(buttonUrl, '_blank', 'noopener,noreferrer') : undefined}
-      dismissible={dismissible}
-      onDismiss={handleDismiss}
+      dismissible={false}
     >
-      {hasMultiple && (
-        <div className="absolute left-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
-          <Button
-            type="button"
-            className={twMerge('!ml-0 flex h-6 w-6 items-center justify-center !p-0', buttonColorClass)}
-            onClick={handlePrev}
-            aria-label="Previous"
-          >
-            <Icon iconName="chevron-left" iconStyle="solid" />
-          </Button>
-          <span className="min-w-[28px] text-center text-xs">
-            {safeIndex + 1}/{visibleBanners.length}
-          </span>
-          <Button
-            type="button"
-            className={twMerge('!ml-0 flex h-6 w-6 items-center justify-center !p-0', buttonColorClass)}
-            onClick={handleNext}
-            aria-label="Next"
-          >
-            <Icon iconName="chevron-right" iconStyle="solid" />
-          </Button>
-        </div>
-      )}
       {title && <strong className="mr-2">{title}</strong>}
       {message}
+      {(hasMultiple || dismissible) && (
+        <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
+          {hasMultiple && (
+            <>
+              <Button
+                type="button"
+                className={twMerge('!ml-0 flex h-7 w-7 items-center justify-center !p-0', buttonColorClass)}
+                onClick={handlePrev}
+                aria-label="Previous"
+              >
+                <Icon iconName="chevron-left" iconStyle="solid" />
+              </Button>
+              <span className="min-w-[28px] text-center text-xs">{safeIndex + 1}/{visibleBanners.length}</span>
+              <Button
+                type="button"
+                className={twMerge('!ml-0 flex h-7 w-7 items-center justify-center !p-0', buttonColorClass)}
+                onClick={handleNext}
+                aria-label="Next"
+              >
+                <Icon iconName="chevron-right" iconStyle="solid" />
+              </Button>
+            </>
+          )}
+          {hasMultiple && dismissible && (
+            <div className="mx-3 h-4 w-px opacity-20" style={{ backgroundColor: 'currentColor' }} />
+          )}
+          {dismissible && (
+            <Button
+              type="button"
+              className={twMerge('!ml-0 flex h-7 w-7 items-center justify-center !p-0', buttonColorClass)}
+              onClick={handleDismiss}
+              aria-label="Dismiss"
+            >
+              <Icon iconName="xmark" iconStyle="solid" />
+            </Button>
+          )}
+        </div>
+      )}
     </Banner>
   )
 }

--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { BANNER_ICON_BUTTON_CLASSNAME, Banner, Button, Icon, bannerButtonVariants } from '@qovery/shared/ui'
+import { Banner, Button, Icon, bannerButtonVariants } from '@qovery/shared/ui'
 import { useLocalStorage } from '@qovery/shared/util-hooks'
 import { twMerge } from '@qovery/shared/util-js'
 import {
@@ -18,6 +18,8 @@ const VARIANT_PRIORITY: Record<AnnouncementBannerPayload['variant'], number> = {
   warning: 1,
   info: 2,
 }
+
+const BANNER_ICON_BUTTON_CLASSNAME = 'flex h-7 w-7 items-center justify-center p-0'
 
 const LEGACY_DISMISSED_KEY = 'announcement_banner_dismissed'
 const DISMISSED_MESSAGES_KEY = 'announcement_banners_dismissed'

--- a/libs/shared/posthog/feature/src/lib/hooks/use-announcement-banner/use-announcement-banner.spec.ts
+++ b/libs/shared/posthog/feature/src/lib/hooks/use-announcement-banner/use-announcement-banner.spec.ts
@@ -8,6 +8,8 @@ jest.mock('posthog-js', () => ({
   onFeatureFlags: jest.fn(),
 }))
 
+const BANNER_FLAG = 'banners-annoucement'
+
 describe('useAnnouncementBanner', () => {
   const mockIsFeatureEnabled = posthog.isFeatureEnabled as jest.MockedFunction<typeof posthog.isFeatureEnabled>
   const mockGetFeatureFlagPayload = posthog.getFeatureFlagPayload as jest.MockedFunction<
@@ -19,129 +21,142 @@ describe('useAnnouncementBanner', () => {
     jest.clearAllMocks()
   })
 
-  it('should return null when feature flag is disabled', () => {
+  it('should return empty array when feature flag is disabled', () => {
     mockIsFeatureEnabled.mockReturnValue(false)
 
     const { result } = renderHook(() => useAnnouncementBanner())
 
-    expect(result.current).toBeNull()
-    expect(mockIsFeatureEnabled).toHaveBeenCalledWith('banner_announcement')
+    expect(result.current).toEqual([])
+    expect(mockIsFeatureEnabled).toHaveBeenCalledWith(BANNER_FLAG)
   })
 
-  it('should return null when payload is null', () => {
+  it('should return empty array when payload is null', () => {
     mockIsFeatureEnabled.mockReturnValue(true)
     mockGetFeatureFlagPayload.mockReturnValue(null)
 
     const { result } = renderHook(() => useAnnouncementBanner())
 
-    expect(result.current).toBeNull()
+    expect(result.current).toEqual([])
   })
 
-  it('should return null when payload is not an object', () => {
+  it('should return empty array when payload is not an array', () => {
     mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue('invalid payload' as never)
+    mockGetFeatureFlagPayload.mockReturnValue({ message: 'test', variant: 'info', dismissible: false } as never)
 
     const { result } = renderHook(() => useAnnouncementBanner())
 
-    expect(result.current).toBeNull()
+    expect(result.current).toEqual([])
   })
 
-  it('should return null when payload is missing required fields', () => {
+  it('should parse payload when returned as a JSON string', () => {
     mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      message: 'Test message',
-    } as never)
+    mockGetFeatureFlagPayload.mockReturnValue(
+      JSON.stringify([{ id: 'banner-1', message: 'Parsed banner', variant: 'info', dismissible: false }]) as never
+    )
 
     const { result } = renderHook(() => useAnnouncementBanner())
 
-    expect(result.current).toBeNull()
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].message).toBe('Parsed banner')
+    expect(result.current[0].id).toBe('banner-1')
   })
 
-  it('should return null when variant is invalid', () => {
+  it('should return empty array when payload is an invalid JSON string', () => {
     mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      message: 'Test message',
-      variant: 'invalid',
-      dismissible: true,
-    } as never)
+    mockGetFeatureFlagPayload.mockReturnValue('not valid json' as never)
 
     const { result } = renderHook(() => useAnnouncementBanner())
 
-    expect(result.current).toBeNull()
+    expect(result.current).toEqual([])
   })
 
-  it('should return banner data with info variant', () => {
+  it('should return empty array when payload is an empty array', () => {
     mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      title: 'Info Title',
-      message: 'Info message',
-      variant: 'info',
-      dismissible: true,
-    })
+    mockGetFeatureFlagPayload.mockReturnValue([] as never)
 
     const { result } = renderHook(() => useAnnouncementBanner())
 
-    expect(result.current).toEqual({
-      title: 'Info Title',
-      message: 'Info message',
-      variant: 'info',
-      dismissible: true,
-    })
+    expect(result.current).toEqual([])
   })
 
-  it('should return banner data with warning variant', () => {
+  it('should return valid banners from array payload', () => {
     mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      message: 'Warning message',
-      variant: 'warning',
-      dismissible: false,
-    })
+    mockGetFeatureFlagPayload.mockReturnValue([
+      { title: 'Kubernetes Upgrade', message: 'Upgrade available', variant: 'info', dismissible: true },
+      { message: 'Maintenance window', variant: 'warning', dismissible: false },
+    ] as never)
 
     const { result } = renderHook(() => useAnnouncementBanner())
 
-    expect(result.current).toEqual({
+    expect(result.current).toEqual([
+      {
+        title: 'Kubernetes Upgrade',
+        message: 'Upgrade available',
+        variant: 'info',
+        dismissible: true,
+        buttonLabel: undefined,
+        buttonUrl: undefined,
+      },
+      {
+        title: undefined,
+        message: 'Maintenance window',
+        variant: 'warning',
+        dismissible: false,
+        buttonLabel: undefined,
+        buttonUrl: undefined,
+      },
+    ])
+  })
+
+  it('should skip invalid items in the array', () => {
+    mockIsFeatureEnabled.mockReturnValue(true)
+    mockGetFeatureFlagPayload.mockReturnValue([
+      { message: 'Valid banner', variant: 'info', dismissible: false },
+      { message: 'Missing variant', dismissible: false },
+      null,
+      { message: 'Invalid variant', variant: 'unknown', dismissible: true },
+    ] as never)
+
+    const { result } = renderHook(() => useAnnouncementBanner())
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].message).toBe('Valid banner')
+  })
+
+  it('should return banner with optional buttonLabel and buttonUrl', () => {
+    mockIsFeatureEnabled.mockReturnValue(true)
+    mockGetFeatureFlagPayload.mockReturnValue([
+      {
+        message: 'New feature',
+        variant: 'info',
+        dismissible: false,
+        buttonLabel: 'Have a look',
+        buttonUrl: 'https://docs.qovery.com',
+      },
+    ] as never)
+
+    const { result } = renderHook(() => useAnnouncementBanner())
+
+    expect(result.current[0]).toEqual({
       title: undefined,
-      message: 'Warning message',
-      variant: 'warning',
+      message: 'New feature',
+      variant: 'info',
       dismissible: false,
+      buttonLabel: 'Have a look',
+      buttonUrl: 'https://docs.qovery.com',
     })
   })
 
-  it('should return banner data with error variant', () => {
+  it('should ignore non-string buttonLabel and buttonUrl', () => {
     mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      title: 'Error Title',
-      message: 'Error message',
-      variant: 'error',
-      dismissible: true,
-    })
+    mockGetFeatureFlagPayload.mockReturnValue([
+      { message: 'Test', variant: 'info', dismissible: false, buttonLabel: 123, buttonUrl: true },
+    ] as never)
 
     const { result } = renderHook(() => useAnnouncementBanner())
 
-    expect(result.current).toEqual({
-      title: 'Error Title',
-      message: 'Error message',
-      variant: 'error',
-      dismissible: true,
-    })
-  })
-
-  it('should return banner data without title when title is not provided', () => {
-    mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      message: 'Message only',
-      variant: 'info',
-      dismissible: false,
-    })
-
-    const { result } = renderHook(() => useAnnouncementBanner())
-
-    expect(result.current).toEqual({
-      title: undefined,
-      message: 'Message only',
-      variant: 'info',
-      dismissible: false,
-    })
+    expect(result.current[0].buttonLabel).toBeUndefined()
+    expect(result.current[0].buttonUrl).toBeUndefined()
   })
 
   it('should register feature flag listener', () => {
@@ -150,82 +165,5 @@ describe('useAnnouncementBanner', () => {
     renderHook(() => useAnnouncementBanner())
 
     expect(mockOnFeatureFlags).toHaveBeenCalled()
-  })
-
-  it('should return null when dismissible is not a boolean', () => {
-    mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      message: 'Test message',
-      variant: 'info',
-      dismissible: 'true',
-    } as never)
-
-    const { result } = renderHook(() => useAnnouncementBanner())
-
-    expect(result.current).toBeNull()
-  })
-
-  it('should return banner data with optional buttonLabel and buttonUrl', () => {
-    mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      message: 'New feature available',
-      variant: 'info',
-      dismissible: false,
-      buttonLabel: 'Learn more',
-      buttonUrl: 'https://docs.qovery.com',
-    })
-
-    const { result } = renderHook(() => useAnnouncementBanner())
-
-    expect(result.current).toEqual({
-      title: undefined,
-      message: 'New feature available',
-      variant: 'info',
-      dismissible: false,
-      buttonLabel: 'Learn more',
-      buttonUrl: 'https://docs.qovery.com',
-    })
-  })
-
-  it('should return banner data without button fields when not provided', () => {
-    mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      message: 'Simple message',
-      variant: 'warning',
-      dismissible: true,
-    })
-
-    const { result } = renderHook(() => useAnnouncementBanner())
-
-    expect(result.current).toEqual({
-      title: undefined,
-      message: 'Simple message',
-      variant: 'warning',
-      dismissible: true,
-      buttonLabel: undefined,
-      buttonUrl: undefined,
-    })
-  })
-
-  it('should ignore non-string buttonLabel and buttonUrl', () => {
-    mockIsFeatureEnabled.mockReturnValue(true)
-    mockGetFeatureFlagPayload.mockReturnValue({
-      message: 'Test message',
-      variant: 'info',
-      dismissible: false,
-      buttonLabel: 123,
-      buttonUrl: true,
-    } as never)
-
-    const { result } = renderHook(() => useAnnouncementBanner())
-
-    expect(result.current).toEqual({
-      title: undefined,
-      message: 'Test message',
-      variant: 'info',
-      dismissible: false,
-      buttonLabel: undefined,
-      buttonUrl: undefined,
-    })
   })
 })

--- a/libs/shared/posthog/feature/src/lib/hooks/use-announcement-banner/use-announcement-banner.ts
+++ b/libs/shared/posthog/feature/src/lib/hooks/use-announcement-banner/use-announcement-banner.ts
@@ -2,6 +2,7 @@ import posthog from 'posthog-js'
 import { useEffect, useState } from 'react'
 
 export interface AnnouncementBannerPayload {
+  id?: string
   title?: string
   message: string
   variant: 'info' | 'warning' | 'error'
@@ -10,45 +11,64 @@ export interface AnnouncementBannerPayload {
   buttonUrl?: string
 }
 
-export function useAnnouncementBanner() {
-  const [bannerData, setBannerData] = useState<AnnouncementBannerPayload | null>(null)
+const BANNER_FLAG = 'banners-annoucement'
+
+function validateBannerItem(item: unknown): AnnouncementBannerPayload | null {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return null
+
+  const p = item as Record<string, unknown>
+
+  if (
+    typeof p['message'] === 'string' &&
+    (p['variant'] === 'info' || p['variant'] === 'warning' || p['variant'] === 'error') &&
+    typeof p['dismissible'] === 'boolean'
+  ) {
+    return {
+      id: typeof p['id'] === 'string' ? p['id'] : undefined,
+      title: typeof p['title'] === 'string' ? p['title'] : undefined,
+      message: p['message'],
+      variant: p['variant'],
+      dismissible: p['dismissible'],
+      buttonLabel: typeof p['buttonLabel'] === 'string' ? p['buttonLabel'] : undefined,
+      buttonUrl: typeof p['buttonUrl'] === 'string' ? p['buttonUrl'] : undefined,
+    }
+  }
+
+  return null
+}
+
+export function useAnnouncementBanner(): AnnouncementBannerPayload[] {
+  const [banners, setBanners] = useState<AnnouncementBannerPayload[]>([])
 
   useEffect(() => {
     const checkBanner = () => {
-      const isEnabled = posthog.isFeatureEnabled('banner_announcement')
+      const isEnabled = posthog.isFeatureEnabled(BANNER_FLAG)
 
       if (!isEnabled) {
-        setBannerData(null)
+        setBanners([])
         return
       }
 
-      const payload = posthog.getFeatureFlagPayload('banner_announcement')
+      const rawPayload = posthog.getFeatureFlagPayload(BANNER_FLAG)
 
-      if (!payload || typeof payload !== 'object') {
-        setBannerData(null)
+      let payload: unknown = rawPayload
+      if (typeof rawPayload === 'string') {
+        try {
+          payload = JSON.parse(rawPayload)
+        } catch {
+          setBanners([])
+          return
+        }
+      }
+
+      if (!Array.isArray(payload)) {
+        setBanners([])
         return
       }
 
-      const typedPayload = payload as Record<string, unknown>
+      const validBanners = payload.map(validateBannerItem).filter((b): b is AnnouncementBannerPayload => b !== null)
 
-      if (
-        typeof typedPayload['message'] === 'string' &&
-        (typedPayload['variant'] === 'info' ||
-          typedPayload['variant'] === 'warning' ||
-          typedPayload['variant'] === 'error') &&
-        typeof typedPayload['dismissible'] === 'boolean'
-      ) {
-        setBannerData({
-          title: typeof typedPayload['title'] === 'string' ? typedPayload['title'] : undefined,
-          message: typedPayload['message'],
-          variant: typedPayload['variant'],
-          dismissible: typedPayload['dismissible'],
-          buttonLabel: typeof typedPayload['buttonLabel'] === 'string' ? typedPayload['buttonLabel'] : undefined,
-          buttonUrl: typeof typedPayload['buttonUrl'] === 'string' ? typedPayload['buttonUrl'] : undefined,
-        })
-      } else {
-        setBannerData(null)
-      }
+      setBanners(validBanners)
     }
 
     checkBanner()
@@ -56,5 +76,5 @@ export function useAnnouncementBanner() {
     posthog.onFeatureFlags(checkBanner)
   }, [])
 
-  return bannerData
+  return banners
 }

--- a/libs/shared/ui/src/lib/components/banner/banner.tsx
+++ b/libs/shared/ui/src/lib/components/banner/banner.tsx
@@ -18,8 +18,6 @@ const bannerVariants = cva('flex h-10 items-center justify-center text-sm font-m
 
 export type BannerColor = NonNullable<VariantProps<typeof bannerVariants>['color']>
 
-export const BANNER_ICON_BUTTON_CLASSNAME = 'flex h-7 w-7 items-center justify-center p-0'
-
 export const bannerButtonVariants = cva('', {
   variants: {
     color: {
@@ -60,8 +58,7 @@ export const Banner = forwardRef<HTMLDivElement, PropsWithChildren<BannerProps>>
         <Button
           type="button"
           className={twMerge(
-            'absolute right-2 top-1/2 -translate-y-1/2',
-            BANNER_ICON_BUTTON_CLASSNAME,
+            'absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center p-0',
             bannerButtonVariants({ color })
           )}
           onClick={onDismiss}

--- a/libs/shared/ui/src/lib/components/banner/banner.tsx
+++ b/libs/shared/ui/src/lib/components/banner/banner.tsx
@@ -16,13 +16,17 @@ const bannerVariants = cva('flex h-10 items-center justify-center text-sm font-m
   },
 })
 
-const buttonVariants = cva('ml-4', {
+export type BannerColor = NonNullable<VariantProps<typeof bannerVariants>['color']>
+
+export const BANNER_ICON_BUTTON_CLASSNAME = 'flex h-7 w-7 items-center justify-center p-0'
+
+export const bannerButtonVariants = cva('', {
   variants: {
     color: {
-      brand: ['!bg-brand-400/50', 'hover:!bg-brand-400/75', '!text-white'],
-      yellow: ['!bg-yellow-600/50', 'hover:!bg-yellow-600/75', '!text-yellow-900'],
-      purple: ['!bg-purple-400', 'hover:!bg-purple-600', '!text-white'],
-      red: ['!bg-red-400', 'hover:!bg-red-600', '!text-white'],
+      brand: ['bg-brand-400/50', 'hover:bg-brand-400/75', 'text-white'],
+      yellow: ['bg-yellow-600/50', 'hover:bg-yellow-600/75', 'text-yellow-900'],
+      purple: ['bg-purple-400', 'hover:bg-purple-600', 'text-white'],
+      red: ['bg-red-400', 'hover:bg-red-600', 'text-white'],
     },
   },
 })
@@ -43,7 +47,11 @@ export const Banner = forwardRef<HTMLDivElement, PropsWithChildren<BannerProps>>
     <div className={twMerge(bannerVariants({ color }), 'relative')} ref={forwardedRef}>
       {children}
       {buttonLabel && (
-        <Button type="button" className={twMerge('gap-1', buttonVariants({ color }))} onClick={onClickButton}>
+        <Button
+          type="button"
+          className={twMerge('ml-4 gap-1', bannerButtonVariants({ color }))}
+          onClick={onClickButton}
+        >
           {buttonLabel}
           {buttonIconRight && <Icon iconName={buttonIconRight} />}
         </Button>
@@ -52,8 +60,9 @@ export const Banner = forwardRef<HTMLDivElement, PropsWithChildren<BannerProps>>
         <Button
           type="button"
           className={twMerge(
-            'absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 justify-center',
-            buttonVariants({ color })
+            'absolute right-2 top-1/2 -translate-y-1/2',
+            BANNER_ICON_BUTTON_CLASSNAME,
+            bannerButtonVariants({ color })
           )}
           onClick={onDismiss}
           aria-label="Dismiss"


### PR DESCRIPTION
This PR introduces support for displaying multiple banners in the product instead of being limited to a single banner at a time.

Changes Included:

- Updated the PostHog banner payload structure to accept multiple banners.
- Added frontend support for rendering multiple banners in a carousel.
- Implemented banner prioritization order:
  - Error
  - Warning
  - Info
- Updated local storage logic to manage dismissal state individually for each banner.
- Added conditional carousel behavior:
  - If multiple banners are present, they are displayed in the carousel.
  - If only one banner is present, it is displayed as a standard standalone banner without carousel navigation

## Summary

**Issue**: QOV-1822

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="2210" height="792" alt="image" src="https://github.com/user-attachments/assets/6aaa655e-cc79-48c1-a4fc-a4827e1b077d" />| <img width="2210" height="604" alt="image" src="https://github.com/user-attachments/assets/3a431908-1047-4ea5-b248-70064ede0b66" /> |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
