### PR TITLE
feat(logs): add Slack-like scroll UX to service, deployment and cluster logs

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-logs-list/cluster-logs-list.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-logs-list/cluster-logs-list.tsx
@@ -109,7 +109,7 @@ export function ClusterLogsList({ logs, firstDate, refScrollSection }: ClusterLo
               {bufferedLogsCount > 999 ? '999+' : bufferedLogsCount}
             </span>
           )}
-          <Icon iconName="arrow-down-to-line" />
+          <Icon iconName="arrow-down" />
         </Button>
       )}
     </div>

--- a/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-logs-list/cluster-logs-list.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-logs-list/cluster-logs-list.tsx
@@ -1,6 +1,6 @@
 import { type ClusterLogs } from 'qovery-typescript-axios'
 import { type RefObject, useEffect, useMemo, useRef, useState } from 'react'
-import { Icon } from '@qovery/shared/ui'
+import { Button, Icon } from '@qovery/shared/ui'
 import { ClusterLogRow } from '../cluster-log-row/cluster-log-row'
 
 const MAX_VISIBLE_CLUSTER_LOGS = 500
@@ -19,6 +19,8 @@ function isNearBottom(section: HTMLDivElement) {
 
 export function ClusterLogsList({ logs, firstDate, refScrollSection }: ClusterLogsListProps) {
   const [showPreviousLogs, setShowPreviousLogs] = useState(false)
+  const [isScrolledUp, setIsScrolledUp] = useState(false)
+  const [bufferedLogsCount, setBufferedLogsCount] = useState(0)
   const shouldAutoScrollRef = useRef(true)
   const previousLogCountRef = useRef(0)
   const firstLogTimestamp = logs[0]?.timestamp
@@ -33,50 +35,83 @@ export function ClusterLogsList({ logs, firstDate, refScrollSection }: ClusterLo
     setShowPreviousLogs(false)
     shouldAutoScrollRef.current = true
     previousLogCountRef.current = 0
+    setBufferedLogsCount(0)
+    setIsScrolledUp(false)
   }, [firstLogTimestamp])
 
   useEffect(() => {
     const section = refScrollSection.current
     if (!section) return
 
-    const hasNewLogs = logs.length > previousLogCountRef.current
+    const newLogsCount = logs.length - previousLogCountRef.current
     previousLogCountRef.current = logs.length
 
-    if (!hasNewLogs || !shouldAutoScrollRef.current) return
+    if (newLogsCount <= 0) return
+
+    if (!shouldAutoScrollRef.current) {
+      setBufferedLogsCount((c) => c + newLogsCount)
+      return
+    }
 
     section.scroll(0, section.scrollHeight + SCROLL_BOTTOM_PADDING)
   }, [logs.length, refScrollSection])
 
   return (
-    <div
-      ref={refScrollSection}
-      data-testid="cluster-logs-scroll-section"
-      className="w-full flex-1 overflow-y-auto pb-10"
-      onScroll={(event) => {
-        shouldAutoScrollRef.current = isNearBottom(event.currentTarget)
-      }}
-    >
-      {!showPreviousLogs && visibleStartIndex > 0 && (
-        <button
-          type="button"
-          className="block w-full bg-surface-neutral py-1.5 text-center text-sm font-medium text-neutral-subtle transition hover:bg-surface-neutral-component"
-          onClick={() => setShowPreviousLogs(true)}
-        >
-          Load previous logs
-          <Icon iconName="arrow-up" className="ml-1.5" />
-        </button>
-      )}
+    <div className="relative flex min-h-0 w-full flex-1 flex-col">
+      <div
+        ref={refScrollSection}
+        data-testid="cluster-logs-scroll-section"
+        className="min-h-0 w-full flex-1 overflow-y-auto pb-10"
+        onScroll={(event) => {
+          const atBottom = isNearBottom(event.currentTarget)
+          shouldAutoScrollRef.current = atBottom
+          setIsScrolledUp(!atBottom)
+          if (atBottom) setBufferedLogsCount(0)
+        }}
+      >
+        {!showPreviousLogs && visibleStartIndex > 0 && (
+          <button
+            type="button"
+            className="block w-full bg-surface-neutral py-1.5 text-center text-sm font-medium text-neutral-subtle transition hover:bg-surface-neutral-component"
+            onClick={() => setShowPreviousLogs(true)}
+          >
+            Load previous logs
+            <Icon iconName="arrow-up" className="ml-1.5" />
+          </button>
+        )}
 
-      <div className="flex flex-col">
-        {visibleLogs.map((log, index) => (
-          <ClusterLogRow
-            key={visibleStartIndex + index}
-            data={log}
-            index={visibleStartIndex + index}
-            firstDate={firstDate}
-          />
-        ))}
+        <div className="flex flex-col">
+          {visibleLogs.map((log, index) => (
+            <ClusterLogRow
+              key={visibleStartIndex + index}
+              data={log}
+              index={visibleStartIndex + index}
+              firstDate={firstDate}
+            />
+          ))}
+        </div>
       </div>
+      {isScrolledUp && (
+        <Button
+          className="absolute bottom-[7px] left-1/2 flex w-72 -translate-x-1/2 items-center justify-center gap-2 text-sm"
+          variant="solid"
+          radius="full"
+          size="md"
+          type="button"
+          onClick={() => {
+            const section = refScrollSection.current
+            if (section) section.scroll(0, section.scrollHeight)
+          }}
+        >
+          Jump to latest log
+          {bufferedLogsCount > 0 && (
+            <span className="rounded-full bg-white/20 px-1.5 py-0.5 text-xs font-semibold tabular-nums">
+              {bufferedLogsCount > 999 ? '999+' : bufferedLogsCount}
+            </span>
+          )}
+          <Icon iconName="arrow-down-to-line" />
+        </Button>
+      )}
     </div>
   )
 }

--- a/libs/domains/service-logs/feature/src/lib/hooks/use-deployment-logs/use-deployment-logs.ts
+++ b/libs/domains/service-logs/feature/src/lib/hooks/use-deployment-logs/use-deployment-logs.ts
@@ -1,7 +1,7 @@
 import { type QueryClient } from '@tanstack/react-query'
 import { useLocation } from '@tanstack/react-router'
 import { type EnvironmentLogs } from 'qovery-typescript-axios'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useEnvironment } from '@qovery/domains/environments/feature'
 import { QOVERY_WS } from '@qovery/shared/util-node-env'
 import { useReactQueryWsSubscription } from '@qovery/state/util-queries'
@@ -36,10 +36,20 @@ export function useDeploymentLogs({
   const { data: environment } = useEnvironment({ environmentId, suspense: true })
 
   // States for controlling log actions, showing new, previous or paused logs
-  const [newMessagesAvailable, setNewMessagesAvailable] = useState(false)
+  const [bufferedLogsCount, setBufferedLogsCount] = useState(0)
   const [showPreviousLogs, setShowPreviousLogs] = useState(false)
-  const [pauseLogs, setPauseLogs] = useState(false)
+  const [isScrollPaused, setIsScrollPaused] = useState(false)
+  const isScrollPausedRef = useRef(false)
   const [debounceTime, setDebounceTime] = useState(1000)
+
+  const setPauseLogs = useCallback((paused: boolean | ((prev: boolean) => boolean)) => {
+    setIsScrollPaused((prev) => {
+      const next = typeof paused === 'function' ? paused(prev) : paused
+      isScrollPausedRef.current = next
+      if (!next) setBufferedLogsCount(0)
+      return next
+    })
+  }, [])
 
   const [logs, setLogs] = useState<EnvironmentLogs[]>([])
   const [messageChunks, setMessageChunks] = useState<EnvironmentLogs[][]>([])
@@ -49,7 +59,7 @@ export function useDeploymentLogs({
 
   const messageHandler = useCallback(
     (_: QueryClient, message: EnvironmentLogs[]) => {
-      setNewMessagesAvailable(true)
+      if (isScrollPausedRef.current) setBufferedLogsCount((c) => c + message.length)
       setMessageChunks((prevChunks) => {
         const lastChunk = prevChunks[prevChunks.length - 1] || []
         if (lastChunk.length < CHUNK_SIZE) {
@@ -83,27 +93,25 @@ export function useDeploymentLogs({
   const flushDelay = logs.length === 0 ? 0 : debounceTime
 
   useEffect(() => {
-    if (messageChunks.length === 0 || pauseLogs) return
+    if (messageChunks.length === 0) return
 
     const timerId = setTimeout(() => {
-      if (!pauseLogs) {
-        setMessageChunks((prevChunks) => prevChunks.slice(1))
-        setLogs((prevLogs) => {
-          const combinedLogs = [...prevLogs, ...messageChunks[0]]
+      setMessageChunks((prevChunks) => prevChunks.slice(1))
+      setLogs((prevLogs) => {
+        const combinedLogs = [...prevLogs, ...messageChunks[0]]
 
-          if (!hash && combinedLogs.length > 1000) {
-            setDebounceTime(100)
-          }
+        if (!hash && combinedLogs.length > 1000) {
+          setDebounceTime(100)
+        }
 
-          return [...new Map(combinedLogs.map((item) => [item['timestamp'], item])).values()]
-        })
-      }
+        return [...new Map(combinedLogs.map((item) => [item['timestamp'], item])).values()]
+      })
     }, flushDelay)
 
     return () => {
       clearTimeout(timerId)
     }
-  }, [messageChunks, pauseLogs, hash, flushDelay])
+  }, [messageChunks, hash, flushDelay])
 
   // Filter deployment logs by serviceId and stageId
   // Display entries when the name is "delete" or stageId is empty or equal with current stageId
@@ -135,9 +143,8 @@ export function useDeploymentLogs({
 
   return {
     data: logsByServiceId,
-    setNewMessagesAvailable,
-    newMessagesAvailable,
-    pauseLogs,
+    bufferedLogsCount,
+    isScrollPaused,
     setPauseLogs,
     showPreviousLogs,
     setShowPreviousLogs,

--- a/libs/domains/service-logs/feature/src/lib/hooks/use-service-live-logs/use-service-live-logs.ts
+++ b/libs/domains/service-logs/feature/src/lib/hooks/use-service-live-logs/use-service-live-logs.ts
@@ -25,12 +25,22 @@ export function useServiceLiveLogs({ clusterId, serviceId, enabled = false }: Us
   const serviceLogsBuffer = useRef<NormalizedServiceLog[]>([])
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
-  const [newLogsAvailable, setNewLogsAvailable] = useState(false)
-  const [pauseLogs, setPauseLogs] = useState(false)
+  const [bufferedLogsCount, setBufferedLogsCount] = useState(0)
+  const [isScrollPaused, setIsScrollPaused] = useState(false)
+  const isScrollPausedRef = useRef(false)
   const [isFetched, setIsFetched] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
 
   const [debouncedLogs, setDebouncedLogs] = useState<NormalizedServiceLog[]>([])
+
+  const setPauseLogs = useCallback((paused: boolean | ((prev: boolean) => boolean)) => {
+    setIsScrollPaused((prev) => {
+      const next = typeof paused === 'function' ? paused(prev) : paused
+      isScrollPausedRef.current = next
+      if (!next) setBufferedLogsCount(0)
+      return next
+    })
+  }, [])
 
   const flushBufferedLogs = useCallback(() => {
     if (serviceLogsBuffer.current.length > 0) {
@@ -71,7 +81,7 @@ export function useServiceLiveLogs({ clusterId, serviceId, enabled = false }: Us
         version?: string
       }
     ) => {
-      setNewLogsAvailable(true)
+      if (isScrollPausedRef.current) setBufferedLogsCount((c) => c + 1)
       const normalizedLog = normalizeWebSocketLog(log)
       serviceLogsBuffer.current.push(normalizedLog)
       scheduleFlush()
@@ -90,7 +100,7 @@ export function useServiceLiveLogs({ clusterId, serviceId, enabled = false }: Us
         version?: string
       }
     ) => {
-      setNewLogsAvailable(true)
+      if (isScrollPausedRef.current) setBufferedLogsCount((c) => c + 1)
       const normalizedLog = normalizeWebSocketLog(log)
 
       // Temporary fix to show NGINX logs as unknown to avoid UI issues
@@ -111,7 +121,7 @@ export function useServiceLiveLogs({ clusterId, serviceId, enabled = false }: Us
         version?: string
       }
     ) => {
-      setNewLogsAvailable(true)
+      if (isScrollPausedRef.current) setBufferedLogsCount((c) => c + 1)
       const normalizedLog = normalizeWebSocketLog(log)
 
       // Temporary fix to show Envoy logs as unknown to avoid UI issues
@@ -124,7 +134,7 @@ export function useServiceLiveLogs({ clusterId, serviceId, enabled = false }: Us
   const onCloseHandler = useCallback((_: QueryClient) => {
     setDebouncedLogs([])
     serviceLogsBuffer.current = []
-    setNewLogsAvailable(false)
+    setBufferedLogsCount(0)
     setIsFetched(true)
     setIsLoading(false)
   }, [])
@@ -266,11 +276,10 @@ export function useServiceLiveLogs({ clusterId, serviceId, enabled = false }: Us
   )
 
   return {
-    data: pauseLogs ? pausedDataLogs : debouncedLogs,
-    pauseLogs,
+    data: isScrollPaused ? pausedDataLogs : debouncedLogs,
+    isScrollPaused,
     setPauseLogs,
-    setNewLogsAvailable,
-    newLogsAvailable,
+    bufferedLogsCount,
     isFetched,
     isLoading,
   }

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.spec.tsx
@@ -125,10 +125,9 @@ describe('ListDeploymentLogs', () => {
 
     useDeploymentLogs.mockReturnValue({
       data: mockLogs,
-      pauseLogs: false,
+      isScrollPaused: false,
       setPauseLogs: jest.fn(),
-      newMessagesAvailable: false,
-      setNewMessagesAvailable: jest.fn(),
+      bufferedLogsCount: 0,
       showPreviousLogs: false,
       setShowPreviousLogs: jest.fn(),
     })

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
@@ -571,12 +571,7 @@ function DeploymentLogsBody({
         )}
       </div>
       {isLastVersion && (
-        <ShowNewLogsButton
-          pauseLogs={pauseLogs}
-          setPauseLogs={setPauseLogs}
-          newMessagesAvailable={bufferedLogsCount > 0}
-          bufferedLogsCount={bufferedLogsCount}
-        />
+        <ShowNewLogsButton pauseLogs={pauseLogs} setPauseLogs={setPauseLogs} bufferedLogsCount={bufferedLogsCount} />
       )}
     </>
   )

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
@@ -239,6 +239,8 @@ interface DeploymentLogsBodyProps {
   hasNewDeploymentBanner: boolean
 }
 
+const PAUSE_SCROLL_THRESHOLD = 80
+
 function DeploymentLogsBody({
   environment,
   environmentStatus,
@@ -251,6 +253,7 @@ function DeploymentLogsBody({
   const { hash } = useLocation()
   const { organizationId = '', projectId = '', serviceId = '', executionId = '' } = useParams({ strict: false })
   const refScrollSection = useRef<HTMLDivElement>(null)
+  const accumulatedScrollUp = useRef(0)
   const { updateStageId } = useContext(ServiceStageIdsContext)
   const { setDevopsCopilotOpen, sendMessageRef } = useContext(DevopsCopilotContext)
   const { mutateAsync: generateBuildUsageReport, isLoading: isBuildReportLoading } = useGenerateBuildUsageReport()
@@ -263,10 +266,9 @@ function DeploymentLogsBody({
   const { data: deploymentStatus } = useDeploymentStatus({ environmentId: environment.id, serviceId, suspense: true })
   const {
     data: logs = [],
-    pauseLogs,
+    isScrollPaused: pauseLogs,
     setPauseLogs,
-    newMessagesAvailable,
-    setNewMessagesAvailable,
+    bufferedLogsCount,
     showPreviousLogs,
     setShowPreviousLogs,
   } = useDeploymentLogs({
@@ -284,6 +286,16 @@ function DeploymentLogsBody({
 
     !pauseLogs && section.scroll(0, section.scrollHeight)
   }, [logs, pauseLogs])
+
+  const handleScroll = useCallback(() => {
+    if (!pauseLogs) return
+    const section = refScrollSection.current
+    if (!section) return
+    const isAtBottom = section.scrollTop + section.clientHeight >= section.scrollHeight - 4
+    if (isAtBottom) {
+      setPauseLogs(false)
+    }
+  }, [pauseLogs, setPauseLogs])
 
   // `useEffect` used to scroll to the hash id
   useEffect(() => {
@@ -516,15 +528,24 @@ function DeploymentLogsBody({
       <div
         className={clsx(logsViewportHeightClass, 'w-full overflow-y-scroll')}
         ref={refScrollSection}
+        onScroll={handleScroll}
         onWheel={(event) => {
-          if (
-            !pauseLogs &&
-            refScrollSection.current &&
-            refScrollSection.current.clientHeight !== refScrollSection.current.scrollHeight &&
-            event.deltaY < 0
-          ) {
-            setPauseLogs(true)
-            setNewMessagesAvailable(false)
+          if (pauseLogs) return
+
+          const section = refScrollSection.current
+          if (!section) return
+
+          const hasScrollableContent = section.clientHeight !== section.scrollHeight
+          if (!hasScrollableContent) return
+
+          if (event.deltaY < 0) {
+            accumulatedScrollUp.current += Math.abs(event.deltaY)
+            if (accumulatedScrollUp.current >= PAUSE_SCROLL_THRESHOLD) {
+              accumulatedScrollUp.current = 0
+              setPauseLogs(true)
+            }
+          } else {
+            accumulatedScrollUp.current = 0
           }
         }}
       >
@@ -553,7 +574,8 @@ function DeploymentLogsBody({
         <ShowNewLogsButton
           pauseLogs={pauseLogs}
           setPauseLogs={setPauseLogs}
-          newMessagesAvailable={newMessagesAvailable}
+          newMessagesAvailable={bufferedLogsCount > 0}
+          bufferedLogsCount={bufferedLogsCount}
         />
       )}
     </>

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
@@ -254,6 +254,7 @@ function DeploymentLogsBody({
   const { organizationId = '', projectId = '', serviceId = '', executionId = '' } = useParams({ strict: false })
   const refScrollSection = useRef<HTMLDivElement>(null)
   const accumulatedScrollUp = useRef(0)
+  const [isScrolledUp, setIsScrolledUp] = useState(false)
   const { updateStageId } = useContext(ServiceStageIdsContext)
   const { setDevopsCopilotOpen, sendMessageRef } = useContext(DevopsCopilotContext)
   const { mutateAsync: generateBuildUsageReport, isLoading: isBuildReportLoading } = useGenerateBuildUsageReport()
@@ -288,11 +289,11 @@ function DeploymentLogsBody({
   }, [logs, pauseLogs])
 
   const handleScroll = useCallback(() => {
-    if (!pauseLogs) return
     const section = refScrollSection.current
     if (!section) return
     const isAtBottom = section.scrollTop + section.clientHeight >= section.scrollHeight - 4
-    if (isAtBottom) {
+    setIsScrolledUp(!isAtBottom)
+    if (isAtBottom && pauseLogs) {
       setPauseLogs(false)
     }
   }, [pauseLogs, setPauseLogs])
@@ -570,7 +571,7 @@ function DeploymentLogsBody({
           <ProgressIndicator className="mb-2 pl-2" pauseLogs={pauseLogs} message="Streaming deployment logs" />
         )}
       </div>
-      {isLastVersion && (
+      {isScrolledUp && (
         <ShowNewLogsButton pauseLogs={pauseLogs} setPauseLogs={setPauseLogs} bufferedLogsCount={bufferedLogsCount} />
       )}
     </>

--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
@@ -329,12 +329,7 @@ function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; en
           </div>
         )}
         {isLiveMode && (
-          <ShowNewLogsButton
-            pauseLogs={pauseLogs}
-            setPauseLogs={setPauseLogs}
-            newMessagesAvailable={bufferedLogsCount > 0}
-            bufferedLogsCount={bufferedLogsCount}
-          />
+          <ShowNewLogsButton pauseLogs={pauseLogs} setPauseLogs={setPauseLogs} bufferedLogsCount={bufferedLogsCount} />
         )}
       </div>
     </div>

--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
@@ -2,7 +2,7 @@ import { getRouteApi } from '@tanstack/react-router'
 import { differenceInHours } from 'date-fns'
 import posthog from 'posthog-js'
 import { type Cluster, type Environment, type EnvironmentStatus, type Status } from 'qovery-typescript-axios'
-import { memo, useEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { match } from 'ts-pattern'
 import { EnableObservabilityButtonContactUs } from '@qovery/domains/observability/feature'
 import { useRunningStatus, useService } from '@qovery/domains/services/feature'
@@ -68,9 +68,12 @@ function Placeholder({
   }
 }
 
+const PAUSE_SCROLL_THRESHOLD = 80
+
 function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; environment: Environment }) {
   const { serviceId } = route.useParams()
   const refScrollSection = useRef<HTMLDivElement>(null)
+  const accumulatedScrollUp = useRef(0)
 
   const queryParams = route.useSearch()
 
@@ -112,10 +115,9 @@ function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; en
   // Live logs hook - only enabled when in live mode
   const {
     data: liveLogs = [],
-    pauseLogs,
+    isScrollPaused: pauseLogs,
     setPauseLogs,
-    newLogsAvailable,
-    setNewLogsAvailable,
+    bufferedLogsCount,
     isFetched: isLiveLogsFetched,
     isLoading: isLiveLogsLoading,
   } = useServiceLiveLogs({
@@ -140,10 +142,9 @@ function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; en
 
   useEffect(() => {
     if (isLiveMode && serviceEnabled) {
-      setNewLogsAvailable(true)
       setPauseLogs(false)
     }
-  }, [isLiveMode, serviceEnabled, setNewLogsAvailable, setPauseLogs])
+  }, [isLiveMode, serviceEnabled, setPauseLogs])
 
   useEffect(() => {
     posthog.capture('service-logs', {
@@ -201,6 +202,16 @@ function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; en
 
     !pauseLogs && section.scroll(0, section.scrollHeight)
   }, [logs, pauseLogs, isLiveMode])
+
+  const handleScroll = useCallback(() => {
+    if (!isLiveMode || !pauseLogs) return
+    const section = refScrollSection.current
+    if (!section) return
+    const isAtBottom = section.scrollTop + section.clientHeight >= section.scrollHeight - 4
+    if (isAtBottom) {
+      setPauseLogs(false)
+    }
+  }, [isLiveMode, pauseLogs, setPauseLogs])
 
   const isServiceProgressing = match(runningStatus?.state)
     .with('RUNNING', 'WARNING', () => true)
@@ -262,17 +273,24 @@ function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; en
           <div
             className="h-[calc(100vh-209px)] w-full overflow-y-scroll "
             ref={refScrollSection}
+            onScroll={handleScroll}
             onWheel={(event) => {
-              if (!liveLogs) return
+              if (!liveLogs || pauseLogs) return
 
               const section = refScrollSection.current
               if (!section) return
 
               const hasScrollableContent = section.clientHeight !== section.scrollHeight
+              if (!hasScrollableContent) return
 
-              if (!pauseLogs && hasScrollableContent && event.deltaY < 0) {
-                setPauseLogs(true)
-                setNewLogsAvailable(false)
+              if (event.deltaY < 0) {
+                accumulatedScrollUp.current += Math.abs(event.deltaY)
+                if (accumulatedScrollUp.current >= PAUSE_SCROLL_THRESHOLD) {
+                  accumulatedScrollUp.current = 0
+                  setPauseLogs(true)
+                }
+              } else {
+                accumulatedScrollUp.current = 0
               }
             }}
           >
@@ -314,7 +332,8 @@ function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; en
           <ShowNewLogsButton
             pauseLogs={pauseLogs}
             setPauseLogs={setPauseLogs}
-            newMessagesAvailable={newLogsAvailable}
+            newMessagesAvailable={bufferedLogsCount > 0}
+            bufferedLogsCount={bufferedLogsCount}
           />
         )}
       </div>

--- a/libs/domains/service-logs/feature/src/lib/show-new-logs-button/show-new-logs-button.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/show-new-logs-button/show-new-logs-button.spec.tsx
@@ -27,7 +27,7 @@ describe('ShowNewLogsButton', () => {
       <ShowNewLogsButton pauseLogs={true} newMessagesAvailable={true} setPauseLogs={setPauseLogs} />
     )
 
-    const button = screen.getByRole('button', { name: /new logs/i })
+    const button = screen.getByRole('button', { name: /jump to latest log/i })
     await userEvent.click(button)
     expect(setPauseLogs).toHaveBeenCalledWith(false)
   })

--- a/libs/domains/service-logs/feature/src/lib/show-new-logs-button/show-new-logs-button.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/show-new-logs-button/show-new-logs-button.spec.tsx
@@ -15,17 +15,13 @@ jest.mock('@tanstack/react-router', () => ({
 
 describe('ShowNewLogsButton', () => {
   it('should render successfully', () => {
-    const { baseElement } = renderWithProviders(
-      <ShowNewLogsButton pauseLogs={true} setPauseLogs={jest.fn()} newMessagesAvailable={true} />
-    )
+    const { baseElement } = renderWithProviders(<ShowNewLogsButton pauseLogs={true} setPauseLogs={jest.fn()} />)
     expect(baseElement).toBeTruthy()
   })
 
   it('calls setPauseLogs with false when button is clicked', async () => {
     const setPauseLogs = jest.fn()
-    const { userEvent } = renderWithProviders(
-      <ShowNewLogsButton pauseLogs={true} newMessagesAvailable={true} setPauseLogs={setPauseLogs} />
-    )
+    const { userEvent } = renderWithProviders(<ShowNewLogsButton pauseLogs={true} setPauseLogs={setPauseLogs} />)
 
     const button = screen.getByRole('button', { name: /jump to latest log/i })
     await userEvent.click(button)

--- a/libs/domains/service-logs/feature/src/lib/show-new-logs-button/show-new-logs-button.tsx
+++ b/libs/domains/service-logs/feature/src/lib/show-new-logs-button/show-new-logs-button.tsx
@@ -6,13 +6,19 @@ export interface ShowNewLogsButtonProps {
   pauseLogs: boolean
   setPauseLogs: Dispatch<SetStateAction<boolean>>
   newMessagesAvailable: boolean
+  bufferedLogsCount?: number
 }
 
-export function ShowNewLogsButton({ pauseLogs, setPauseLogs, newMessagesAvailable }: ShowNewLogsButtonProps) {
+export function ShowNewLogsButton({
+  pauseLogs,
+  setPauseLogs,
+  newMessagesAvailable,
+  bufferedLogsCount,
+}: ShowNewLogsButtonProps) {
   const navigate = useNavigate()
   const { hash, pathname, search } = useLocation()
 
-  if (pauseLogs && newMessagesAvailable) {
+  if (pauseLogs) {
     return (
       <Button
         className="absolute bottom-[7px] left-1/2 flex w-72 -translate-x-1/2 items-center justify-center gap-2 text-sm"
@@ -25,7 +31,12 @@ export function ShowNewLogsButton({ pauseLogs, setPauseLogs, newMessagesAvailabl
           if (hash) navigate({ to: pathname + search })
         }}
       >
-        New logs
+        Jump to latest log
+        {bufferedLogsCount !== undefined && bufferedLogsCount > 0 && (
+          <span className="rounded-full bg-white/20 px-1.5 py-0.5 text-xs font-semibold tabular-nums">
+            {bufferedLogsCount > 999 ? '999+' : bufferedLogsCount}
+          </span>
+        )}
         <Icon iconName="arrow-down-to-line" />
       </Button>
     )

--- a/libs/domains/service-logs/feature/src/lib/show-new-logs-button/show-new-logs-button.tsx
+++ b/libs/domains/service-logs/feature/src/lib/show-new-logs-button/show-new-logs-button.tsx
@@ -5,16 +5,10 @@ import { Button, Icon } from '@qovery/shared/ui'
 export interface ShowNewLogsButtonProps {
   pauseLogs: boolean
   setPauseLogs: Dispatch<SetStateAction<boolean>>
-  newMessagesAvailable: boolean
   bufferedLogsCount?: number
 }
 
-export function ShowNewLogsButton({
-  pauseLogs,
-  setPauseLogs,
-  newMessagesAvailable,
-  bufferedLogsCount,
-}: ShowNewLogsButtonProps) {
+export function ShowNewLogsButton({ pauseLogs, setPauseLogs, bufferedLogsCount }: ShowNewLogsButtonProps) {
   const navigate = useNavigate()
   const { hash, pathname, search } = useLocation()
 
@@ -37,7 +31,7 @@ export function ShowNewLogsButton({
             {bufferedLogsCount > 999 ? '999+' : bufferedLogsCount}
           </span>
         )}
-        <Icon iconName="arrow-down-to-line" />
+        <Icon iconName="arrow-down" />
       </Button>
     )
   }


### PR DESCRIPTION
## Summary

- When the user scrolls up in live logs (service, deployment, cluster), the view sticks to the current position instead of following new incoming lines
- A **"Jump to latest log"** button appears at the bottom with a badge showing the count of new log lines received while scrolled away
- Scrolling back to the bottom automatically resumes live streaming and dismisses the button
- Scrolling up now requires crossing an **80px threshold** before pausing, preventing accidental triggers from small scroll gestures
- **Fixed**: deployment logs were not rendering new lines while scrolled up — incoming message chunks were blocked from flushing to the DOM until the user scrolled back down, causing a visible pop of content on resume
- Renamed internal state for clarity: `pauseLogs` → `isScrollPaused`, `newLogsAvailable` (boolean) → `bufferedLogsCount` (number)

## Screenshots / Recordings

N/A

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see .cursor/rules)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using Conventional Commits with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code