### PR TITLE
fix(page-settings): auto-select No Access when unchecking

### DIFF
--- a/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-cluster/row-cluster.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-cluster/row-cluster.spec.tsx
@@ -1,4 +1,5 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
+import { OrganizationCustomRoleClusterPermission, type OrganizationCustomRoleClusterPermissionsInner } from 'qovery-typescript-axios'
 import { customRolesMock } from '@qovery/shared/factories'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import RowCluster from './row-cluster'
@@ -15,6 +16,27 @@ describe('RowCluster', () => {
 
     expect(screen.getByText(cluster.cluster_name)).toBeInTheDocument()
     expect(screen.getAllByRole('checkbox')).toHaveLength(3)
+  })
+
+  it('should set permission to VIEWER when clicking an already-selected cluster permission (AC-3)', async () => {
+    const defaultValues = {
+      cluster_permissions: {
+        '1': OrganizationCustomRoleClusterPermission.ADMIN,
+      },
+    }
+
+    const { userEvent, container } = renderWithProviders(
+      wrapWithReactHookForm(<RowCluster cluster={cluster} />, { defaultValues })
+    )
+
+    const adminCheckbox = container.querySelector('button[value="ADMIN"]') as HTMLButtonElement
+    expect(adminCheckbox).toBeChecked()
+
+    await userEvent.click(adminCheckbox)
+
+    expect(adminCheckbox).not.toBeChecked()
+    const viewerCheckbox = container.querySelector('button[value="VIEWER"]') as HTMLButtonElement
+    expect(viewerCheckbox).toBeChecked()
   })
 
   it('should notify global check when a permission is selected', async () => {

--- a/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-cluster/row-cluster.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-cluster/row-cluster.spec.tsx
@@ -1,5 +1,8 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
-import { OrganizationCustomRoleClusterPermission, type OrganizationCustomRoleClusterPermissionsInner } from 'qovery-typescript-axios'
+import {
+  OrganizationCustomRoleClusterPermission,
+  type OrganizationCustomRoleClusterPermissionsInner,
+} from 'qovery-typescript-axios'
 import { customRolesMock } from '@qovery/shared/factories'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import RowCluster from './row-cluster'

--- a/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-cluster/row-cluster.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-cluster/row-cluster.tsx
@@ -62,6 +62,14 @@ export function RowCluster(props: RowClusterProps) {
                   checked={field.value === permission}
                   onCheckedChange={(checked) => {
                     if (!checked) {
+                      field.onChange(OrganizationCustomRoleClusterPermission.VIEWER)
+                      if (setGlobalCheck) {
+                        setGlobalCheckByValue(
+                          getValues(`cluster_permissions.${cluster.cluster_id}`),
+                          OrganizationCustomRoleClusterPermission.VIEWER,
+                          setGlobalCheck
+                        )
+                      }
                       return
                     }
 

--- a/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-cluster/row-cluster.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-cluster/row-cluster.tsx
@@ -61,24 +61,12 @@ export function RowCluster(props: RowClusterProps) {
                   value={permission}
                   checked={field.value === permission}
                   onCheckedChange={(checked) => {
-                    if (!checked) {
-                      field.onChange(OrganizationCustomRoleClusterPermission.VIEWER)
-                      if (setGlobalCheck) {
-                        setGlobalCheckByValue(
-                          getValues(`cluster_permissions.${cluster.cluster_id}`),
-                          OrganizationCustomRoleClusterPermission.VIEWER,
-                          setGlobalCheck
-                        )
-                      }
-                      return
-                    }
-
-                    field.onChange(permission)
-
+                    const value = checked ? permission : OrganizationCustomRoleClusterPermission.VIEWER
+                    field.onChange(value)
                     if (setGlobalCheck) {
                       setGlobalCheckByValue(
                         getValues(`cluster_permissions.${cluster.cluster_id}`),
-                        permission,
+                        value,
                         setGlobalCheck
                       )
                     }

--- a/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-project/row-project.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-project/row-project.spec.tsx
@@ -1,6 +1,9 @@
 import userEvent from '@testing-library/user-event'
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
-import { type OrganizationCustomRoleProjectPermissionsInner } from 'qovery-typescript-axios'
+import {
+  OrganizationCustomRoleProjectPermission,
+  type OrganizationCustomRoleProjectPermissionsInner,
+} from 'qovery-typescript-axios'
 import { customRolesMock } from '@qovery/shared/factories'
 import { renderWithProviders } from '@qovery/shared/util-tests'
 import RowProject, { OrganizationCustomRoleProjectPermissionAdmin } from './row-project'
@@ -30,6 +33,65 @@ describe('RowProject', () => {
     await user.click(input)
 
     expect(input).toBeChecked()
+  })
+
+  it('should set permission to NO_ACCESS when clicking an already-selected permission (AC-1)', async () => {
+    project.is_admin = false
+
+    const user = userEvent.setup()
+    const defaultValues = {
+      project_permissions: {
+        '1': {
+          ADMIN: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          DEVELOPMENT: OrganizationCustomRoleProjectPermission.MANAGER,
+          PREVIEW: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          STAGING: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          PRODUCTION: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+        },
+      },
+    }
+
+    const { container } = renderWithProviders(
+      wrapWithReactHookForm(<RowProject project={project} />, { defaultValues })
+    )
+
+    const managerCheckbox = container.querySelector('button[value="MANAGER"]') as HTMLButtonElement
+    expect(managerCheckbox).toBeChecked()
+
+    await user.click(managerCheckbox)
+
+    expect(managerCheckbox).not.toBeChecked()
+    const noAccessCheckbox = container.querySelector('button[value="NO_ACCESS"]') as HTMLButtonElement
+    expect(noAccessCheckbox).toBeChecked()
+  })
+
+  it('should update global header to NO_ACCESS after all rows become NO_ACCESS (AC-2)', async () => {
+    project.is_admin = false
+
+    const user = userEvent.setup()
+    const defaultValues = {
+      project_permissions: {
+        '1': {
+          ADMIN: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          DEVELOPMENT: OrganizationCustomRoleProjectPermission.MANAGER,
+          PREVIEW: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          STAGING: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+          PRODUCTION: OrganizationCustomRoleProjectPermission.NO_ACCESS,
+        },
+      },
+    }
+
+    const { container, getByTestId } = renderWithProviders(
+      wrapWithReactHookForm(<RowProject project={project} />, { defaultValues })
+    )
+
+    const headerNoAccess = getByTestId(`project.${OrganizationCustomRoleProjectPermission.NO_ACCESS}`)
+    expect(headerNoAccess).not.toBeChecked()
+
+    const managerCheckbox = container.querySelector('button[value="MANAGER"]') as HTMLButtonElement
+    await user.click(managerCheckbox)
+
+    expect(headerNoAccess).toBeChecked()
   })
 
   it('should be admin by default and check global select', async () => {

--- a/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-project/row-project.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-project/row-project.tsx
@@ -113,21 +113,13 @@ export function RowProject(props: RowProjectProps) {
                           value={currentPermission}
                           checked={field.value === currentPermission}
                           onCheckedChange={(checked) => {
-                            if (!checked) {
-                              field.onChange(OrganizationCustomRoleProjectPermission.NO_ACCESS)
-                              setGlobalCheckByValue(
-                                getValues(`project_permissions.${project.project_id}`),
-                                OrganizationCustomRoleProjectPermission.NO_ACCESS,
-                                setGlobalCheck
-                              )
-                              return
-                            }
-
-                            field.onChange(currentPermission)
-
+                            const value = checked
+                              ? currentPermission
+                              : OrganizationCustomRoleProjectPermission.NO_ACCESS
+                            field.onChange(value)
                             setGlobalCheckByValue(
                               getValues(`project_permissions.${project.project_id}`),
-                              currentPermission,
+                              value,
                               setGlobalCheck
                             )
                           }}

--- a/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-project/row-project.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-roles-edit/row-project/row-project.tsx
@@ -114,6 +114,12 @@ export function RowProject(props: RowProjectProps) {
                           checked={field.value === currentPermission}
                           onCheckedChange={(checked) => {
                             if (!checked) {
+                              field.onChange(OrganizationCustomRoleProjectPermission.NO_ACCESS)
+                              setGlobalCheckByValue(
+                                getValues(`project_permissions.${project.project_id}`),
+                                OrganizationCustomRoleProjectPermission.NO_ACCESS,
+                                setGlobalCheck
+                              )
                               return
                             }
 


### PR DESCRIPTION
## Summary

**Issue**: QOV-1800

When you clicked on an already active permission to remove it, nothing happened. You had to click on "No Access" to disable it, which wasn't intuitive. Now, clicking on an already selected permission removes it automatically.

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| https://github.com/user-attachments/assets/64173597-b9d9-41b7-bdcc-b2d4e92f8918 | https://github.com/user-attachments/assets/96838bf5-3b3f-4c38-8dfe-1e0c16ceef63 |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
