### PR TITLE
fix(devops-copilot): troubleshoot banner that passes over the select

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
@@ -499,7 +499,7 @@ export function ListDeploymentLogs({
           </div>
         </div>
         <div
-          className="max-h-[calc(100vh-170px)] w-full overflow-y-scroll pb-12"
+          className="isolate max-h-[calc(100vh-170px)] w-full overflow-y-scroll pb-12"
           ref={refScrollSection}
           onWheel={(event) => {
             if (


### PR DESCRIPTION
## Summary

**Issue**: QOV-1825

Fixed a display bug when the troubleshooting banner was hovering over the select

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="2346" height="1401" alt="2026-04-13_10-20-21" src="https://github.com/user-attachments/assets/b349b290-5602-4aad-b9d9-ab14310027f8" /> | <img width="2345" height="1406" alt="image" src="https://github.com/user-attachments/assets/ce4a4c83-2c77-449d-95c9-aaf51bdd8d04" /> |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
