### PR TITLE
feat(console-migration): add banner to migrate console to new-console

### DIFF
--- a/libs/pages/layout/src/lib/ui/console-migration-prompt/console-migration-prompt.tsx
+++ b/libs/pages/layout/src/lib/ui/console-migration-prompt/console-migration-prompt.tsx
@@ -1,0 +1,54 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import { Button, Icon } from '@qovery/shared/ui'
+
+export interface ConsoleMigrationPromptProps {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => void
+}
+
+export function ConsoleMigrationPrompt({ open, onClose, onConfirm }: ConsoleMigrationPromptProps) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed bottom-[18px] left-[calc(50%+2rem)] max-w-content-with-navigation-left -translate-x-1/2">
+          <motion.aside
+            key="console-migration-prompt"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 20 }}
+            transition={{
+              animate: { duration: 0.12, ease: 'easeOut', delay: 2 },
+              exit: { duration: 0.12, ease: 'easeOut' },
+            }}
+          >
+            <div className="overflow-hidden rounded-full border border-neutral-200 bg-white/95 shadow-[0_16px_48px_rgba(16,30,54,0.14)] backdrop-blur">
+              <div className="flex h-10 items-center justify-center gap-2 bg-gradient-to-r from-brand-500/10 via-sky-400/10 to-brand-500/5 px-4 pl-2">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand-500/10 text-brand-500">
+                  <Icon iconName="gift" className="text-xs" />
+                </div>
+                <p className="max-w-[32rem] truncate text-center text-ssm text-neutral-400">
+                  Switch to the new console and redirect future visits automatically.
+                </p>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button type="button" size="sm" color="brand" onClick={onConfirm}>
+                    Try now
+                  </Button>
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="flex h-4 w-4 items-center justify-center text-neutral-400 transition-colors hover:text-neutral-350"
+                  >
+                    <Icon iconName="xmark" iconStyle="regular" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </motion.aside>
+        </div>
+      )}
+    </AnimatePresence>
+  )
+}
+
+export default ConsoleMigrationPrompt

--- a/libs/pages/layout/src/lib/ui/console-migration-prompt/console-migration-prompt.tsx
+++ b/libs/pages/layout/src/lib/ui/console-migration-prompt/console-migration-prompt.tsx
@@ -30,7 +30,7 @@ export function ConsoleMigrationPrompt({ open, onClose, onConfirm }: ConsoleMigr
                 <p className="max-w-[32rem] truncate text-center text-ssm text-neutral-400">
                   A new version of the Qovery console available! Join the early access now.
                 </p>
-                <div className="flex shrink-0 items-center gap-0.5">
+                <div className="flex shrink-0 items-center gap-1">
                   <Button type="button" size="sm" color="brand" radius="full" onClick={onConfirm}>
                     Try now
                   </Button>

--- a/libs/pages/layout/src/lib/ui/console-migration-prompt/console-migration-prompt.tsx
+++ b/libs/pages/layout/src/lib/ui/console-migration-prompt/console-migration-prompt.tsx
@@ -34,7 +34,7 @@ export function ConsoleMigrationPrompt({ open, onClose, onConfirm }: ConsoleMigr
                   <Button type="button" size="sm" color="brand" radius="full" onClick={onConfirm}>
                     Try now
                   </Button>
-                  <Button type="button" size="sm" variant="plain" color="neutral" radius="full" onClick={onClose}>
+                  <Button type="button" size="sm" variant="outline" color="neutral" radius="full" onClick={onClose}>
                     Not interested
                   </Button>
                 </div>

--- a/libs/pages/layout/src/lib/ui/console-migration-prompt/console-migration-prompt.tsx
+++ b/libs/pages/layout/src/lib/ui/console-migration-prompt/console-migration-prompt.tsx
@@ -23,24 +23,20 @@ export function ConsoleMigrationPrompt({ open, onClose, onConfirm }: ConsoleMigr
             }}
           >
             <div className="overflow-hidden rounded-full border border-neutral-200 bg-white/95 shadow-[0_16px_48px_rgba(16,30,54,0.14)] backdrop-blur">
-              <div className="flex h-10 items-center justify-center gap-2 bg-gradient-to-r from-brand-500/10 via-sky-400/10 to-brand-500/5 px-4 pl-2">
+              <div className="flex h-10 items-center justify-center gap-2 bg-gradient-to-r from-brand-500/10 via-sky-400/10 to-brand-500/5 px-2">
                 <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand-500/10 text-brand-500">
                   <Icon iconName="gift" className="text-xs" />
                 </div>
                 <p className="max-w-[32rem] truncate text-center text-ssm text-neutral-400">
-                  Switch to the new console and redirect future visits automatically.
+                  A new version of the Qovery console available! Join the early access now.
                 </p>
-                <div className="flex shrink-0 items-center gap-2">
-                  <Button type="button" size="sm" color="brand" onClick={onConfirm}>
+                <div className="flex shrink-0 items-center gap-0.5">
+                  <Button type="button" size="sm" color="brand" radius="full" onClick={onConfirm}>
                     Try now
                   </Button>
-                  <button
-                    type="button"
-                    onClick={onClose}
-                    className="flex h-4 w-4 items-center justify-center text-neutral-400 transition-colors hover:text-neutral-350"
-                  >
-                    <Icon iconName="xmark" iconStyle="regular" />
-                  </button>
+                  <Button type="button" size="sm" variant="plain" color="neutral" radius="full" onClick={onClose}>
+                    Not interested
+                  </Button>
                 </div>
               </div>
             </div>

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.spec.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.spec.tsx
@@ -1,11 +1,28 @@
+import posthog from 'posthog-js'
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { CloudProviderEnum } from 'qovery-typescript-axios'
-import { IntercomProvider } from 'react-use-intercom'
+import { type ReactNode } from 'react'
+import * as iamFeature from '@qovery/shared/iam/feature'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import LayoutPage, { type LayoutPageProps } from './layout-page'
+import { redirectToUrl } from './layout-page.utils'
+
+jest.mock('posthog-js', () => ({
+  capture: jest.fn(),
+  getFeatureFlagPayload: jest.fn(),
+  isFeatureEnabled: jest.fn(() => false),
+  onFeatureFlags: jest.fn(),
+}))
+
+jest.mock('posthog-js/react', () => ({
+  useFeatureFlagEnabled: jest.fn(() => true),
+  useFeatureFlagVariantKey: jest.fn(() => false),
+}))
 
 jest.mock('@qovery/domains/clusters/feature', () => {
   return {
     ...jest.requireActual('@qovery/domains/clusters/feature'),
+    ClusterDeploymentProgressCard: () => null,
     useClusterStatuses: () => ({
       data: [
         {
@@ -17,11 +34,36 @@ jest.mock('@qovery/domains/clusters/feature', () => {
   }
 })
 
-const renderComponent = (props: LayoutPageProps) => (
-  <IntercomProvider appId="__test__app__id__" autoBoot={false}>
-    <LayoutPage {...props} />
-  </IntercomProvider>
-)
+jest.mock('@qovery/domains/organizations/feature', () => ({
+  FreeTrialBanner: () => null,
+  InvoiceBanner: () => null,
+  useOrganization: () => ({ data: undefined }),
+}))
+
+jest.mock('@qovery/shared/assistant/feature', () => ({
+  AssistantTrigger: () => null,
+}))
+
+jest.mock('@qovery/shared/devops-copilot/feature', () => ({
+  DevopsCopilotButton: () => null,
+  DevopsCopilotTrigger: () => null,
+}))
+
+jest.mock('@qovery/shared/posthog/feature', () => ({
+  AnnouncementBanner: () => null,
+}))
+
+jest.mock('./layout-page.utils', () => ({
+  redirectToUrl: jest.fn(),
+}))
+
+jest.mock('../navigation/navigation', () => () => null)
+jest.mock('../top-bar/top-bar', () => ({ children }: { children: ReactNode }) => <>{children}</>)
+jest.mock('../../feature/spotlight-trigger/spotlight-trigger', () => () => null)
+
+const useFeatureFlagEnabledMock = useFeatureFlagEnabled as jest.MockedFunction<typeof useFeatureFlagEnabled>
+
+const renderComponent = (props: LayoutPageProps) => <LayoutPage {...props} />
 
 describe('LayoutPage', () => {
   const props: LayoutPageProps = {
@@ -29,23 +71,65 @@ describe('LayoutPage', () => {
     topBar: false,
   }
 
+  beforeEach(() => {
+    localStorage.clear()
+    jest.clearAllMocks()
+    useFeatureFlagEnabledMock.mockReturnValue(true)
+    jest.spyOn(iamFeature, 'getNewConsoleUrl').mockReturnValue('https://new-console.qovery.com/organization/123')
+    jest.spyOn(iamFeature, 'useConsoleRedirectPreference').mockReturnValue({
+      preferredConsole: 'legacy',
+      isNewConsoleDefault: false,
+      setPreferredConsole: jest.fn(),
+      setIsNewConsoleDefault: jest.fn(),
+    })
+    jest.spyOn(iamFeature, 'useUserRole').mockReturnValue({
+      roles: [],
+      isQoveryAdminUser: false,
+      loading: false,
+    } as ReturnType<typeof iamFeature.useUserRole>)
+  })
+
   it('should render successfully', () => {
     const { baseElement } = renderWithProviders(renderComponent({ ...props }))
     expect(baseElement).toBeTruthy()
   })
 
   it('should have cluster deployment error banner', () => {
-    props.clusters = [
-      {
-        id: '0000-0000-0000-0000',
-        name: 'cluster-name',
-        created_at: '',
-        region: '',
-        cloud_provider: CloudProviderEnum.AWS,
-      },
-    ]
-
-    renderWithProviders(renderComponent({ ...props }))
+    renderWithProviders(
+      renderComponent({
+        ...props,
+        clusters: [
+          {
+            id: '0000-0000-0000-0000',
+            name: 'cluster-name',
+            created_at: '',
+            region: '',
+            cloud_provider: CloudProviderEnum.AWS,
+          },
+        ],
+      })
+    )
     screen.getByText('Check the credentials configuration')
+  })
+
+  it('should capture an analytics event when dismissing the console migration prompt', async () => {
+    const { userEvent } = renderWithProviders(renderComponent({ ...props }))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Not interested' }))
+
+    expect(posthog.capture).toHaveBeenCalledWith('legacy-console-migration-prompt-dismissed', {
+      target_url: 'https://new-console.qovery.com/organization/123',
+    })
+  })
+
+  it('should capture an analytics event when confirming the console migration prompt', async () => {
+    const { userEvent } = renderWithProviders(renderComponent({ ...props }))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Try now' }))
+
+    expect(posthog.capture).toHaveBeenCalledWith('legacy-console-migration-prompt-confirmed', {
+      target_url: 'https://new-console.qovery.com/organization/123',
+    })
+    expect(redirectToUrl).toHaveBeenCalledWith('https://new-console.qovery.com/organization/123')
   })
 })

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.spec.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.spec.tsx
@@ -117,7 +117,7 @@ describe('LayoutPage', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Not interested' }))
 
-    expect(posthog.capture).toHaveBeenCalledWith('legacy-console-migration-prompt-dismissed', {
+    expect(posthog.capture).toHaveBeenCalledWith('console-migration-prompt-dismissed', {
       target_url: 'https://new-console.qovery.com/organization/123',
     })
   })
@@ -127,7 +127,7 @@ describe('LayoutPage', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Try now' }))
 
-    expect(posthog.capture).toHaveBeenCalledWith('legacy-console-migration-prompt-confirmed', {
+    expect(posthog.capture).toHaveBeenCalledWith('console-migration-prompt-confirmed', {
       target_url: 'https://new-console.qovery.com/organization/123',
     })
     expect(redirectToUrl).toHaveBeenCalledWith('https://new-console.qovery.com/organization/123')

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
@@ -64,7 +64,7 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
   const { data: clusterStatuses } = useClusterStatuses({ organizationId, enabled: !!organizationId })
   const { data: organization } = useOrganization({ organizationId })
   const { roles, isQoveryAdminUser } = useUserRole()
-  const { useNewConsoleByDefault, setUseNewConsoleByDefault } = useConsoleRedirectPreference()
+  const { isNewConsoleDefault, setIsNewConsoleDefault } = useConsoleRedirectPreference()
   const isNewNavigationActivationEnabled = Boolean(useFeatureFlagEnabled('new-navigation-activation'))
   const isAlertingFeatureFlagEnabled = useFeatureFlagVariantKey('alerting')
   const isFeatureFlag = useFeatureFlagVariantKey('devops-copilot')
@@ -144,25 +144,25 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
   }, [deployingClusters])
 
   const shouldShowConsoleMigrationBanner = Boolean(
-    isNewNavigationActivationEnabled && newConsoleUrl && !useNewConsoleByDefault && !isConsoleMigrationBannerDismissed
+    isNewNavigationActivationEnabled && newConsoleUrl && !isNewConsoleDefault && !isConsoleMigrationBannerDismissed
   )
 
   useEffect(() => {
-    if (!useNewConsoleByDefault || shouldBypassLegacyConsoleRedirect() || !newConsoleUrl) {
+    if (!isNewConsoleDefault || shouldBypassLegacyConsoleRedirect() || !newConsoleUrl) {
       return
     }
 
     if (window.location.href !== newConsoleUrl) {
       window.location.assign(newConsoleUrl)
     }
-  }, [newConsoleUrl, useNewConsoleByDefault])
+  }, [newConsoleUrl, isNewConsoleDefault])
 
   const handleConsoleMigration = () => {
     if (!newConsoleUrl) {
       return
     }
 
-    setUseNewConsoleByDefault(true)
+    setIsNewConsoleDefault(true)
     window.location.assign(newConsoleUrl)
   }
 

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
@@ -28,6 +28,7 @@ import SpotlightTrigger from '../../feature/spotlight-trigger/spotlight-trigger'
 import ConsoleMigrationPrompt from '../console-migration-prompt/console-migration-prompt'
 import Navigation from '../navigation/navigation'
 import TopBar from '../top-bar/top-bar'
+import { redirectToUrl } from './layout-page.utils'
 
 const CONSOLE_MIGRATION_PROMPT_CONFIRMED = 'console-migration-prompt-confirmed'
 const CONSOLE_MIGRATION_PROMPT_DISMISSED = 'console-migration-prompt-dismissed'
@@ -157,7 +158,7 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
     }
 
     if (window.location.href !== newConsoleUrl) {
-      window.location.assign(newConsoleUrl)
+      redirectToUrl(newConsoleUrl)
     }
   }, [newConsoleUrl, isNewConsoleDefault])
 
@@ -170,7 +171,7 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
       target_url: newConsoleUrl,
     })
     setIsNewConsoleDefault(true)
-    window.location.assign(newConsoleUrl)
+    redirectToUrl(newConsoleUrl)
   }
 
   const handleConsoleMigrationDismiss = () => {

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
@@ -1,3 +1,4 @@
+import posthog from 'posthog-js'
 import { useFeatureFlagEnabled, useFeatureFlagVariantKey } from 'posthog-js/react'
 import { type Cluster, ClusterStateEnum, type Organization } from 'qovery-typescript-axios'
 import { type PropsWithChildren, useEffect, useMemo } from 'react'
@@ -27,6 +28,9 @@ import SpotlightTrigger from '../../feature/spotlight-trigger/spotlight-trigger'
 import ConsoleMigrationPrompt from '../console-migration-prompt/console-migration-prompt'
 import Navigation from '../navigation/navigation'
 import TopBar from '../top-bar/top-bar'
+
+const CONSOLE_MIGRATION_PROMPT_CONFIRMED = 'console-migration-prompt-confirmed'
+const CONSOLE_MIGRATION_PROMPT_DISMISSED = 'console-migration-prompt-dismissed'
 
 export interface LayoutPageProps {
   defaultOrganizationId: string
@@ -162,8 +166,18 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
       return
     }
 
+    posthog.capture(CONSOLE_MIGRATION_PROMPT_CONFIRMED, {
+      target_url: newConsoleUrl,
+    })
     setIsNewConsoleDefault(true)
     window.location.assign(newConsoleUrl)
+  }
+
+  const handleConsoleMigrationDismiss = () => {
+    posthog.capture(CONSOLE_MIGRATION_PROMPT_DISMISSED, {
+      target_url: newConsoleUrl,
+    })
+    setIsConsoleMigrationBannerDismissed(true)
   }
 
   return (
@@ -233,7 +247,7 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
         <ConsoleMigrationPrompt
           open={shouldShowConsoleMigrationBanner}
           onConfirm={handleConsoleMigration}
-          onClose={() => setIsConsoleMigrationBannerDismissed(true)}
+          onClose={handleConsoleMigrationDismiss}
         />
       </main>
     </>

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
@@ -1,6 +1,6 @@
-import { useFeatureFlagVariantKey } from 'posthog-js/react'
+import { useFeatureFlagEnabled, useFeatureFlagVariantKey } from 'posthog-js/react'
 import { type Cluster, ClusterStateEnum, type Organization } from 'qovery-typescript-axios'
-import { type PropsWithChildren, useMemo } from 'react'
+import { type PropsWithChildren, useEffect, useMemo } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { match } from 'ts-pattern'
 import { ClusterDeploymentProgressCard, useClusterStatuses } from '@qovery/domains/clusters/feature'
@@ -8,7 +8,12 @@ import { useAlerts } from '@qovery/domains/observability/feature'
 import { FreeTrialBanner, InvoiceBanner, useOrganization } from '@qovery/domains/organizations/feature'
 import { AssistantTrigger } from '@qovery/shared/assistant/feature'
 import { DevopsCopilotButton, DevopsCopilotTrigger } from '@qovery/shared/devops-copilot/feature'
-import { useUserRole } from '@qovery/shared/iam/feature'
+import {
+  getNewConsoleUrl,
+  shouldBypassLegacyConsoleRedirect,
+  useConsoleRedirectPreference,
+  useUserRole,
+} from '@qovery/shared/iam/feature'
 import { AnnouncementBanner } from '@qovery/shared/posthog/feature'
 import {
   CLUSTER_SETTINGS_CREDENTIALS_URL,
@@ -17,7 +22,9 @@ import {
   INFRA_LOGS_URL,
 } from '@qovery/shared/routes'
 import { Banner, WarningScreenMobile } from '@qovery/shared/ui'
+import { useLocalStorage } from '@qovery/shared/util-hooks'
 import SpotlightTrigger from '../../feature/spotlight-trigger/spotlight-trigger'
+import ConsoleMigrationPrompt from '../console-migration-prompt/console-migration-prompt'
 import Navigation from '../navigation/navigation'
 import TopBar from '../top-bar/top-bar'
 
@@ -57,10 +64,17 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
   const { data: clusterStatuses } = useClusterStatuses({ organizationId, enabled: !!organizationId })
   const { data: organization } = useOrganization({ organizationId })
   const { roles, isQoveryAdminUser } = useUserRole()
+  const { useNewConsoleByDefault, setUseNewConsoleByDefault } = useConsoleRedirectPreference()
+  const isNewNavigationActivationEnabled = Boolean(useFeatureFlagEnabled('new-navigation-activation'))
   const isAlertingFeatureFlagEnabled = useFeatureFlagVariantKey('alerting')
   const isFeatureFlag = useFeatureFlagVariantKey('devops-copilot')
+  const [isConsoleMigrationBannerDismissed, setIsConsoleMigrationBannerDismissed] = useLocalStorage(
+    'legacy-console-migration-banner-dismissed',
+    false
+  )
 
   const isQoveryUserWithMobileCheck = checkQoveryUser(isQoveryAdminUser)
+  const newConsoleUrl = getNewConsoleUrl()
 
   const matchLogInfraRoute = pathname.includes(INFRA_LOGS_URL(organizationId, clusterStatuses?.[0]?.cluster_id))
 
@@ -129,6 +143,29 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
     return deployingClusters.length > 0
   }, [deployingClusters])
 
+  const shouldShowConsoleMigrationBanner = Boolean(
+    isNewNavigationActivationEnabled && newConsoleUrl && !useNewConsoleByDefault && !isConsoleMigrationBannerDismissed
+  )
+
+  useEffect(() => {
+    if (!useNewConsoleByDefault || shouldBypassLegacyConsoleRedirect() || !newConsoleUrl) {
+      return
+    }
+
+    if (window.location.href !== newConsoleUrl) {
+      window.location.assign(newConsoleUrl)
+    }
+  }, [newConsoleUrl, useNewConsoleByDefault])
+
+  const handleConsoleMigration = () => {
+    if (!newConsoleUrl) {
+      return
+    }
+
+    setUseNewConsoleByDefault(true)
+    window.location.assign(newConsoleUrl)
+  }
+
   return (
     <>
       {displayQoveryAdminBanner && (
@@ -193,6 +230,11 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
         {showFloatingDeploymentCard && (
           <ClusterDeploymentProgressCard organizationId={organizationId} clusters={deployingClusters} />
         )}
+        <ConsoleMigrationPrompt
+          open={shouldShowConsoleMigrationBanner}
+          onConfirm={handleConsoleMigration}
+          onClose={() => setIsConsoleMigrationBannerDismissed(true)}
+        />
       </main>
     </>
   )

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.utils.ts
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.utils.ts
@@ -1,0 +1,3 @@
+export function redirectToUrl(url: string) {
+  window.location.assign(url)
+}

--- a/libs/pages/user/src/lib/feature/page-user-general-feature/page-user-general-feature.spec.tsx
+++ b/libs/pages/user/src/lib/feature/page-user-general-feature/page-user-general-feature.spec.tsx
@@ -25,8 +25,8 @@ describe('PageUserGeneral', () => {
       },
     })
     useConsoleRedirectPreferenceMockSpy.mockReturnValue({
-      useNewConsoleByDefault: false,
-      setUseNewConsoleByDefault: jest.fn(),
+      isNewConsoleDefault: false,
+      setIsNewConsoleDefault: jest.fn(),
     })
     useFeatureFlagEnabledMock.mockReturnValue(false)
   })

--- a/libs/pages/user/src/lib/feature/page-user-general-feature/page-user-general-feature.spec.tsx
+++ b/libs/pages/user/src/lib/feature/page-user-general-feature/page-user-general-feature.spec.tsx
@@ -1,9 +1,16 @@
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 import * as domainUserFeature from '@qovery/shared/iam/feature'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import PageUserGeneralFeature from './page-user-general-feature'
 
+jest.mock('posthog-js/react', () => ({
+  useFeatureFlagEnabled: jest.fn(() => false),
+}))
+
 const useEditUserAccountMockSpy = jest.spyOn(domainUserFeature, 'useEditUserAccount') as jest.Mock
 const useUserAccountMockSky = jest.spyOn(domainUserFeature, 'useUserAccount') as jest.Mock
+const useConsoleRedirectPreferenceMockSpy = jest.spyOn(domainUserFeature, 'useConsoleRedirectPreference') as jest.Mock
+const useFeatureFlagEnabledMock = useFeatureFlagEnabled as jest.MockedFunction<typeof useFeatureFlagEnabled>
 
 describe('PageUserGeneral', () => {
   beforeEach(() => {
@@ -17,6 +24,11 @@ describe('PageUserGeneral', () => {
         communication_email: '',
       },
     })
+    useConsoleRedirectPreferenceMockSpy.mockReturnValue({
+      useNewConsoleByDefault: false,
+      setUseNewConsoleByDefault: jest.fn(),
+    })
+    useFeatureFlagEnabledMock.mockReturnValue(false)
   })
 
   it('should render successfully', () => {
@@ -41,5 +53,13 @@ describe('PageUserGeneral', () => {
       last_name: 'test',
       communication_email: 'test2@test.com',
     })
+  })
+
+  it('should render the console toggle only when the feature flag is enabled', () => {
+    useFeatureFlagEnabledMock.mockReturnValue(true)
+
+    renderWithProviders(<PageUserGeneralFeature />)
+
+    expect(screen.getByText('Use the new console by default')).toBeInTheDocument()
   })
 })

--- a/libs/pages/user/src/lib/feature/page-user-general-feature/page-user-general-feature.tsx
+++ b/libs/pages/user/src/lib/feature/page-user-general-feature/page-user-general-feature.tsx
@@ -1,7 +1,8 @@
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useAuth } from '@qovery/shared/auth'
 import { type IconEnum } from '@qovery/shared/enums'
-import { useEditUserAccount, useUserAccount } from '@qovery/shared/iam/feature'
+import { useConsoleRedirectPreference, useEditUserAccount, useUserAccount } from '@qovery/shared/iam/feature'
 import { Icon } from '@qovery/shared/ui'
 import { useDocumentTitle } from '@qovery/shared/util-hooks'
 import PageUserGeneral from '../../ui/page-user-general/page-user-general'
@@ -12,6 +13,8 @@ export function PageUserGeneralFeature() {
   const { user: userToken } = useAuth()
   const { data: user } = useUserAccount()
   const { mutateAsync, isLoading: loading } = useEditUserAccount()
+  const { useNewConsoleByDefault, setUseNewConsoleByDefault } = useConsoleRedirectPreference()
+  const isNewNavigationActivationEnabled = Boolean(useFeatureFlagEnabled('new-navigation-activation'))
 
   const methods = useForm({
     mode: 'onChange',
@@ -49,6 +52,9 @@ export function PageUserGeneralFeature() {
         loading={loading}
         picture={user?.profile_picture_url as string}
         accountOptions={accountOptions}
+        showNewConsoleToggle={isNewNavigationActivationEnabled}
+        useNewConsoleByDefault={useNewConsoleByDefault}
+        onUseNewConsoleByDefaultChange={setUseNewConsoleByDefault}
       />
     </FormProvider>
   )

--- a/libs/pages/user/src/lib/feature/page-user-general-feature/page-user-general-feature.tsx
+++ b/libs/pages/user/src/lib/feature/page-user-general-feature/page-user-general-feature.tsx
@@ -13,7 +13,7 @@ export function PageUserGeneralFeature() {
   const { user: userToken } = useAuth()
   const { data: user } = useUserAccount()
   const { mutateAsync, isLoading: loading } = useEditUserAccount()
-  const { useNewConsoleByDefault, setUseNewConsoleByDefault } = useConsoleRedirectPreference()
+  const { isNewConsoleDefault, setIsNewConsoleDefault } = useConsoleRedirectPreference()
   const isNewNavigationActivationEnabled = Boolean(useFeatureFlagEnabled('new-navigation-activation'))
 
   const methods = useForm({
@@ -53,8 +53,8 @@ export function PageUserGeneralFeature() {
         picture={user?.profile_picture_url as string}
         accountOptions={accountOptions}
         showNewConsoleToggle={isNewNavigationActivationEnabled}
-        useNewConsoleByDefault={useNewConsoleByDefault}
-        onUseNewConsoleByDefaultChange={setUseNewConsoleByDefault}
+        isNewConsoleDefault={isNewConsoleDefault}
+        onNewConsoleDefaultChange={setIsNewConsoleDefault}
       />
     </FormProvider>
   )

--- a/libs/pages/user/src/lib/ui/page-user-general/page-user-general.spec.tsx
+++ b/libs/pages/user/src/lib/ui/page-user-general/page-user-general.spec.tsx
@@ -11,8 +11,8 @@ describe('PageUserGeneral', () => {
     accountOptions: [],
     picture: '/',
     showNewConsoleToggle: true,
-    useNewConsoleByDefault: false,
-    onUseNewConsoleByDefaultChange: jest.fn(),
+    isNewConsoleDefault: false,
+    onNewConsoleDefaultChange: jest.fn(),
   }
 
   const defaultValues = {
@@ -63,14 +63,14 @@ describe('PageUserGeneral', () => {
   })
 
   it('should toggle the console preference', async () => {
-    const onUseNewConsoleByDefaultChange = jest.fn()
+    const onNewConsoleDefaultChange = jest.fn()
 
     const { userEvent } = renderWithProviders(
       wrapWithReactHookForm(
         <PageUserGeneral
           {...props}
-          onUseNewConsoleByDefaultChange={onUseNewConsoleByDefaultChange}
-          useNewConsoleByDefault={false}
+          onNewConsoleDefaultChange={onNewConsoleDefaultChange}
+          isNewConsoleDefault={false}
         />,
         {
           defaultValues: defaultValues,
@@ -80,7 +80,7 @@ describe('PageUserGeneral', () => {
 
     await userEvent.click(screen.getByText('Use the new console by default'))
 
-    expect(onUseNewConsoleByDefaultChange).toHaveBeenCalledWith(true)
+    expect(onNewConsoleDefaultChange).toHaveBeenCalledWith(true)
   })
 
   it('should not render the console preference toggle when disabled', () => {

--- a/libs/pages/user/src/lib/ui/page-user-general/page-user-general.spec.tsx
+++ b/libs/pages/user/src/lib/ui/page-user-general/page-user-general.spec.tsx
@@ -10,6 +10,9 @@ describe('PageUserGeneral', () => {
     loading: false,
     accountOptions: [],
     picture: '/',
+    showNewConsoleToggle: true,
+    useNewConsoleByDefault: false,
+    onUseNewConsoleByDefaultChange: jest.fn(),
   }
 
   const defaultValues = {
@@ -38,6 +41,7 @@ describe('PageUserGeneral', () => {
     screen.getByLabelText('Last name')
     screen.getAllByLabelText('Account email')
     screen.getByLabelText('Communication email')
+    screen.getByText('Use the new console by default')
   })
 
   it('should submit the form', async () => {
@@ -56,5 +60,36 @@ describe('PageUserGeneral', () => {
 
     await userEvent.click(submitButton)
     expect(mockSubmit).toHaveBeenCalled()
+  })
+
+  it('should toggle the console preference', async () => {
+    const onUseNewConsoleByDefaultChange = jest.fn()
+
+    const { userEvent } = renderWithProviders(
+      wrapWithReactHookForm(
+        <PageUserGeneral
+          {...props}
+          onUseNewConsoleByDefaultChange={onUseNewConsoleByDefaultChange}
+          useNewConsoleByDefault={false}
+        />,
+        {
+          defaultValues: defaultValues,
+        }
+      )
+    )
+
+    await userEvent.click(screen.getByText('Use the new console by default'))
+
+    expect(onUseNewConsoleByDefaultChange).toHaveBeenCalledWith(true)
+  })
+
+  it('should not render the console preference toggle when disabled', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(<PageUserGeneral {...props} showNewConsoleToggle={false} />, {
+        defaultValues: defaultValues,
+      })
+    )
+
+    expect(screen.queryByText('Use the new console by default')).not.toBeInTheDocument()
   })
 })

--- a/libs/pages/user/src/lib/ui/page-user-general/page-user-general.tsx
+++ b/libs/pages/user/src/lib/ui/page-user-general/page-user-general.tsx
@@ -1,19 +1,30 @@
 import { type FormEventHandler } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { type Value } from '@qovery/shared/interfaces'
-import { BlockContent, Button, Heading, InputSelect, InputText, Section } from '@qovery/shared/ui'
+import { BlockContent, Button, Heading, InputSelect, InputText, InputToggle, Section } from '@qovery/shared/ui'
 
 export interface PageUserGeneralProps {
   onSubmit: FormEventHandler<HTMLFormElement>
   loading: boolean
   picture: string
   accountOptions: Value[]
+  showNewConsoleToggle: boolean
+  useNewConsoleByDefault: boolean
+  onUseNewConsoleByDefaultChange: (value: boolean) => void
 }
 
 const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
 const timezoneOffset = new Date().getTimezoneOffset() / -60
 
-export function PageUserGeneral({ onSubmit, loading, picture, accountOptions }: PageUserGeneralProps) {
+export function PageUserGeneral({
+  onSubmit,
+  loading,
+  picture,
+  accountOptions,
+  showNewConsoleToggle,
+  useNewConsoleByDefault,
+  onUseNewConsoleByDefaultChange,
+}: PageUserGeneralProps) {
   const { control, formState, watch } = useFormContext()
 
   return (
@@ -112,6 +123,17 @@ export function PageUserGeneral({ onSubmit, loading, picture, accountOptions }: 
             <p className="mb-3 mt-1 text-xs text-neutral-350">
               Timezone used to display timestamp within the interface
             </p>
+            {showNewConsoleToggle && (
+              <InputToggle
+                className="mt-4"
+                value={useNewConsoleByDefault}
+                onChange={onUseNewConsoleByDefaultChange}
+                title="Use the new console by default"
+                description="When enabled, visits to the legacy console will automatically redirect you to the new console."
+                forceAlignTop
+                small
+              />
+            )}
           </BlockContent>
           <div className="flex justify-end">
             <Button data-testid="submit-button" size="lg" type="submit" disabled={!formState.isValid} loading={loading}>

--- a/libs/pages/user/src/lib/ui/page-user-general/page-user-general.tsx
+++ b/libs/pages/user/src/lib/ui/page-user-general/page-user-general.tsx
@@ -9,8 +9,8 @@ export interface PageUserGeneralProps {
   picture: string
   accountOptions: Value[]
   showNewConsoleToggle: boolean
-  useNewConsoleByDefault: boolean
-  onUseNewConsoleByDefaultChange: (value: boolean) => void
+  isNewConsoleDefault: boolean
+  onNewConsoleDefaultChange: (value: boolean) => void
 }
 
 const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -22,8 +22,8 @@ export function PageUserGeneral({
   picture,
   accountOptions,
   showNewConsoleToggle,
-  useNewConsoleByDefault,
-  onUseNewConsoleByDefaultChange,
+  isNewConsoleDefault,
+  onNewConsoleDefaultChange,
 }: PageUserGeneralProps) {
   const { control, formState, watch } = useFormContext()
 
@@ -126,8 +126,8 @@ export function PageUserGeneral({
             {showNewConsoleToggle && (
               <InputToggle
                 className="mt-4"
-                value={useNewConsoleByDefault}
-                onChange={onUseNewConsoleByDefaultChange}
+                value={isNewConsoleDefault}
+                onChange={onNewConsoleDefaultChange}
                 title="Use the new console by default"
                 description="When enabled, visits to the legacy console will automatically redirect you to the new console."
                 forceAlignTop

--- a/libs/shared/iam/feature/src/index.ts
+++ b/libs/shared/iam/feature/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/use-user-account/use-user-account'
+export * from './lib/use-console-redirect-preference/use-console-redirect-preference'
 export * from './lib/use-user-edit-account/use-user-edit-account'
 export * from './lib/use-user-role/use-user-role'

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.spec.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.spec.ts
@@ -1,0 +1,41 @@
+import {
+  getNewConsoleUrl,
+  getStoredConsolePreference,
+  shouldBypassLegacyConsoleRedirect,
+} from './use-console-redirect-preference'
+
+describe('useConsoleRedirectPreference', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.cookie = 'qovery-console-preference=; Max-Age=0; Path=/'
+  })
+
+  it('should return the new console url for legacy console hosts', () => {
+    expect(getNewConsoleUrl('https://console.qovery.com/organization/123?foo=bar#hash')).toBe(
+      'https://new-console.qovery.com/organization/123?foo=bar#hash'
+    )
+  })
+
+  it('should return null when current host is not the legacy console', () => {
+    expect(getNewConsoleUrl('https://new-console.qovery.com/organization/123')).toBeNull()
+    expect(getNewConsoleUrl('http://localhost:4200/organization/123')).toBeNull()
+  })
+
+  it('should read the preference from local storage first', () => {
+    localStorage.setItem('qovery-console-preference', 'new')
+    document.cookie = 'qovery-console-preference=legacy; Path=/'
+
+    expect(getStoredConsolePreference()).toBe('new')
+  })
+
+  it('should fallback to cookies when local storage is empty', () => {
+    document.cookie = 'qovery-console-preference=new; Path=/'
+
+    expect(getStoredConsolePreference()).toBe('new')
+  })
+
+  it('should detect the redirect bypass query param', () => {
+    expect(shouldBypassLegacyConsoleRedirect('?legacy=1')).toBe(true)
+    expect(shouldBypassLegacyConsoleRedirect('?legacy=0')).toBe(false)
+  })
+})

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
@@ -64,16 +64,15 @@ export function getStoredConsolePreference(): ConsolePreference {
 }
 
 export function getNewConsoleUrl(currentUrl = window.location.href): string | null {
-  // const url = new URL(currentUrl)
+  const url = new URL(currentUrl)
 
-  // if (!url.hostname.startsWith('console.')) {
-  //   return null
-  // }
+  if (!url.hostname.startsWith('console.')) {
+    return null
+  }
 
-  // url.hostname = url.hostname.replace(/^console\./, 'new-console.')
+  url.hostname = url.hostname.replace(/^console\./, 'new-console.')
 
-  // return url.toString()
-  return 'https://new-console.qovery.com'
+  return url.toString()
 }
 
 export function shouldBypassLegacyConsoleRedirect(search = window.location.search): boolean {

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
@@ -88,7 +88,7 @@ export function useConsoleRedirectPreference() {
     setPreferredConsoleState(preference)
   }, [])
 
-  const setUseNewConsoleByDefault = useCallback(
+  const setIsNewConsoleDefault = useCallback(
     (value: boolean) => {
       setPreferredConsole(value ? 'new' : 'legacy')
     },
@@ -97,8 +97,8 @@ export function useConsoleRedirectPreference() {
 
   return {
     preferredConsole,
-    useNewConsoleByDefault: preferredConsole === 'new',
+    isNewConsoleDefault: preferredConsole === 'new',
     setPreferredConsole,
-    setUseNewConsoleByDefault,
+    setIsNewConsoleDefault,
   }
 }

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
@@ -1,0 +1,105 @@
+import { useCallback, useState } from 'react'
+
+export type ConsolePreference = 'legacy' | 'new'
+
+const CONSOLE_PREFERENCE_STORAGE_KEY = 'qovery-console-preference'
+const CONSOLE_PREFERENCE_COOKIE_KEY = 'qovery-console-preference'
+const LEGACY_CONSOLE_BYPASS_QUERY_PARAM = 'legacy'
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365
+
+function isConsolePreference(value: string | null): value is ConsolePreference {
+  return value === 'legacy' || value === 'new'
+}
+
+function getCookieDomain(hostname: string): string | undefined {
+  return hostname.endsWith('.qovery.com') ? '.qovery.com' : undefined
+}
+
+function readCookieValue(cookieName: string): string | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const cookie = document.cookie
+    .split('; ')
+    .find((item) => item.startsWith(`${cookieName}=`))
+    ?.split('=')
+    .slice(1)
+    .join('=')
+
+  return cookie ? decodeURIComponent(cookie) : null
+}
+
+function persistConsolePreference(preference: ConsolePreference) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  localStorage.setItem(CONSOLE_PREFERENCE_STORAGE_KEY, preference)
+
+  const domain = getCookieDomain(window.location.hostname)
+  document.cookie = `${CONSOLE_PREFERENCE_COOKIE_KEY}=${encodeURIComponent(preference)}; Path=/; Max-Age=${ONE_YEAR_IN_SECONDS}; SameSite=Lax${
+    domain ? `; Domain=${domain}` : ''
+  }`
+}
+
+export function getStoredConsolePreference(): ConsolePreference {
+  if (typeof window === 'undefined') {
+    return 'legacy'
+  }
+
+  const localStoragePreference = localStorage.getItem(CONSOLE_PREFERENCE_STORAGE_KEY)
+
+  if (isConsolePreference(localStoragePreference)) {
+    return localStoragePreference
+  }
+
+  const cookiePreference = readCookieValue(CONSOLE_PREFERENCE_COOKIE_KEY)
+
+  if (isConsolePreference(cookiePreference)) {
+    return cookiePreference
+  }
+
+  return 'legacy'
+}
+
+export function getNewConsoleUrl(currentUrl = window.location.href): string | null {
+  // const url = new URL(currentUrl)
+
+  // if (!url.hostname.startsWith('console.')) {
+  //   return null
+  // }
+
+  // url.hostname = url.hostname.replace(/^console\./, 'new-console.')
+
+  // return url.toString()
+  return 'https://new-console.qovery.com'
+}
+
+export function shouldBypassLegacyConsoleRedirect(search = window.location.search): boolean {
+  const searchParams = new URLSearchParams(search)
+  return searchParams.get(LEGACY_CONSOLE_BYPASS_QUERY_PARAM) === '1'
+}
+
+export function useConsoleRedirectPreference() {
+  const [preferredConsole, setPreferredConsoleState] = useState<ConsolePreference>(() => getStoredConsolePreference())
+
+  const setPreferredConsole = useCallback((preference: ConsolePreference) => {
+    persistConsolePreference(preference)
+    setPreferredConsoleState(preference)
+  }, [])
+
+  const setUseNewConsoleByDefault = useCallback(
+    (value: boolean) => {
+      setPreferredConsole(value ? 'new' : 'legacy')
+    },
+    [setPreferredConsole]
+  )
+
+  return {
+    preferredConsole,
+    useNewConsoleByDefault: preferredConsole === 'new',
+    setPreferredConsole,
+    setUseNewConsoleByDefault,
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

- Add the first part of the console migration and a feature flag enabled only for our team for now (available [here](https://us.posthog.com/project/3828/feature_flags/648567))
- Need an second PR to add a toggle in the user modal after rebasing this one⁠￼

## Screenshots / Recordings

<img width="1467" height="835" alt="Screenshot 2026-04-20 at 15 46 06" src="https://github.com/user-attachments/assets/ee161296-e321-4027-839d-926f95bd5711" />

<img width="1462" height="835" alt="Screenshot 2026-04-20 at 15 46 21" src="https://github.com/user-attachments/assets/9062f0f5-6014-42c9-9e80-5d129315d6ee" />

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
