### PR TITLE
fix(page-settings): auto-select No Access when unchecking

### DIFF
--- a/libs/pages/settings/src/lib/ui/page-organization-roles-edit/row-cluster/row-cluster.spec.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles-edit/row-cluster/row-cluster.spec.tsx
@@ -1,6 +1,9 @@
-import { render } from '__tests__/utils/setup-jest'
+import { act, fireEvent, render } from '__tests__/utils/setup-jest'
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
-import { type OrganizationCustomRoleClusterPermissionsInner } from 'qovery-typescript-axios'
+import {
+  OrganizationCustomRoleClusterPermission,
+  type OrganizationCustomRoleClusterPermissionsInner,
+} from 'qovery-typescript-axios'
 import { customRolesMock } from '@qovery/shared/factories'
 import RowCluster from './row-cluster'
 
@@ -10,5 +13,27 @@ describe('RowCluster', () => {
   it('should render successfully', () => {
     const { baseElement } = render(wrapWithReactHookForm(<RowCluster cluster={clusters[0]} />))
     expect(baseElement).toBeTruthy()
+  })
+
+  it('should set permission to VIEWER when clicking an already-selected cluster permission (AC-3)', async () => {
+    const defaultValues = {
+      cluster_permissions: {
+        '1': OrganizationCustomRoleClusterPermission.ADMIN,
+      },
+    }
+
+    const { container } = render(wrapWithReactHookForm(<RowCluster cluster={clusters[0]} />, { defaultValues }))
+
+    const adminInput = container.querySelector('input[value="ADMIN"]') as HTMLInputElement
+    expect(adminInput).toBeChecked()
+
+    await act(() => {
+      fireEvent.click(adminInput)
+    })
+
+    expect(adminInput).not.toBeChecked()
+
+    const viewerInput = container.querySelector('input[value="VIEWER"]') as HTMLInputElement
+    expect(viewerInput).toBeChecked()
   })
 })

--- a/libs/pages/settings/src/lib/ui/page-organization-roles-edit/row-cluster/row-cluster.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles-edit/row-cluster/row-cluster.tsx
@@ -34,7 +34,7 @@ const setGlobalCheckByValue = (
 export function RowCluster(props: RowClusterProps) {
   const { cluster, setGlobalCheck } = props
 
-  const { control, getValues } = useFormContext()
+  const { control, getValues, setValue } = useFormContext()
 
   return (
     <div className="flex h-10 border-b border-neutral-250">
@@ -50,6 +50,18 @@ export function RowCluster(props: RowClusterProps) {
           <div
             key={`${cluster.cluster_id}.${permission}`}
             className="flex h-full flex-1 items-center justify-center border-r border-neutral-250 px-4 last:border-0"
+            onClick={() => {
+              const fieldName = `cluster_permissions.${cluster.cluster_id}`
+              if (getValues(fieldName) === permission) {
+                setValue(fieldName, OrganizationCustomRoleClusterPermission.VIEWER)
+                if (setGlobalCheck)
+                  setGlobalCheckByValue(
+                    getValues(fieldName),
+                    OrganizationCustomRoleClusterPermission.VIEWER,
+                    setGlobalCheck
+                  )
+              }
+            }}
           >
             <Controller
               name={`cluster_permissions.${cluster.cluster_id}`}

--- a/libs/pages/settings/src/lib/ui/page-organization-roles-edit/row-project/row-project.spec.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles-edit/row-project/row-project.spec.tsx
@@ -1,6 +1,9 @@
 import { act, fireEvent, render } from '__tests__/utils/setup-jest'
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
-import { type OrganizationCustomRoleProjectPermissionsInner } from 'qovery-typescript-axios'
+import {
+  OrganizationCustomRoleProjectPermission,
+  type OrganizationCustomRoleProjectPermissionsInner,
+} from 'qovery-typescript-axios'
 import { customRolesMock } from '@qovery/shared/factories'
 import { resetForm } from '../../../feature/page-organization-roles-edit-feature/page-organization-roles-edit-feature'
 import RowProject, { OrganizationCustomRoleProjectPermissionAdmin } from './row-project'
@@ -36,6 +39,68 @@ describe('RowProject', () => {
     })
 
     expect(input).toBeChecked()
+  })
+
+  it('should set permission to NO_ACCESS when clicking an already-selected permission (AC-1)', async () => {
+    project.is_admin = false
+
+    const defaultValues = {
+      project_permissions: {
+        '1': {
+          ADMIN: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          DEVELOPMENT: OrganizationCustomRoleProjectPermission.MANAGER,
+          PREVIEW: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          STAGING: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          PRODUCTION: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+        },
+      },
+    }
+
+    const { container } = render(wrapWithReactHookForm(<RowProject project={project} />, { defaultValues }))
+
+    const managerInput = container.querySelector('input[value="MANAGER"]') as HTMLInputElement
+    expect(managerInput).toBeChecked()
+
+    await act(() => {
+      fireEvent.click(managerInput)
+    })
+
+    expect(managerInput).not.toBeChecked()
+
+    const noAccessInput = container.querySelector('input[value="NO_ACCESS"]:not([disabled])') as HTMLInputElement
+    expect(noAccessInput).toBeChecked()
+  })
+
+  it('should update global header to NO_ACCESS after all rows become NO_ACCESS (AC-2)', async () => {
+    project.is_admin = false
+
+    const defaultValues = {
+      project_permissions: {
+        '1': {
+          ADMIN: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          DEVELOPMENT: OrganizationCustomRoleProjectPermission.MANAGER,
+          PREVIEW: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          STAGING: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          PRODUCTION: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+        },
+      },
+    }
+
+    const { container, getByTestId } = render(
+      wrapWithReactHookForm(<RowProject project={project} />, { defaultValues })
+    )
+
+    const headerNoAccess = getByTestId(
+      `project.${OrganizationCustomRoleProjectPermission.NO_ACCESS}`
+    ) as HTMLInputElement
+    expect(headerNoAccess).not.toBeChecked()
+
+    const managerInput = container.querySelector('input[value="MANAGER"]') as HTMLInputElement
+    await act(() => {
+      fireEvent.click(managerInput)
+    })
+
+    expect(headerNoAccess).toBeChecked()
   })
 
   it('should be admin by default and check global select', async () => {

--- a/libs/pages/settings/src/lib/ui/page-organization-roles-edit/row-project/row-project.tsx
+++ b/libs/pages/settings/src/lib/ui/page-organization-roles-edit/row-project/row-project.tsx
@@ -106,6 +106,17 @@ export function RowProject(props: RowProjectProps) {
                   <div
                     key={currentPermission}
                     className="flex h-full flex-1 items-center justify-center border-r border-neutral-250 px-4 last:border-0"
+                    onClick={() => {
+                      const fieldName = `project_permissions.${project.project_id}.${permission.environment_type}`
+                      if (getValues(fieldName) === currentPermission) {
+                        setValue(fieldName, OrganizationCustomRoleProjectPermission.NO_ACCESS)
+                        setGlobalCheckByValue(
+                          getValues(`project_permissions.${project.project_id}`),
+                          OrganizationCustomRoleProjectPermission.NO_ACCESS,
+                          setGlobalCheck
+                        )
+                      }
+                    }}
                   >
                     <Controller
                       name={`project_permissions.${project.project_id}.${permission.environment_type}`}


### PR DESCRIPTION
## Summary

**Issue**: QOV-1800

When you clicked on an already active permission to remove it, nothing happened. You had to click on "No Access" to disable it, which wasn't intuitive. Now, clicking on an already selected permission removes it automatically.

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| https://github.com/user-attachments/assets/997cb99a-cee4-4c0f-8a61-34f4f2b2d891 | https://github.com/user-attachments/assets/486a547c-0b83-41e7-8610-1b4895a379a9 |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
