### PR TITLE
feat(organization-banners): add organization-specific banners for Qovery admin users

### DIFF
--- a/apps/console-v5/src/app/components/organization-banners/organization-banners.tsx
+++ b/apps/console-v5/src/app/components/organization-banners/organization-banners.tsx
@@ -1,0 +1,31 @@
+import { useParams } from '@tanstack/react-router'
+import { useOrganization } from '@qovery/domains/organizations/feature'
+import { useUserRole } from '@qovery/shared/iam/feature'
+import { AnnouncementBanner } from '@qovery/shared/posthog/feature'
+import { Banner } from '@qovery/shared/ui'
+
+export function OrganizationBanners() {
+  const { organizationId = '' } = useParams({ strict: false })
+  const { data: organization } = useOrganization({ organizationId, enabled: !!organizationId })
+  const { roles, isQoveryAdminUser } = useUserRole()
+
+  const displayQoveryAdminBanner = (() => {
+    if (isQoveryAdminUser) {
+      const checkIfUserHasOrganization = roles.some((org) => org.includes(organizationId)) ?? true
+      return !checkIfUserHasOrganization
+    }
+    return false
+  })()
+
+  return (
+    <>
+      {displayQoveryAdminBanner ? (
+        <Banner color="yellow">
+          Qovery admin message - This organization is a customer (<b>{organization?.name}</b>), please be careful with
+          actions.
+        </Banner>
+      ) : null}
+      <AnnouncementBanner />
+    </>
+  )
+}

--- a/apps/console-v5/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/route.tsx
@@ -8,6 +8,7 @@ import { DevopsCopilotTrigger } from '@qovery/shared/devops-copilot/feature'
 import { ErrorBoundary, Icon, LoaderSpinner, Navbar } from '@qovery/shared/ui'
 import { queries } from '@qovery/state/util-queries'
 import Header from '../../../app/components/header/header'
+import { OrganizationBanners } from '../../../app/components/organization-banners/organization-banners'
 import { type FileRouteTypes } from '../../../routeTree.gen'
 
 export const Route = createFileRoute('/_authenticated/organization')({
@@ -494,6 +495,7 @@ function OrganizationRoute() {
         {/* TODO: Conflicts with body main:not(.h-screen, .layout-onboarding) */}
         <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-auto">
           <ErrorBoundary>
+            <OrganizationBanners />
             <Header />
 
             <Suspense fallback={<MainLoader />}>

--- a/libs/shared/ui/src/lib/components/banner/banner.tsx
+++ b/libs/shared/ui/src/lib/components/banner/banner.tsx
@@ -42,7 +42,7 @@ export const Banner = forwardRef<HTMLDivElement, PropsWithChildren<BannerProps>>
     <div className={twMerge(bannerVariants({ color }), 'relative', className)} ref={forwardedRef} {...props}>
       {children}
       {buttonLabel && (
-        <Button type="button" className="ml-4 gap-1" variant="solid" color={color} onClick={onClickButton}>
+        <Button type="button" className="ml-4 gap-1" variant="surface" color={color} onClick={onClickButton}>
           {buttonLabel}
           {buttonIconRight && <Icon iconName={buttonIconRight} />}
         </Button>


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Add "admin" and information banners 

## Screenshots / Recordings

<img width="1464" height="877" alt="Screenshot 2026-04-09 at 18 10 33" src="https://github.com/user-attachments/assets/fa2779f9-3eaa-4a29-8570-08fb39ad66de" />

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
