### PR TITLE
feat(eks-anywhere): add cluster backup configuration and hide extra tags

### DIFF
--- a/apps/console-v5/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
@@ -103,7 +103,7 @@ function ClusterGeneralSettingsForm({ cluster }: { cluster: Cluster }) {
               <BlockContent title="General information">
                 <ClusterGeneralSettings fromDetail />
               </BlockContent>
-              {cluster.cloud_provider === 'AWS' && (
+              {cluster.cloud_provider === 'AWS' && cluster.installation_type !== 'PARTIALLY_MANAGED' && (
                 <Section className="mb-10 gap-3">
                   <Heading>Extra tags</Heading>
                   <LabelSetting filterPropagateToCloudProvider={true} />

--- a/apps/console-v5/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useParams } from '@tanstack/react-router'
-import { type Cluster } from 'qovery-typescript-axios'
+import { type Cluster, KubernetesEnum } from 'qovery-typescript-axios'
 import { type FieldValues, FormProvider, useForm } from 'react-hook-form'
 import { ClusterGeneralSettings, useCluster, useEditCluster } from '@qovery/domains/clusters/feature'
 import { LabelSetting } from '@qovery/domains/organizations/feature'
@@ -103,7 +103,7 @@ function ClusterGeneralSettingsForm({ cluster }: { cluster: Cluster }) {
               <BlockContent title="General information">
                 <ClusterGeneralSettings fromDetail />
               </BlockContent>
-              {cluster.cloud_provider === 'AWS' && cluster.installation_type !== 'PARTIALLY_MANAGED' && (
+              {cluster.cloud_provider === 'AWS' && cluster.kubernetes !== KubernetesEnum.PARTIALLY_MANAGED && (
                 <Section className="mb-10 gap-3">
                   <Heading>Extra tags</Heading>
                   <LabelSetting filterPropagateToCloudProvider={true} />

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
@@ -236,7 +236,7 @@ export function StepGeneral({ organizationId, onSubmit, labelsSetting }: StepGen
               )}
             </Section>
 
-            {watchCloudProvider === 'AWS' && (
+            {watchCloudProvider === 'AWS' && watchInstallationType !== 'PARTIALLY_MANAGED' && (
               <Section className="mb-10 gap-3">
                 <Heading>Extra tags</Heading>
                 {labelsSetting}

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
@@ -52,6 +52,9 @@ function SubnetsList({ title, index, subnets }: { title: string; index: string; 
 }
 
 export function StepSummaryPresentation(props: StepSummaryPresentationProps) {
+  const clusterBackup = props.resourcesData.infrastructure_charts_parameters?.eks_anywhere_parameters?.cluster_backup
+  const showClusterBackup = Boolean(clusterBackup?.enabled)
+
   const checkIfFeaturesAvailable = () => {
     const feature = []
 
@@ -324,36 +327,31 @@ export function StepSummaryPresentation(props: StepSummaryPresentationProps) {
                       </ul>
                     </div>
 
-                    {(() => {
-                      const clusterBackup =
-                        props.resourcesData.infrastructure_charts_parameters?.eks_anywhere_parameters?.cluster_backup
-                      if (!clusterBackup?.enabled) return null
-                      return (
-                        <div>
-                          <span className="text-sm font-bold text-neutral-subtle">Backup</span>
-                          <ul className="list-none space-y-2 text-sm text-neutral-subtle">
+                    {showClusterBackup && (
+                      <div>
+                        <span className="text-sm font-bold text-neutral-subtle">Backup</span>
+                        <ul className="list-none space-y-2 text-sm text-neutral-subtle">
+                          <li>
+                            <span className="font-medium">Bucket: </span>
+                            {clusterBackup?.s3?.bucket}
+                          </li>
+                          <li>
+                            <span className="font-medium">Region: </span>
+                            {clusterBackup?.s3?.region}
+                          </li>
+                          <li>
+                            <span className="font-medium">Role ARN: </span>
+                            {clusterBackup?.s3?.role_arn}
+                          </li>
+                          {clusterBackup?.s3?.key_prefix && (
                             <li>
-                              <span className="font-medium">Bucket: </span>
-                              {clusterBackup.s3?.bucket}
+                              <span className="font-medium">Key prefix: </span>
+                              {clusterBackup.s3.key_prefix}
                             </li>
-                            <li>
-                              <span className="font-medium">Region: </span>
-                              {clusterBackup.s3?.region}
-                            </li>
-                            <li>
-                              <span className="font-medium">Role ARN: </span>
-                              {clusterBackup.s3?.role_arn}
-                            </li>
-                            {clusterBackup.s3?.key_prefix && (
-                              <li>
-                                <span className="font-medium">Key prefix: </span>
-                                {clusterBackup.s3.key_prefix}
-                              </li>
-                            )}
-                          </ul>
-                        </div>
-                      )
-                    })()}
+                          )}
+                        </ul>
+                      </div>
+                    )}
 
                     <div>
                       <span className="text-sm font-bold text-neutral-subtle">Cert Manager</span>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
@@ -324,6 +324,37 @@ export function StepSummaryPresentation(props: StepSummaryPresentationProps) {
                       </ul>
                     </div>
 
+                    {(() => {
+                      const clusterBackup =
+                        props.resourcesData.infrastructure_charts_parameters?.eks_anywhere_parameters?.cluster_backup
+                      if (!clusterBackup?.enabled) return null
+                      return (
+                        <div>
+                          <span className="text-sm font-bold text-neutral-subtle">Backup</span>
+                          <ul className="list-none space-y-2 text-sm text-neutral-subtle">
+                            <li>
+                              <span className="font-medium">Bucket: </span>
+                              {clusterBackup.s3?.bucket}
+                            </li>
+                            <li>
+                              <span className="font-medium">Region: </span>
+                              {clusterBackup.s3?.region}
+                            </li>
+                            <li>
+                              <span className="font-medium">Role ARN: </span>
+                              {clusterBackup.s3?.role_arn}
+                            </li>
+                            {clusterBackup.s3?.key_prefix && (
+                              <li>
+                                <span className="font-medium">Key prefix: </span>
+                                {clusterBackup.s3.key_prefix}
+                              </li>
+                            )}
+                          </ul>
+                        </div>
+                      )
+                    })()}
+
                     <div>
                       <span className="text-sm font-bold text-neutral-subtle">Cert Manager</span>
                       <ul className="list-none space-y-2 text-sm text-neutral-subtle">

--- a/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings-form.utils.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings-form.utils.ts
@@ -84,6 +84,7 @@ export const getInfrastructureChartsParametersWithEksAnywhereGit = (
         provider: data.provider ?? currentEksAnywhereParameters?.git_repository?.provider,
       },
       yaml_file_path: yamlFilePath,
+      cluster_backup: data.infrastructure_charts_parameters?.eks_anywhere_parameters?.cluster_backup,
     },
   }
 }

--- a/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings.spec.tsx
@@ -13,13 +13,14 @@ describe('ClusterEksSettings', () => {
     expect(baseElement).toBeTruthy()
   })
 
-  it('should have 4 sections', () => {
+  it('should have 5 sections', () => {
     const { baseElement } = render(<ClusterEksSettings />)
     const sections = baseElement.querySelectorAll('section')
-    expect(sections).toHaveLength(4)
+    expect(sections).toHaveLength(5)
     expect(sections[0]).toHaveTextContent('Infrastructure charts source')
-    expect(sections[1]).toHaveTextContent('Cert Manager')
-    expect(sections[2]).toHaveTextContent('MetalLB')
-    expect(sections[3]).toHaveTextContent('Nginx')
+    expect(sections[1]).toHaveTextContent('Backup')
+    expect(sections[2]).toHaveTextContent('Cert Manager')
+    expect(sections[3]).toHaveTextContent('MetalLB')
+    expect(sections[4]).toHaveTextContent('Nginx')
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings.tsx
@@ -57,6 +57,8 @@ export const ClusterEksSettings = ({ gitSettings }: ClusterEksSettingsProps) => 
               onChange={field.onChange}
               title="Enable backup"
               description="Enable periodic backup of the EKS Anywhere cluster state to S3."
+              align="top"
+              small
             />
           )}
         />

--- a/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
-import { Heading, InputText, Section } from '@qovery/shared/ui'
+import { Controller, useFormContext, useWatch } from 'react-hook-form'
+import { Heading, InputText, InputToggle, Section } from '@qovery/shared/ui'
 import { type ClusterEksSettingsFormData } from './cluster-eks-settings-form.utils'
 
 export interface ClusterEksSettingsProps {
@@ -9,6 +9,10 @@ export interface ClusterEksSettingsProps {
 
 export const ClusterEksSettings = ({ gitSettings }: ClusterEksSettingsProps) => {
   const { control } = useFormContext<ClusterEksSettingsFormData>()
+  const backupEnabled = useWatch({
+    control,
+    name: 'infrastructure_charts_parameters.eks_anywhere_parameters.cluster_backup.enabled',
+  })
 
   return (
     <>
@@ -20,6 +24,113 @@ export const ClusterEksSettings = ({ gitSettings }: ClusterEksSettingsProps) => 
           </p>
         </div>
         {gitSettings}
+      </Section>
+
+      <Section className="gap-4">
+        <div className="space-y-1">
+          <Heading>Backup</Heading>
+          <p className="text-sm text-neutral-subtle">Configure the backup of your EKS Anywhere cluster.</p>
+        </div>
+
+        <Controller
+          name="infrastructure_charts_parameters.eks_anywhere_parameters.cluster_backup.enabled"
+          control={control}
+          render={({ field }) => (
+            <InputToggle
+              name={field.name}
+              value={field.value ?? false}
+              onChange={field.onChange}
+              title="Enable backup"
+              description="Enable periodic backup of the EKS Anywhere cluster state to S3."
+            />
+          )}
+        />
+
+        {backupEnabled && (
+          <>
+            <div className="space-y-1">
+              <Heading>S3</Heading>
+              <p className="text-sm text-neutral-subtle">S3 bucket configuration for backup artifacts.</p>
+            </div>
+
+            <Controller
+              name="infrastructure_charts_parameters.eks_anywhere_parameters.cluster_backup.s3.bucket"
+              control={control}
+              rules={{ required: 'Please enter a S3 bucket name.' }}
+              render={({ field, fieldState: { error } }) => (
+                <InputText
+                  dataTestId="input-backup-s3-bucket"
+                  type="text"
+                  name={field.name}
+                  value={field.value}
+                  onChange={(e) => {
+                    field.onChange(e.target.value)
+                  }}
+                  label="Bucket"
+                  error={error?.message}
+                />
+              )}
+            />
+
+            <Controller
+              name="infrastructure_charts_parameters.eks_anywhere_parameters.cluster_backup.s3.region"
+              control={control}
+              rules={{ required: 'Please enter a S3 region.' }}
+              render={({ field, fieldState: { error } }) => (
+                <InputText
+                  dataTestId="input-backup-s3-region"
+                  type="text"
+                  name={field.name}
+                  value={field.value}
+                  onChange={(e) => {
+                    field.onChange(e.target.value)
+                  }}
+                  label="Region"
+                  error={error?.message}
+                />
+              )}
+            />
+
+            <Controller
+              name="infrastructure_charts_parameters.eks_anywhere_parameters.cluster_backup.s3.role_arn"
+              control={control}
+              rules={{ required: 'Please enter an IAM role ARN.' }}
+              render={({ field, fieldState: { error } }) => (
+                <InputText
+                  dataTestId="input-backup-s3-role-arn"
+                  type="text"
+                  name={field.name}
+                  value={field.value}
+                  onChange={(e) => {
+                    field.onChange(e.target.value)
+                  }}
+                  label="Role ARN"
+                  hint="IAM role ARN assumed to upload backup artifacts."
+                  error={error?.message}
+                />
+              )}
+            />
+
+            <Controller
+              name="infrastructure_charts_parameters.eks_anywhere_parameters.cluster_backup.s3.key_prefix"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <InputText
+                  dataTestId="input-backup-s3-key-prefix"
+                  type="text"
+                  name={field.name}
+                  value={field.value}
+                  onChange={(e) => {
+                    field.onChange(e.target.value)
+                  }}
+                  label="Key prefix"
+                  hint="Optional S3 key prefix used for backup object keys."
+                  error={error?.message}
+                />
+              )}
+            />
+          </>
+        )}
       </Section>
 
       <Section className="gap-4">

--- a/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-eks-settings/cluster-eks-settings.tsx
@@ -1,6 +1,9 @@
-import { type ReactNode } from 'react'
+import { type ClusterRegion } from 'qovery-typescript-axios'
+import { type ReactNode, useMemo } from 'react'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
-import { Heading, InputText, InputToggle, Section } from '@qovery/shared/ui'
+import { useCloudProviders } from '@qovery/domains/cloud-providers/feature'
+import { type Value } from '@qovery/shared/interfaces'
+import { Heading, IconFlag, InputSelect, InputText, InputToggle, Section } from '@qovery/shared/ui'
 import { type ClusterEksSettingsFormData } from './cluster-eks-settings-form.utils'
 
 export interface ClusterEksSettingsProps {
@@ -13,6 +16,18 @@ export const ClusterEksSettings = ({ gitSettings }: ClusterEksSettingsProps) => 
     control,
     name: 'infrastructure_charts_parameters.eks_anywhere_parameters.cluster_backup.enabled',
   })
+
+  const { data: cloudProviders = [] } = useCloudProviders()
+  const awsRegions: Value[] = useMemo(() => {
+    const awsProvider = cloudProviders.find((p) => p.short_name === 'AWS')
+    return (
+      awsProvider?.regions?.map((region: ClusterRegion) => ({
+        label: `${region.city} (${region.name})`,
+        value: region.name,
+        icon: <IconFlag code={region.country_code} />,
+      })) ?? []
+    )
+  }, [cloudProviders])
 
   return (
     <>
@@ -75,18 +90,17 @@ export const ClusterEksSettings = ({ gitSettings }: ClusterEksSettingsProps) => 
             <Controller
               name="infrastructure_charts_parameters.eks_anywhere_parameters.cluster_backup.s3.region"
               control={control}
-              rules={{ required: 'Please enter a S3 region.' }}
+              rules={{ required: 'Please select a S3 region.' }}
               render={({ field, fieldState: { error } }) => (
-                <InputText
+                <InputSelect
                   dataTestId="input-backup-s3-region"
-                  type="text"
-                  name={field.name}
                   value={field.value}
-                  onChange={(e) => {
-                    field.onChange(e.target.value)
-                  }}
+                  onChange={field.onChange}
                   label="Region"
+                  options={awsRegions}
                   error={error?.message}
+                  isSearchable
+                  portal
                 />
               )}
             />

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mermaid": "11.6.0",
     "monaco-editor": "0.53.0",
     "posthog-js": "1.260.1",
-    "qovery-typescript-axios": "1.1.858",
+    "qovery-typescript-axios": "1.1.859",
     "react": "18.3.1",
     "react-country-flag": "3.0.2",
     "react-datepicker": "4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6152,7 +6152,7 @@ __metadata:
     prettier: 3.2.5
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
-    qovery-typescript-axios: 1.1.858
+    qovery-typescript-axios: 1.1.859
     qovery-ws-typescript-axios: 0.1.506
     react: 18.3.1
     react-country-flag: 3.0.2
@@ -26056,12 +26056,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:1.1.858":
-  version: 1.1.858
-  resolution: "qovery-typescript-axios@npm:1.1.858"
+"qovery-typescript-axios@npm:1.1.859":
+  version: 1.1.859
+  resolution: "qovery-typescript-axios@npm:1.1.859"
   dependencies:
     axios: 1.12.2
-  checksum: b6f8e62fe69c54c63efa904edbcb4d1536b75861b261990843d13f12f9e646ca66c42c57a4a501eb9cec92e9ca72614ea4c5a8104d933f2ab715a2990ce189e1
+  checksum: 99eeba75ea9abb584fde40f033e8794e2e123cda08acfedda73ce37cc47a9f574cf557e90e9c0fb0581ddc8998a0f96dccaafd98fb0c6b7a7069ca833ad9e3ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION



## Summary

Add backup configuration support for EKS Anywhere clusters

 Hide Extra tags section for PARTIALLY_MANAGED (EKS Anywhere) clusters in both creation flow and cluster settings
  
  
<img width="936" height="895" alt="Screenshot 2026-04-10 at 13 57 01" src="https://github.com/user-attachments/assets/4a1e874f-1e1a-4ed1-8486-f40197573007" />
http://localhost:4200/organization/148bff50-453d-4111-8353-915bd6ec08b3/cluster/eb77465e-a1b2-4c62-aa1c-89db4cac8bc3/overview
**Issue**: <!-- QOV-1234 -->

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
