### PR TITLE
feat(mcp-server): add MCP server settings route and component

### DIFF
--- a/apps/console-v5/src/routeTree.gen.ts
+++ b/apps/console-v5/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as AuthenticatedOrganizationOrganizationIdAlertsIndexRouteImport 
 import { Route as AuthenticatedOrganizationOrganizationIdClusterIdIndexRouteImport } from './routes/_authenticated/organization/$organizationId/$clusterId/index'
 import { Route as AuthenticatedOrganizationOrganizationIdSettingsWebhookRouteImport } from './routes/_authenticated/organization/$organizationId/settings/webhook'
 import { Route as AuthenticatedOrganizationOrganizationIdSettingsMembersRouteImport } from './routes/_authenticated/organization/$organizationId/settings/members'
+import { Route as AuthenticatedOrganizationOrganizationIdSettingsMcpServerRouteImport } from './routes/_authenticated/organization/$organizationId/settings/mcp-server'
 import { Route as AuthenticatedOrganizationOrganizationIdSettingsLabelsAnnotationsRouteImport } from './routes/_authenticated/organization/$organizationId/settings/labels-annotations'
 import { Route as AuthenticatedOrganizationOrganizationIdSettingsHelmRepositoriesRouteImport } from './routes/_authenticated/organization/$organizationId/settings/helm-repositories'
 import { Route as AuthenticatedOrganizationOrganizationIdSettingsGitRepositoryAccessRouteImport } from './routes/_authenticated/organization/$organizationId/settings/git-repository-access'
@@ -296,6 +297,13 @@ const AuthenticatedOrganizationOrganizationIdSettingsMembersRoute =
   AuthenticatedOrganizationOrganizationIdSettingsMembersRouteImport.update({
     id: '/members',
     path: '/members',
+    getParentRoute: () =>
+      AuthenticatedOrganizationOrganizationIdSettingsRouteRoute,
+  } as any)
+const AuthenticatedOrganizationOrganizationIdSettingsMcpServerRoute =
+  AuthenticatedOrganizationOrganizationIdSettingsMcpServerRouteImport.update({
+    id: '/mcp-server',
+    path: '/mcp-server',
     getParentRoute: () =>
       AuthenticatedOrganizationOrganizationIdSettingsRouteRoute,
   } as any)
@@ -1380,6 +1388,7 @@ export interface FileRoutesByFullPath {
   '/organization/$organizationId/settings/git-repository-access': typeof AuthenticatedOrganizationOrganizationIdSettingsGitRepositoryAccessRoute
   '/organization/$organizationId/settings/helm-repositories': typeof AuthenticatedOrganizationOrganizationIdSettingsHelmRepositoriesRoute
   '/organization/$organizationId/settings/labels-annotations': typeof AuthenticatedOrganizationOrganizationIdSettingsLabelsAnnotationsRoute
+  '/organization/$organizationId/settings/mcp-server': typeof AuthenticatedOrganizationOrganizationIdSettingsMcpServerRoute
   '/organization/$organizationId/settings/members': typeof AuthenticatedOrganizationOrganizationIdSettingsMembersRoute
   '/organization/$organizationId/settings/webhook': typeof AuthenticatedOrganizationOrganizationIdSettingsWebhookRoute
   '/organization/$organizationId/$clusterId': typeof AuthenticatedOrganizationOrganizationIdClusterIdIndexRoute
@@ -1523,6 +1532,7 @@ export interface FileRoutesByTo {
   '/organization/$organizationId/settings/git-repository-access': typeof AuthenticatedOrganizationOrganizationIdSettingsGitRepositoryAccessRoute
   '/organization/$organizationId/settings/helm-repositories': typeof AuthenticatedOrganizationOrganizationIdSettingsHelmRepositoriesRoute
   '/organization/$organizationId/settings/labels-annotations': typeof AuthenticatedOrganizationOrganizationIdSettingsLabelsAnnotationsRoute
+  '/organization/$organizationId/settings/mcp-server': typeof AuthenticatedOrganizationOrganizationIdSettingsMcpServerRoute
   '/organization/$organizationId/settings/members': typeof AuthenticatedOrganizationOrganizationIdSettingsMembersRoute
   '/organization/$organizationId/settings/webhook': typeof AuthenticatedOrganizationOrganizationIdSettingsWebhookRoute
   '/organization/$organizationId/$clusterId': typeof AuthenticatedOrganizationOrganizationIdClusterIdIndexRoute
@@ -1661,6 +1671,7 @@ export interface FileRoutesById {
   '/_authenticated/organization/$organizationId/settings/git-repository-access': typeof AuthenticatedOrganizationOrganizationIdSettingsGitRepositoryAccessRoute
   '/_authenticated/organization/$organizationId/settings/helm-repositories': typeof AuthenticatedOrganizationOrganizationIdSettingsHelmRepositoriesRoute
   '/_authenticated/organization/$organizationId/settings/labels-annotations': typeof AuthenticatedOrganizationOrganizationIdSettingsLabelsAnnotationsRoute
+  '/_authenticated/organization/$organizationId/settings/mcp-server': typeof AuthenticatedOrganizationOrganizationIdSettingsMcpServerRoute
   '/_authenticated/organization/$organizationId/settings/members': typeof AuthenticatedOrganizationOrganizationIdSettingsMembersRoute
   '/_authenticated/organization/$organizationId/settings/webhook': typeof AuthenticatedOrganizationOrganizationIdSettingsWebhookRoute
   '/_authenticated/organization/$organizationId/$clusterId/': typeof AuthenticatedOrganizationOrganizationIdClusterIdIndexRoute
@@ -1810,6 +1821,7 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/settings/git-repository-access'
     | '/organization/$organizationId/settings/helm-repositories'
     | '/organization/$organizationId/settings/labels-annotations'
+    | '/organization/$organizationId/settings/mcp-server'
     | '/organization/$organizationId/settings/members'
     | '/organization/$organizationId/settings/webhook'
     | '/organization/$organizationId/$clusterId'
@@ -1953,6 +1965,7 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/settings/git-repository-access'
     | '/organization/$organizationId/settings/helm-repositories'
     | '/organization/$organizationId/settings/labels-annotations'
+    | '/organization/$organizationId/settings/mcp-server'
     | '/organization/$organizationId/settings/members'
     | '/organization/$organizationId/settings/webhook'
     | '/organization/$organizationId/$clusterId'
@@ -2090,6 +2103,7 @@ export interface FileRouteTypes {
     | '/_authenticated/organization/$organizationId/settings/git-repository-access'
     | '/_authenticated/organization/$organizationId/settings/helm-repositories'
     | '/_authenticated/organization/$organizationId/settings/labels-annotations'
+    | '/_authenticated/organization/$organizationId/settings/mcp-server'
     | '/_authenticated/organization/$organizationId/settings/members'
     | '/_authenticated/organization/$organizationId/settings/webhook'
     | '/_authenticated/organization/$organizationId/$clusterId/'
@@ -2379,6 +2393,13 @@ declare module '@tanstack/react-router' {
       path: '/members'
       fullPath: '/organization/$organizationId/settings/members'
       preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsMembersRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsRouteRoute
+    }
+    '/_authenticated/organization/$organizationId/settings/mcp-server': {
+      id: '/_authenticated/organization/$organizationId/settings/mcp-server'
+      path: '/mcp-server'
+      fullPath: '/organization/$organizationId/settings/mcp-server'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsMcpServerRouteImport
       parentRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsRouteRoute
     }
     '/_authenticated/organization/$organizationId/settings/labels-annotations': {
@@ -3274,6 +3295,7 @@ interface AuthenticatedOrganizationOrganizationIdSettingsRouteRouteChildren {
   AuthenticatedOrganizationOrganizationIdSettingsGitRepositoryAccessRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsGitRepositoryAccessRoute
   AuthenticatedOrganizationOrganizationIdSettingsHelmRepositoriesRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsHelmRepositoriesRoute
   AuthenticatedOrganizationOrganizationIdSettingsLabelsAnnotationsRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsLabelsAnnotationsRoute
+  AuthenticatedOrganizationOrganizationIdSettingsMcpServerRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsMcpServerRoute
   AuthenticatedOrganizationOrganizationIdSettingsMembersRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsMembersRoute
   AuthenticatedOrganizationOrganizationIdSettingsWebhookRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsWebhookRoute
   AuthenticatedOrganizationOrganizationIdSettingsIndexRoute: typeof AuthenticatedOrganizationOrganizationIdSettingsIndexRoute
@@ -3305,6 +3327,8 @@ const AuthenticatedOrganizationOrganizationIdSettingsRouteRouteChildren: Authent
       AuthenticatedOrganizationOrganizationIdSettingsHelmRepositoriesRoute,
     AuthenticatedOrganizationOrganizationIdSettingsLabelsAnnotationsRoute:
       AuthenticatedOrganizationOrganizationIdSettingsLabelsAnnotationsRoute,
+    AuthenticatedOrganizationOrganizationIdSettingsMcpServerRoute:
+      AuthenticatedOrganizationOrganizationIdSettingsMcpServerRoute,
     AuthenticatedOrganizationOrganizationIdSettingsMembersRoute:
       AuthenticatedOrganizationOrganizationIdSettingsMembersRoute,
     AuthenticatedOrganizationOrganizationIdSettingsWebhookRoute:

--- a/apps/console-v5/src/routes/_authenticated/organization/$organizationId/settings/mcp-server.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/$organizationId/settings/mcp-server.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SettingsMcpServer } from '@qovery/domains/organizations/feature'
+
+export const Route = createFileRoute('/_authenticated/organization/$organizationId/settings/mcp-server')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <SettingsMcpServer />
+}

--- a/apps/console-v5/src/routes/_authenticated/organization/$organizationId/settings/route.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/$organizationId/settings/route.tsx
@@ -92,6 +92,12 @@ function RouteComponent() {
     icon: 'sparkles' as const,
   }
 
+  const mcpServerLink = {
+    title: 'MCP server',
+    to: `${pathSettings}/mcp-server`,
+    icon: 'code' as const,
+  }
+
   const dangerZoneLink = {
     title: 'Danger zone',
     to: `${pathSettings}/danger-zone`,
@@ -110,6 +116,7 @@ function RouteComponent() {
     webhookLink,
     apiTokenLink,
     aiCopilotLink,
+    mcpServerLink,
     ...(isOrganizationAdmin ? [dangerZoneLink] : []),
   ]
 

--- a/libs/domains/organizations/feature/src/index.ts
+++ b/libs/domains/organizations/feature/src/index.ts
@@ -99,6 +99,7 @@ export * from './lib/settings-container-registries/settings-container-registries
 export * from './lib/settings-billing-summary/settings-billing-summary'
 export * from './lib/settings-webhook/settings-webhook'
 export * from './lib/settings-api-token/settings-api-token'
+export * from './lib/settings-mcp-server/settings-mcp-server'
 export * from './lib/settings-danger-zone/settings-danger-zone'
 export * from './lib/settings-billing-details/settings-billing-details'
 export * from './lib/settings-roles/settings-roles'

--- a/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.spec.tsx
@@ -1,12 +1,18 @@
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { SettingsMcpServer } from './settings-mcp-server'
 
+jest.mock('@tanstack/react-router', () => ({
+  ...jest.requireActual('@tanstack/react-router'),
+  useParams: () => ({ organizationId: 'org-1' }),
+}))
+
 describe('SettingsMcpServer', () => {
   it('should render heading and default Claude Code tab content', () => {
     renderWithProviders(<SettingsMcpServer />)
 
     expect(screen.getByRole('heading', { name: 'MCP server' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Configure MCP server' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Configure via OAuth (recommended)' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Configure via API token' })).toBeInTheDocument()
     expect(screen.getByText('Claude Code')).toBeInTheDocument()
     expect(screen.getByText('Codex')).toBeInTheDocument()
     expect(
@@ -24,18 +30,12 @@ describe('SettingsMcpServer', () => {
     expect(screen.getByText("codex mcp add qovery --url 'https://mcp.qovery.com/mcp'")).toBeInTheDocument()
   })
 
-  it('should display access mode badges for MCP tools', () => {
+  it('should render API token setup steps', () => {
     renderWithProviders(<SettingsMcpServer />)
 
-    expect(screen.getByText('devops_copilot')).toBeInTheDocument()
-    expect(screen.getByText('read-write')).toBeInTheDocument()
-    expect(screen.getAllByText('read-only')).toHaveLength(4)
-  })
-
-  it('should render docs link for API token setup', () => {
-    renderWithProviders(<SettingsMcpServer />)
-
-    const docsLink = screen.getByRole('link', { name: 'See how' })
-    expect(docsLink).toHaveAttribute('href', 'https://www.qovery.com/docs/copilot/mcp-server#2-api-token')
+    expect(screen.getByText('1. Generate token and copy it')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Generate API token' })).toBeInTheDocument()
+    expect(screen.getByText('2. Authenticate through your API token')).toBeInTheDocument()
+    expect(screen.getByText(/Authorization: Token your_qovery_token/)).toBeInTheDocument()
   })
 })

--- a/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.spec.tsx
@@ -1,0 +1,41 @@
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { SettingsMcpServer } from './settings-mcp-server'
+
+describe('SettingsMcpServer', () => {
+  it('should render heading and default Claude Code tab content', () => {
+    renderWithProviders(<SettingsMcpServer />)
+
+    expect(screen.getByRole('heading', { name: 'MCP server' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Configure MCP server' })).toBeInTheDocument()
+    expect(screen.getByText('Claude Code')).toBeInTheDocument()
+    expect(screen.getByText('Codex')).toBeInTheDocument()
+    expect(
+      screen.getByText('claude mcp add --transport http qovery https://mcp.qovery.com/mcp --callback-port 4242')
+    ).toBeInTheDocument()
+  })
+
+  it('should switch to Codex instructions when clicking Codex tab', async () => {
+    const { userEvent } = renderWithProviders(<SettingsMcpServer />)
+
+    await userEvent.click(screen.getByText('Codex'))
+
+    expect(screen.getByText('1. Update your config.toml')).toBeInTheDocument()
+    expect(screen.getByText('mcp_oauth_callback_port = 4242')).toBeInTheDocument()
+    expect(screen.getByText("codex mcp add qovery --url 'https://mcp.qovery.com/mcp'")).toBeInTheDocument()
+  })
+
+  it('should display access mode badges for MCP tools', () => {
+    renderWithProviders(<SettingsMcpServer />)
+
+    expect(screen.getByText('devops_copilot')).toBeInTheDocument()
+    expect(screen.getByText('read-write')).toBeInTheDocument()
+    expect(screen.getAllByText('read-only')).toHaveLength(4)
+  })
+
+  it('should render docs link for API token setup', () => {
+    renderWithProviders(<SettingsMcpServer />)
+
+    const docsLink = screen.getByRole('link', { name: 'See how' })
+    expect(docsLink).toHaveAttribute('href', 'https://www.qovery.com/docs/copilot/mcp-server#2-api-token')
+  })
+})

--- a/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.tsx
@@ -35,7 +35,7 @@ const MCP_TOOLS = [
     icon: 'folder-open',
     accessMode: 'read-only',
   },
-]
+] as const
 
 interface CommandBlockProps {
   content: string

--- a/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.tsx
@@ -1,41 +1,9 @@
+import { useParams } from '@tanstack/react-router'
 import { type ReactNode, useState } from 'react'
 import { NeedHelp } from '@qovery/shared/assistant/feature'
-import { Badge, CopyButton, ExternalLink, Heading, Icon, Navbar, Section } from '@qovery/shared/ui'
+import { Button, CopyButton, Heading, Icon, Navbar, Section, useModal } from '@qovery/shared/ui'
 import { useDocumentTitle } from '@qovery/shared/util-hooks'
-
-const MCP_TOOLS = [
-  {
-    name: 'devops_copilot',
-    description:
-      'Send a message to the DevOps Copilot for Qovery actions. Resolve organization, project, environment, and service IDs first, then reference resources by UUID in the message.',
-    icon: 'sparkles',
-    accessMode: 'read-write',
-  },
-  {
-    name: 'get_service_logs',
-    description: 'Fetch service or application logs, optionally scoped to a deployment or a specific pod.',
-    icon: 'scroll',
-    accessMode: 'read-only',
-  },
-  {
-    name: 'list_environments',
-    description: 'List all environments available in a Qovery project.',
-    icon: 'layer-group',
-    accessMode: 'read-only',
-  },
-  {
-    name: 'list_organizations',
-    description: 'List all organizations the authenticated token can access.',
-    icon: 'building',
-    accessMode: 'read-only',
-  },
-  {
-    name: 'list_projects',
-    description: 'List all projects available in a Qovery organization.',
-    icon: 'folder-open',
-    accessMode: 'read-only',
-  },
-] as const
+import CrudModalFeature from '../settings-api-token/crud-modal-feature/crud-modal-feature'
 
 interface CommandBlockProps {
   content: string
@@ -43,8 +11,14 @@ interface CommandBlockProps {
 }
 
 function CommandBlock({ content, showPrompt = false }: CommandBlockProps) {
+  const isMultiline = content.includes('\n')
+
   return (
-    <div className="flex items-center gap-6 rounded border border-neutral bg-surface-neutral-subtle p-3 text-neutral retina:border-[0.5px]">
+    <div
+      className={`flex gap-6 rounded border border-neutral bg-surface-neutral-subtle p-3 text-neutral retina:border-[0.5px] ${
+        isMultiline ? 'items-start' : 'items-center'
+      }`}
+    >
       <div className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-neutral">
         {showPrompt ? <span className="select-none">$ </span> : null}
         {content}
@@ -78,6 +52,8 @@ function InstructionSection({ number, title, description, children }: Instructio
 }
 
 export function SettingsMcpServer() {
+  const { organizationId = '' } = useParams({ strict: false })
+  const { openModal, closeModal } = useModal()
   useDocumentTitle('MCP server - Organization settings')
   const [activeClient, setActiveClient] = useState<'claude-code' | 'codex'>('claude-code')
 
@@ -100,7 +76,7 @@ export function SettingsMcpServer() {
         <div className="max-w-content-with-navigation-left space-y-8">
           <Section className="gap-4">
             <div className="space-y-1">
-              <Heading level={2}>Configure MCP server</Heading>
+              <Heading level={2}>Configure via OAuth (recommended)</Heading>
             </div>
 
             <div className="flex flex-col gap-3">
@@ -139,7 +115,7 @@ export function SettingsMcpServer() {
                       />
                     </InstructionSection>
                   ) : (
-                    <div className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-5">
                       <InstructionSection
                         number={1}
                         title="Update your config.toml"
@@ -158,51 +134,50 @@ export function SettingsMcpServer() {
                   )}
                 </div>
               </div>
-
-              <p className="text-sm text-neutral-subtle">
-                You can also configure the MCP server through an API token.{' '}
-                <ExternalLink
-                  href="https://www.qovery.com/docs/copilot/mcp-server#2-api-token"
-                  size="sm"
-                  className="font-normal text-info hover:text-info"
-                >
-                  See how
-                </ExternalLink>
-                .
-              </p>
             </div>
           </Section>
 
           <Section className="gap-4">
             <div className="space-y-1">
-              <Heading level={2}>MCP tools</Heading>
-              <p className="text-sm text-neutral-subtle">
-                Our Qovery MCP server provides MCP tools that let AI assistants search through projects, environments,
-                service logs and more.
-              </p>
+              <Heading level={2}>Configure via API token</Heading>
             </div>
 
-            <div className="grid gap-2">
-              {MCP_TOOLS.map((tool) => (
-                <div
-                  key={tool.name}
-                  className="flex flex-col gap-2 rounded-md border border-neutral bg-surface-neutral-subtle p-4"
+            <div className="overflow-hidden rounded-md border border-neutral bg-surface-neutral p-4">
+              <div className="flex flex-col gap-5">
+                <InstructionSection
+                  number={1}
+                  title="Generate token and copy it"
+                  description="Save this token securely. You won’t be able to see it again!"
                 >
-                  <div className="flex items-center gap-2">
-                    <Icon iconName={tool.icon} className="text-sm text-neutral-subtle" />
-                    <Heading level={3}>{tool.name}</Heading>
-                    <Badge
-                      size="sm"
-                      variant="surface"
-                      color={tool.accessMode === 'read-write' ? 'yellow' : 'green'}
-                      className="px-1"
+                  <div>
+                    <Button
+                      color="brand"
+                      size="md"
+                      onClick={() =>
+                        openModal({
+                          content: <CrudModalFeature organizationId={organizationId} onClose={closeModal} />,
+                        })
+                      }
                     >
-                      {tool.accessMode}
-                    </Badge>
+                      Generate API token
+                    </Button>
                   </div>
-                  <p className="text-sm text-neutral-subtle">{tool.description}</p>
-                </div>
-              ))}
+                </InstructionSection>
+
+                <InstructionSection
+                  number={2}
+                  title="Authenticate through your API token"
+                  description="Pass your Qovery token via query parameter or Authorization header"
+                >
+                  <CommandBlock
+                    content={`# Query parameter
+https://mcp.qovery.com/mcp?token=your_qovery_token
+
+# Authorization header
+Authorization: Token your_qovery_token`}
+                  />
+                </InstructionSection>
+              </div>
             </div>
           </Section>
         </div>

--- a/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.tsx
@@ -1,0 +1,212 @@
+import { type ReactNode, useState } from 'react'
+import { NeedHelp } from '@qovery/shared/assistant/feature'
+import { Badge, CopyButton, ExternalLink, Heading, Icon, Navbar, Section } from '@qovery/shared/ui'
+import { useDocumentTitle } from '@qovery/shared/util-hooks'
+
+const MCP_TOOLS = [
+  {
+    name: 'devops_copilot',
+    description:
+      'Send a message to the DevOps Copilot for Qovery actions. Resolve organization, project, environment, and service IDs first, then reference resources by UUID in the message.',
+    icon: 'sparkles',
+    accessMode: 'read-write',
+  },
+  {
+    name: 'get_service_logs',
+    description: 'Fetch service or application logs, optionally scoped to a deployment or a specific pod.',
+    icon: 'scroll',
+    accessMode: 'read-only',
+  },
+  {
+    name: 'list_environments',
+    description: 'List all environments available in a Qovery project.',
+    icon: 'layer-group',
+    accessMode: 'read-only',
+  },
+  {
+    name: 'list_organizations',
+    description: 'List all organizations the authenticated token can access.',
+    icon: 'building',
+    accessMode: 'read-only',
+  },
+  {
+    name: 'list_projects',
+    description: 'List all projects available in a Qovery organization.',
+    icon: 'folder-open',
+    accessMode: 'read-only',
+  },
+]
+
+interface CommandBlockProps {
+  content: string
+  showPrompt?: boolean
+}
+
+function CommandBlock({ content, showPrompt = false }: CommandBlockProps) {
+  return (
+    <div className="flex items-center gap-6 rounded border border-neutral bg-surface-neutral-subtle p-3 text-neutral retina:border-[0.5px]">
+      <div className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-neutral">
+        {showPrompt ? <span className="select-none">$ </span> : null}
+        {content}
+      </div>
+      <div className="shrink-0">
+        <CopyButton content={content} />
+      </div>
+    </div>
+  )
+}
+
+interface InstructionSectionProps {
+  number: number
+  title: string
+  description?: string
+  children: ReactNode
+}
+
+function InstructionSection({ number, title, description, children }: InstructionSectionProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-neutral">
+          {number}. {title}
+        </p>
+        {description ? <p className="text-sm text-neutral-subtle">{description}</p> : null}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export function SettingsMcpServer() {
+  useDocumentTitle('MCP server - Organization settings')
+  const [activeClient, setActiveClient] = useState<'claude-code' | 'codex'>('claude-code')
+
+  return (
+    <div className="w-full">
+      <Section className="px-8 pb-8 pt-6">
+        <div className="mb-8 flex w-full justify-between gap-2 border-b border-neutral">
+          <div className="flex w-full items-start justify-between gap-4 pb-6">
+            <div className="flex flex-col gap-2">
+              <Heading>MCP server</Heading>
+              <p className="max-w-2xl text-sm text-neutral-subtle">
+                The Qovery MCP Server lets you interact with your Qovery infrastructure from any MCP-compatible client
+                (Claude, Claude Code, ChatGPT, etc.) using natural language.
+              </p>
+              <NeedHelp className="mt-2" />
+            </div>
+          </div>
+        </div>
+
+        <div className="max-w-content-with-navigation-left space-y-8">
+          <Section className="gap-4">
+            <div className="space-y-1">
+              <Heading level={2}>Configure MCP server</Heading>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <div className="overflow-hidden rounded-md border border-neutral bg-surface-neutral">
+                <div className="border-b border-neutral px-4">
+                  <Navbar.Root
+                    activeId={activeClient}
+                    ariaLabel="MCP client selector"
+                    className="relative top-[1px] -mt-[1px]"
+                  >
+                    <Navbar.Item
+                      id="claude-code"
+                      active={activeClient === 'claude-code'}
+                      onClick={() => setActiveClient('claude-code')}
+                    >
+                      <Icon iconName="claude" iconStyle="brands" />
+                      <span>Claude Code</span>
+                    </Navbar.Item>
+                    <Navbar.Item id="codex" active={activeClient === 'codex'} onClick={() => setActiveClient('codex')}>
+                      <Icon iconName="openai" iconStyle="brands" />
+                      <span>Codex</span>
+                    </Navbar.Item>
+                  </Navbar.Root>
+                </div>
+
+                <div className="p-4">
+                  {activeClient === 'claude-code' ? (
+                    <InstructionSection
+                      number={1}
+                      title="Run this command"
+                      description="Authenticate through OAuth and add the Qovery MCP server to Claude Code."
+                    >
+                      <CommandBlock
+                        content="claude mcp add --transport http qovery https://mcp.qovery.com/mcp --callback-port 4242"
+                        showPrompt
+                      />
+                    </InstructionSection>
+                  ) : (
+                    <div className="flex flex-col gap-4">
+                      <InstructionSection
+                        number={1}
+                        title="Update your config.toml"
+                        description="Add this setting to your Codex configuration file to use the OAuth callback port."
+                      >
+                        <CommandBlock content="mcp_oauth_callback_port = 4242" />
+                      </InstructionSection>
+                      <InstructionSection
+                        number={2}
+                        title="Run this command"
+                        description="Authenticate through OAuth and add the Qovery MCP server to Codex."
+                      >
+                        <CommandBlock content="codex mcp add qovery --url 'https://mcp.qovery.com/mcp'" showPrompt />
+                      </InstructionSection>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <p className="text-sm text-neutral-subtle">
+                You can also configure the MCP server through an API token.{' '}
+                <ExternalLink
+                  href="https://www.qovery.com/docs/copilot/mcp-server#2-api-token"
+                  size="sm"
+                  className="font-normal text-info hover:text-info"
+                >
+                  See how
+                </ExternalLink>
+                .
+              </p>
+            </div>
+          </Section>
+
+          <Section className="gap-4">
+            <div className="space-y-1">
+              <Heading level={2}>MCP tools</Heading>
+              <p className="text-sm text-neutral-subtle">
+                Our Qovery MCP server provides MCP tools that let AI assistants search through projects, environments,
+                service logs and more.
+              </p>
+            </div>
+
+            <div className="grid gap-2">
+              {MCP_TOOLS.map((tool) => (
+                <div
+                  key={tool.name}
+                  className="flex flex-col gap-2 rounded-md border border-neutral bg-surface-neutral-subtle p-4"
+                >
+                  <div className="flex items-center gap-2">
+                    <Icon iconName={tool.icon} className="text-sm text-neutral-subtle" />
+                    <Heading level={3}>{tool.name}</Heading>
+                    <Badge
+                      size="sm"
+                      variant="surface"
+                      color={tool.accessMode === 'read-write' ? 'yellow' : 'green'}
+                      className="px-1"
+                    >
+                      {tool.accessMode}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-neutral-subtle">{tool.description}</p>
+                </div>
+              ))}
+            </div>
+          </Section>
+        </div>
+      </Section>
+    </div>
+  )
+}

--- a/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-mcp-server/settings-mcp-server.tsx
@@ -90,12 +90,18 @@ export function SettingsMcpServer() {
                     <Navbar.Item
                       id="claude-code"
                       active={activeClient === 'claude-code'}
+                      className="cursor-pointer"
                       onClick={() => setActiveClient('claude-code')}
                     >
                       <Icon iconName="claude" iconStyle="brands" />
                       <span>Claude Code</span>
                     </Navbar.Item>
-                    <Navbar.Item id="codex" active={activeClient === 'codex'} onClick={() => setActiveClient('codex')}>
+                    <Navbar.Item
+                      id="codex"
+                      active={activeClient === 'codex'}
+                      className="cursor-pointer"
+                      onClick={() => setActiveClient('codex')}
+                    >
                       <Icon iconName="openai" iconStyle="brands" />
                       <span>Codex</span>
                     </Navbar.Item>


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary
- Introduced a new route for MCP server settings in the authenticated organization settings.
- Created the SettingsMcpServer component to manage MCP server configurations.
- Updated route tree and interfaces to include the new MCP server route.
- Added links to the MCP server settings in the organization settings navigation.
- Implemented tests for the SettingsMcpServer component to ensure proper rendering and functionality.

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings
<img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/47a10e7f-a398-4acd-82ef-ff885e32c248" />
<img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/f9d1b9b2-e0fa-422c-b401-5ba0982a60d8" />


<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
