### PR TITLE
fix(deployment-logs): refresh header and remove queud loader scroll

### DIFF
--- a/apps/console-v5/vite.config.ts
+++ b/apps/console-v5/vite.config.ts
@@ -2,7 +2,6 @@
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
-import react from '@vitejs/plugin-react'
 import { join } from 'path'
 import { defineConfig, loadEnv } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
@@ -32,12 +31,17 @@ export default defineConfig(({ mode }) => {
     define: {
       'process.env': JSON.stringify(clientEnv),
     },
+    oxc: {
+      jsx: {
+        runtime: 'automatic',
+        importSource: 'react',
+      },
+    },
     plugins: [
       tanstackRouter({
         target: 'react',
         autoCodeSplitting: true,
       }),
-      react(),
       nxViteTsPaths(),
       nxCopyAssetsPlugin(['*.md']),
       viteStaticCopy({

--- a/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs-content/deployment-logs-content.tsx
+++ b/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs-content/deployment-logs-content.tsx
@@ -109,7 +109,7 @@ export function DeploymentLogsContent({
   const { serviceId = '', executionId = '' } = useParams({ strict: false })
   const navigate = useNavigate()
 
-  const { data: service, isFetched: isFetchedService } = useService({
+  const { data: service } = useService({
     environmentId: environment.id,
     serviceId,
     suspense: true,
@@ -127,7 +127,7 @@ export function DeploymentLogsContent({
 
   const serviceStatus = (getServiceStatusesById(deploymentStages, serviceId) as Status | null) ?? fallbackServiceStatus
 
-  if (!serviceStatus && isFetchedService) {
+  if (!serviceStatus) {
     return (
       <div className="flex h-full w-full items-center justify-center bg-background">
         <LoaderPlaceholder />

--- a/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs-content/deployment-logs-content.tsx
+++ b/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs-content/deployment-logs-content.tsx
@@ -9,10 +9,11 @@ import {
 } from 'qovery-typescript-axios'
 import { match } from 'ts-pattern'
 import { useDeploymentHistory } from '@qovery/domains/environments/feature'
-import { useService } from '@qovery/domains/services/feature'
+import { useService, useDeploymentStatus as useServiceDeploymentStatus } from '@qovery/domains/services/feature'
 import { Banner } from '@qovery/shared/ui'
 import { useDocumentTitle } from '@qovery/shared/util-hooks'
 import { ListDeploymentLogs } from '../../list-deployment-logs/list-deployment-logs'
+import { LoaderPlaceholder } from '../deployment-logs-placeholder/deployment-logs-placeholder'
 
 export interface DeploymentLogsContentProps {
   environment: Environment
@@ -113,6 +114,10 @@ export function DeploymentLogsContent({
     serviceId,
     suspense: true,
   })
+  const { data: fallbackServiceStatus } = useServiceDeploymentStatus({
+    environmentId: environment.id,
+    serviceId,
+  })
   const { data: environmentDeploymentHistory = [] } = useDeploymentHistory({
     environmentId: environment.id,
     suspense: true,
@@ -120,9 +125,15 @@ export function DeploymentLogsContent({
 
   useDocumentTitle(`Deployment logs - ${service?.name ?? 'Loading…'}`)
 
-  const serviceStatus = getServiceStatusesById(deploymentStages, serviceId) as Status
+  const serviceStatus = (getServiceStatusesById(deploymentStages, serviceId) as Status | null) ?? fallbackServiceStatus
 
-  if (!serviceStatus && isFetchedService) return <div className="h-full w-full bg-background"></div>
+  if (!serviceStatus && isFetchedService) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background">
+        <LoaderPlaceholder />
+      </div>
+    )
+  }
 
   const stageFromServiceId = getStageFromServiceId(deploymentStages ?? [], serviceId)
 

--- a/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs-placeholder/deployment-logs-placeholder.tsx
+++ b/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs-placeholder/deployment-logs-placeholder.tsx
@@ -69,7 +69,7 @@ export function LoaderPlaceholder({
   return (
     <div className="flex w-full flex-col items-center justify-center gap-5 text-center">
       <LoaderDots />
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
         <p className="text-neutral">{title}</p>
         <span className="text-sm text-neutral-subtle">{description}</span>
       </div>

--- a/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs.tsx
@@ -7,7 +7,12 @@ import {
   type EnvironmentStatusesWithStagesPreCheckStage,
 } from 'qovery-typescript-axios'
 import { memo, useCallback, useEffect, useState } from 'react'
-import { useEnvironment } from '@qovery/domains/environments/feature'
+import {
+  useDeploymentHistory,
+  useEnvironment,
+  useDeploymentStages as useEnvironmentDeploymentStages,
+  useDeploymentStatus as useEnvironmentDeploymentStatus,
+} from '@qovery/domains/environments/feature'
 import { useService } from '@qovery/domains/services/feature'
 import { Skeleton } from '@qovery/shared/ui'
 import { QOVERY_WS } from '@qovery/shared/util-node-env'
@@ -49,7 +54,7 @@ function DeploymentLogsWrapper({
   environmentStatus?: EnvironmentStatus
   preCheckStage?: EnvironmentStatusesWithStagesPreCheckStage
 }) {
-  if (!environment || !environmentStatus) {
+  if (!environment) {
     return <Loader />
   }
 
@@ -77,9 +82,19 @@ export function DeploymentLogs() {
     suspense: true,
   })
   const { data: environment } = useEnvironment({ environmentId, suspense: true })
+  const { data: environmentDeploymentHistory = [] } = useDeploymentHistory({
+    environmentId,
+    suspense: true,
+  })
+  const { data: liveDeploymentStages } = useEnvironmentDeploymentStages({ environmentId })
+  const { data: liveEnvironmentStatus } = useEnvironmentDeploymentStatus({ environmentId })
   const [deploymentStages, setDeploymentStages] = useState<DeploymentStageWithServicesStatuses[]>()
   const [environmentStatus, setEnvironmentStatus] = useState<EnvironmentStatus>()
   const [preCheckStage, setPreCheckStage] = useState<EnvironmentStatusesWithStagesPreCheckStage>()
+
+  const isLatestVersion = environmentDeploymentHistory[0]?.identifier.execution_id === executionId
+  const resolvedDeploymentStages = isLatestVersion ? liveDeploymentStages ?? deploymentStages : deploymentStages
+  const resolvedEnvironmentStatus = isLatestVersion ? liveEnvironmentStatus ?? environmentStatus : environmentStatus
 
   const messageHandler = useCallback(
     (
@@ -129,8 +144,8 @@ export function DeploymentLogs() {
       <ServiceStageIdsProvider>
         <DeploymentLogsWrapper
           environment={environment}
-          deploymentStages={deploymentStages}
-          environmentStatus={environmentStatus}
+          deploymentStages={resolvedDeploymentStages}
+          environmentStatus={resolvedEnvironmentStatus}
           preCheckStage={preCheckStage}
         />
 

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -72,12 +72,7 @@ export function HeaderLogs({
     serviceStatus?.state === 'STOPPED'
 
   return (
-    <div
-      className="flex h-12 w-full items-center justify-between border-b border-neutral bg-background"
-      style={{
-        paddingRight: 'var(--padding-sidebar, 16px)',
-      }}
-    >
+    <div className="flex h-12 w-full items-center justify-between border-b border-neutral bg-background pr-4">
       <div className="flex h-full">
         <div className="flex h-full items-center gap-3 py-2.5 pl-4 pr-0.5 text-sm font-medium text-neutral">
           {match(type)

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
@@ -381,7 +381,7 @@ function DeploymentLogsBody({
     () => (type: FilterType) => columnFilters.some((filter) => filter.value === type),
     [columnFilters]
   )
-  const emptyStateHeightClass = hasNewDeploymentBanner ? 'h-[calc(100vh-156px)]' : 'h-[calc(100vh-116px)]'
+  const emptyStateHeightClass = hasNewDeploymentBanner ? 'h-[calc(100vh-201px)]' : 'h-[calc(100vh-161px)]'
   const logsViewportHeightClass = hasNewDeploymentBanner ? 'h-[calc(100vh-249px)]' : 'h-[calc(100vh-209px)]'
 
   const isLastVersion = deploymentHistory?.[0]?.identifier.execution_id === executionId || !executionId

--- a/libs/domains/service-logs/feature/src/lib/progress-indicator/progress-indicator.tsx
+++ b/libs/domains/service-logs/feature/src/lib/progress-indicator/progress-indicator.tsx
@@ -11,7 +11,7 @@ export function ProgressIndicator({ pauseLogs, message, className }: ProgressInd
     <div
       role="progressbar"
       className={twMerge(
-        'mb-10 flex h-8 items-center border-b border-neutral bg-surface-neutral pl-4 text-sm font-bold text-neutral',
+        'mb-10 flex h-8 items-center border-b border-neutral pl-4 text-sm font-bold text-neutral',
         className
       )}
     >

--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
     "@types/shell-quote": "1.7.5",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
-    "@vitejs/plugin-react": "4.2.0",
     "@vitest/ui": "3.0.0",
     "babel-jest": "30.0.5",
     "babel-loader": "8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,7 +143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.23.3, @babel/core@npm:^7.23.7, @babel/core@npm:^7.27.7":
+"@babel/core@npm:^7.23.7, @babel/core@npm:^7.27.7":
   version: 7.29.0
   resolution: "@babel/core@npm:7.29.0"
   dependencies:
@@ -1438,28 +1438,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 36bc3ff0b96bb0ef4723070a50cfdf2e72cfd903a59eba448f9fe92fea47574d6f22efd99364413719e1f3fb3c51b6c9b2990b87af088f8486a84b2a5f9e4560
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx-self@npm:^7.23.3":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.27.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 72cbae66a58c6c36f7e12e8ed79f292192d858dd4bb00e9e89d8b695e4c5cb6ef48eec84bffff421a5db93fd10412c581f1cccdb00264065df76f121995bdb68
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx-source@npm:^7.23.3":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.27.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: e2843362adb53692be5ee9fa07a386d2d8883daad2063a3575b3c373fc14cdf4ea7978c67a183cb631b4c9c8d77b2f48c24c088f8e65cc3600cb8e97d72a7161
   languageName: node
   linkType: hard
 
@@ -6096,7 +6074,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 7.18.0
     "@typescript-eslint/parser": 7.18.0
     "@uidotdev/usehooks": 2.4.1
-    "@vitejs/plugin-react": 4.2.0
     "@vitest/ui": 3.0.0
     "@xterm/addon-attach": 0.11.0
     "@xterm/addon-fit": 0.9.0
@@ -9250,7 +9227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.18.0, @types/babel__core@npm:^7.20.4, @types/babel__core@npm:^7.20.5":
+"@types/babel__core@npm:^7.18.0, @types/babel__core@npm:^7.20.5":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
   dependencies:
@@ -10652,21 +10629,6 @@ __metadata:
   version: 1.11.1
   resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.11.1"
   conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@vitejs/plugin-react@npm:4.2.0":
-  version: 4.2.0
-  resolution: "@vitejs/plugin-react@npm:4.2.0"
-  dependencies:
-    "@babel/core": ^7.23.3
-    "@babel/plugin-transform-react-jsx-self": ^7.23.3
-    "@babel/plugin-transform-react-jsx-source": ^7.23.3
-    "@types/babel__core": ^7.20.4
-    react-refresh: ^0.14.0
-  peerDependencies:
-    vite: ^4.2.0 || ^5.0.0
-  checksum: 515dc270dc433d9d80806501221d152f627aabc342916e9dc0d1d840fec76bc00daf3e41738f9aad286de89ee9325fd423372298bd04a3bfd618601ae62d515d
   languageName: node
   linkType: hard
 
@@ -26432,13 +26394,6 @@ __metadata:
   version: 0.14.0
   resolution: "react-refresh@npm:0.14.0"
   checksum: dc69fa8c993df512f42dd0f1b604978ae89bd747c0ed5ec595c0cc50d535fb2696619ccd98ae28775cc01d0a7c146a532f0f7fb81dc22e1977c242a4912312f4
-  languageName: node
-  linkType: hard
-
-"react-refresh@npm:^0.14.0":
-  version: 0.14.2
-  resolution: "react-refresh@npm:0.14.2"
-  checksum: d80db4bd40a36dab79010dc8aa317a5b931f960c0d83c4f3b81f0552cbcf7f29e115b84bb7908ec6a1eb67720fff7023084eff73ece8a7ddc694882478464382
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Several fixes:
- Deployment logs header and stage statuses now refresh live instead of staying stuck until a manual page reload
- The queued-state loader no longer introduces an unnecessary vertical scroll in the deployment logs view

https://qovery.slack.com/archives/C0AML0VDUV8/p1775827059952919

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
