### PR TITLE
fix(ui): several improvement part 2

### DIFF
--- a/apps/console-v5/src/app/components/not-found-page/not-found-page.tsx
+++ b/apps/console-v5/src/app/components/not-found-page/not-found-page.tsx
@@ -1,10 +1,12 @@
 import { type NotFoundRouteProps } from '@tanstack/react-router'
+import { type ReactNode } from 'react'
 import { useOrganizations } from '@qovery/domains/organizations/feature'
-import { Heading, Icon, Link, LogoBrandedIcon, LogoIcon, Section } from '@qovery/shared/ui'
+import { Heading, Link, LogoIcon, Section } from '@qovery/shared/ui'
 import { type SerializedError } from '@qovery/shared/utils'
 import { useAuth0Context } from '../../../auth/auth0'
 
-type NotFoundPageProps = NotFoundRouteProps & {
+type NotFoundPageProps = Partial<NotFoundRouteProps> & {
+  action?: ReactNode
   error?: unknown
 }
 
@@ -17,7 +19,7 @@ function isNotFoundPageData(data: unknown): data is NotFoundPageData {
   return typeof data === 'object' && data !== null
 }
 
-export function NotFoundPage({ data, error }: NotFoundPageProps) {
+export function NotFoundPage({ action, data, error }: NotFoundPageProps) {
   const errorTyped = error as SerializedError | undefined
   const { isAuthenticated } = useAuth0Context()
   const { data: organizations = [] } = useOrganizations({ enabled: isAuthenticated })
@@ -32,6 +34,25 @@ export function NotFoundPage({ data, error }: NotFoundPageProps) {
     pageData?.message ??
     errorTyped?.message ??
     "The page you're looking for doesn't exist anymore, or the URL is incorrect."
+  const defaultAction = selectedOrganization ? (
+    <Link
+      as="button"
+      to="/organization/$organizationId/overview"
+      params={{ organizationId: selectedOrganization.id }}
+      size="md"
+      className="mt-6 gap-2"
+    >
+      Go to organization
+    </Link>
+  ) : isAuthenticated ? (
+    <Link as="button" to="/" size="md" className="mt-6 gap-2">
+      Go to home
+    </Link>
+  ) : (
+    <Link as="button" to="/login" search={{ redirect: '/' }} size="md" className="mt-6 gap-2">
+      Go to login
+    </Link>
+  )
 
   return (
     <Section className="flex min-h-[70vh] w-full flex-1 items-center justify-center">
@@ -41,25 +62,7 @@ export function NotFoundPage({ data, error }: NotFoundPageProps) {
 
         <p className="mt-3 max-w-xs text-sm text-neutral-subtle">{message}</p>
 
-        {selectedOrganization ? (
-          <Link
-            as="button"
-            to="/organization/$organizationId/overview"
-            params={{ organizationId: selectedOrganization.id }}
-            size="md"
-            className="mt-6 gap-2"
-          >
-            Go to organization
-          </Link>
-        ) : isAuthenticated ? (
-          <Link as="button" to="/" size="md" className="mt-6 gap-2">
-            Go to home
-          </Link>
-        ) : (
-          <Link as="button" to="/login" search={{ redirect: '/' }} size="md" className="mt-6 gap-2">
-            Go to login
-          </Link>
-        )}
+        {action ?? defaultAction}
       </div>
     </Section>
   )

--- a/apps/console-v5/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployments.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployments.tsx
@@ -1,7 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { Suspense } from 'react'
-import { EnvironmentDeploymentListSkeleton } from '@qovery/domains/environments/feature'
-import { EnvironmentDeploymentList } from '@qovery/domains/environments/feature'
+import {
+  EnvironmentActionToolbar,
+  EnvironmentDeploymentList,
+  EnvironmentDeploymentListSkeleton,
+  useEnvironment,
+} from '@qovery/domains/environments/feature'
 import { Heading, Section } from '@qovery/shared/ui'
 import { useDocumentTitle } from '@qovery/shared/util-hooks'
 
@@ -13,6 +17,10 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   useDocumentTitle('Deployment history')
+  const { environmentId = '' } = Route.useParams()
+  const { data: environment } = useEnvironment({ environmentId, suspense: true })
+
+  if (!environment) return null
 
   return (
     <div className="container mx-auto flex min-h-page-container flex-col pt-6">
@@ -20,6 +28,7 @@ function RouteComponent() {
         <div className="flex shrink-0 flex-col gap-6">
           <div className="flex justify-between">
             <Heading>Deployments</Heading>
+            <EnvironmentActionToolbar environment={environment} variant="header" />
           </div>
           <hr className="w-full border-neutral" />
         </div>

--- a/apps/console-v5/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/index.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useParams } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { useEnvironment } from '@qovery/domains/environments/feature'
-import { ServiceDeploymentList, ServiceDeploymentListSkeleton } from '@qovery/domains/services/feature'
+import { ServiceActions, ServiceDeploymentList, ServiceDeploymentListSkeleton } from '@qovery/domains/services/feature'
 import { Heading, Section } from '@qovery/shared/ui'
 
 export const Route = createFileRoute(
@@ -14,12 +14,15 @@ function RouteComponent() {
   const { environmentId = '', serviceId = '' } = useParams({ strict: false })
   const { data: environment } = useEnvironment({ environmentId, suspense: true })
 
+  if (!environment) return null
+
   return (
     <div className="container mx-auto flex min-h-page-container flex-col pt-6">
       <Section className="min-h-0 flex-1 gap-8">
         <div className="flex shrink-0 flex-col gap-6">
           <div className="flex justify-between">
             <Heading>Deployments</Heading>
+            <ServiceActions environment={environment} serviceId={serviceId} variant="deploy-dropdown-only" />
           </div>
           <hr className="w-full border-neutral" />
         </div>

--- a/apps/console-v5/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/route.tsx
@@ -2,7 +2,9 @@ import { type IconName } from '@fortawesome/fontawesome-common-types'
 import { Outlet, createFileRoute, useLocation, useMatches, useParams } from '@tanstack/react-router'
 import posthog from 'posthog-js'
 import { Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { useServiceSummary } from '@qovery/domains/services/feature'
+import { useEnvironment } from '@qovery/domains/environments/feature'
+import { useProject } from '@qovery/domains/projects/feature'
+import { useRecentServices, useServiceSummary } from '@qovery/domains/services/feature'
 import { DevopsCopilotContext } from '@qovery/shared/devops-copilot/context'
 import { DevopsCopilotTrigger } from '@qovery/shared/devops-copilot/feature'
 import { ErrorBoundary, Icon, LoaderSpinner, Navbar } from '@qovery/shared/ui'
@@ -446,7 +448,15 @@ function OrganizationRoute() {
   const needsFullWidth = useFullWidthLayout()
   const bypassLayout = useBypassLayout()
   const location = useLocation()
-  const { organizationId = '' } = useParams({ strict: false })
+  const { organizationId = '', projectId = '', environmentId = '', serviceId = '' } = useParams({ strict: false })
+  const { addToRecentServices } = useRecentServices({ organizationId })
+  const { data: project } = useProject({ organizationId, projectId })
+  const { data: environment } = useEnvironment({ environmentId })
+  const { data: service } = useServiceSummary({
+    environmentId,
+    serviceId,
+    enabled: Boolean(environmentId) && Boolean(serviceId),
+  })
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [devopsCopilotOpen, setDevopsCopilotOpen] = useState(false)
   const sendMessageRef = useRef<((message: string, createNewChat?: boolean) => void) | null>(null)
@@ -460,6 +470,25 @@ function OrganizationRoute() {
     posthog.group('organization_id', organizationId)
     posthog.reloadFeatureFlags()
   }, [organizationId])
+
+  // Add the service to the recent services list (necessary for the spotlight to work)
+  useEffect(() => {
+    if (service?.id && project?.id && environment?.id) {
+      addToRecentServices({
+        id: service.id,
+        name: service.name,
+        description: service.description || '',
+        icon_uri: service.icon_uri,
+        service_type: service.service_type,
+        project_id: project.id,
+        project_name: project.name,
+        environment_id: environment.id,
+        environment_name: environment.name,
+        cluster_id: environment.cluster_id,
+        job_type: 'job_type' in service ? service.job_type : undefined,
+      })
+    }
+  }, [service?.id, project?.id, environment?.id])
 
   useLayoutEffect(() => {
     const scrollContainer = scrollContainerRef.current

--- a/apps/console-v5/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/route.tsx
@@ -7,9 +7,10 @@ import { useProject } from '@qovery/domains/projects/feature'
 import { useRecentServices, useServiceSummary } from '@qovery/domains/services/feature'
 import { DevopsCopilotContext } from '@qovery/shared/devops-copilot/context'
 import { DevopsCopilotTrigger } from '@qovery/shared/devops-copilot/feature'
-import { ErrorBoundary, Icon, LoaderSpinner, Navbar } from '@qovery/shared/ui'
+import { ErrorBoundary, Icon, Link, LoaderSpinner, Navbar } from '@qovery/shared/ui'
 import { queries } from '@qovery/state/util-queries'
 import Header from '../../../app/components/header/header'
+import { NotFoundPage } from '../../../app/components/not-found-page/not-found-page'
 import { OrganizationBanners } from '../../../app/components/organization-banners/organization-banners'
 import { type FileRouteTypes } from '../../../routeTree.gen'
 
@@ -452,11 +453,23 @@ function OrganizationRoute() {
   const { addToRecentServices } = useRecentServices({ organizationId })
   const { data: project } = useProject({ organizationId, projectId })
   const { data: environment } = useEnvironment({ environmentId })
-  const { data: service } = useServiceSummary({
+  const { data: service, isFetched: isServiceSummaryFetched } = useServiceSummary({
     environmentId,
     serviceId,
     enabled: Boolean(environmentId) && Boolean(serviceId),
   })
+  const isServiceNotFound = Boolean(environmentId) && Boolean(serviceId) && isServiceSummaryFetched && !service
+  const serviceNotFoundAction = (
+    <Link
+      as="button"
+      to="/organization/$organizationId/project/$projectId/environment/$environmentId/overview"
+      params={{ organizationId, projectId, environmentId }}
+      size="md"
+      className="mt-6 gap-2"
+    >
+      Go to environment
+    </Link>
+  )
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [devopsCopilotOpen, setDevopsCopilotOpen] = useState(false)
   const sendMessageRef = useRef<((message: string, createNewChat?: boolean) => void) | null>(null)
@@ -507,7 +520,17 @@ function OrganizationRoute() {
           sendMessageRef,
         }}
       >
-        <Outlet />
+        {isServiceNotFound ? (
+          <NotFoundPage
+            action={serviceNotFoundAction}
+            data={{
+              title: 'Service not found',
+              message: "This service doesn't exist anymore, or the URL is incorrect.",
+            }}
+          />
+        ) : (
+          <Outlet />
+        )}
         <DevopsCopilotTrigger />
       </DevopsCopilotContext.Provider>
     )
@@ -537,7 +560,17 @@ function OrganizationRoute() {
                 </div>
 
                 <div className={needsFullWidth ? 'min-h-0' : 'container mx-auto min-h-0 px-4'}>
-                  <Outlet />
+                  {isServiceNotFound ? (
+                    <NotFoundPage
+                      action={serviceNotFoundAction}
+                      data={{
+                        title: 'Service not found',
+                        message: "This service doesn't exist anymore, or the URL is incorrect.",
+                      }}
+                    />
+                  ) : (
+                    <Outlet />
+                  )}
                 </div>
               </>
             </Suspense>

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
@@ -1,4 +1,4 @@
-import { type OrganizationEventResponse } from 'qovery-typescript-axios'
+import { type OrganizationEventResponse, OrganizationEventTargetType } from 'qovery-typescript-axios'
 import { type ReactNode } from 'react'
 import { eventsFactoryMock } from '@qovery/shared/factories'
 import { dateFullFormat } from '@qovery/shared/util-dates'
@@ -68,5 +68,67 @@ describe('RowEvent', () => {
     const target = screen.getByText(props.event?.target_name || '')
 
     expect(target).toHaveAttribute('href', '/organization/1/settings')
+  })
+
+  it.each([
+    OrganizationEventTargetType.APPLICATION,
+    OrganizationEventTargetType.CONTAINER,
+    OrganizationEventTargetType.JOB,
+    OrganizationEventTargetType.HELM,
+    OrganizationEventTargetType.TERRAFORM,
+    OrganizationEventTargetType.DATABASE,
+  ])('should render unified service link for %s target', (targetType) => {
+    renderWithProviders(
+      <RowEvent
+        {...props}
+        event={{
+          ...props.event,
+          target_type: targetType,
+          target_id: 'service-1',
+          target_name: 'service-name',
+          project_id: 'project-1',
+          environment_id: 'environment-1',
+        }}
+      />
+    )
+
+    expect(screen.getByText('service-name')).toHaveAttribute(
+      'href',
+      '/organization/1/project/project-1/environment/environment-1/service/service-1/overview'
+    )
+  })
+
+  it.each([
+    [OrganizationEventTargetType.ORGANIZATION, '/organization/1/settings'],
+    [OrganizationEventTargetType.MEMBERS_AND_ROLES, '/organization/1/settings/members'],
+    [OrganizationEventTargetType.PROJECT, '/organization/1/project/project-1/settings/general'],
+    [OrganizationEventTargetType.ENVIRONMENT, '/organization/1/project/project-1/environment/environment-1'],
+    [OrganizationEventTargetType.CLUSTER, '/organization/1/cluster/cluster-1/settings'],
+    [OrganizationEventTargetType.WEBHOOK, '/organization/1/settings/webhook'],
+    [OrganizationEventTargetType.CONTAINER_REGISTRY, '/organization/1/settings/container-registries'],
+    [OrganizationEventTargetType.ENTERPRISE_CONNECTION, '/organization/1/settings/members'],
+    [OrganizationEventTargetType.HELM_REPOSITORY, '/organization/1/settings/helm-repositories'],
+  ])('should render valid console v5 link for %s target', (targetType, href) => {
+    const targetIdByType: Partial<Record<OrganizationEventTargetType, string>> = {
+      [OrganizationEventTargetType.PROJECT]: 'project-1',
+      [OrganizationEventTargetType.ENVIRONMENT]: 'environment-1',
+      [OrganizationEventTargetType.CLUSTER]: 'cluster-1',
+    }
+
+    renderWithProviders(
+      <RowEvent
+        {...props}
+        event={{
+          ...props.event,
+          target_type: targetType,
+          target_id: targetIdByType[targetType] ?? 'target-1',
+          target_name: 'target-name',
+          project_id: 'project-1',
+          environment_id: 'environment-1',
+        }}
+      />
+    )
+
+    expect(screen.getByText('target-name')).toHaveAttribute('href', href)
   })
 })

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
@@ -10,20 +10,6 @@ import { useState } from 'react'
 import { match } from 'ts-pattern'
 import { type ValidTargetIds } from '@qovery/domains/audit-logs/data-access'
 import { IconEnum } from '@qovery/shared/enums'
-import {
-  APPLICATION_URL,
-  CLUSTER_SETTINGS_URL,
-  CLUSTER_URL,
-  DATABASE_GENERAL_URL,
-  DATABASE_URL,
-  SERVICES_URL,
-  SETTINGS_CONTAINER_REGISTRIES_URL,
-  SETTINGS_MEMBERS_URL,
-  SETTINGS_PROJECT_GENERAL_URL,
-  SETTINGS_PROJECT_URL,
-  SETTINGS_URL,
-  SETTINGS_WEBHOOKS,
-} from '@qovery/shared/routes'
 import { CodeDiffEditor, CodeEditor, type DiffStats, Icon, Skeleton, Tooltip, Truncate } from '@qovery/shared/ui'
 import { dateFullFormat, dateUTCString } from '@qovery/shared/util-dates'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
@@ -59,6 +45,30 @@ export const getSourceIcon = (origin?: OrganizationEventOrigin) => {
       return null
   }
 }
+
+const serviceOverviewUrl = (organizationId: string, projectId: string, environmentId: string, serviceId: string) =>
+  `/organization/${organizationId}/project/${projectId}/environment/${environmentId}/service/${serviceId}/overview`
+
+const projectSettingsUrl = (organizationId: string, projectId: string) =>
+  `/organization/${organizationId}/project/${projectId}/settings/general`
+
+const environmentUrl = (organizationId: string, projectId: string, environmentId: string) =>
+  `/organization/${organizationId}/project/${projectId}/environment/${environmentId}`
+
+const clusterSettingsUrl = (organizationId: string, clusterId: string) =>
+  `/organization/${organizationId}/cluster/${clusterId}/settings`
+
+const organizationSettingsUrl = (organizationId: string) => `/organization/${organizationId}/settings`
+
+const membersSettingsUrl = (organizationId: string) => `${organizationSettingsUrl(organizationId)}/members`
+
+const webhookSettingsUrl = (organizationId: string) => `${organizationSettingsUrl(organizationId)}/webhook`
+
+const containerRegistriesSettingsUrl = (organizationId: string) =>
+  `${organizationSettingsUrl(organizationId)}/container-registries`
+
+const helmRepositoriesSettingsUrl = (organizationId: string) =>
+  `${organizationSettingsUrl(organizationId)}/helm-repositories`
 
 export function RowEvent(props: RowEventProps) {
   const { event, expanded, setExpanded, isPlaceholder, columnsWidth, validTargetIds } = props
@@ -104,32 +114,27 @@ export function RowEvent(props: RowEventProps) {
       </Link>
     )
 
-    const generateApplicationLink = () =>
-      customLink(`${APPLICATION_URL(organizationId, project_id!, environment_id!, target_id!)}`)
+    const generateServiceLink = () =>
+      customLink(serviceOverviewUrl(organizationId, project_id!, environment_id!, target_id!))
 
     const linkConfig: { [key in OrganizationEventTargetType]: () => JSX.Element } = {
-      [OrganizationEventTargetType.APPLICATION]: generateApplicationLink,
-      [OrganizationEventTargetType.CONTAINER]: generateApplicationLink,
-      [OrganizationEventTargetType.JOB]: generateApplicationLink,
-      [OrganizationEventTargetType.HELM]: generateApplicationLink,
-      [OrganizationEventTargetType.TERRAFORM]: generateApplicationLink,
-      [OrganizationEventTargetType.ORGANIZATION]: () => customLink(SETTINGS_URL(organizationId)),
-      [OrganizationEventTargetType.MEMBERS_AND_ROLES]: () =>
-        customLink(SETTINGS_URL(organizationId) + SETTINGS_MEMBERS_URL),
-      [OrganizationEventTargetType.PROJECT]: () =>
-        customLink(SETTINGS_URL(organizationId) + SETTINGS_PROJECT_URL(target_id!) + SETTINGS_PROJECT_GENERAL_URL),
+      [OrganizationEventTargetType.APPLICATION]: generateServiceLink,
+      [OrganizationEventTargetType.CONTAINER]: generateServiceLink,
+      [OrganizationEventTargetType.JOB]: generateServiceLink,
+      [OrganizationEventTargetType.HELM]: generateServiceLink,
+      [OrganizationEventTargetType.TERRAFORM]: generateServiceLink,
+      [OrganizationEventTargetType.ORGANIZATION]: () => customLink(organizationSettingsUrl(organizationId)),
+      [OrganizationEventTargetType.MEMBERS_AND_ROLES]: () => customLink(membersSettingsUrl(organizationId)),
+      [OrganizationEventTargetType.PROJECT]: () => customLink(projectSettingsUrl(organizationId, target_id!)),
       [OrganizationEventTargetType.ENVIRONMENT]: () =>
-        customLink(SERVICES_URL(organizationId, project_id!, target_id!), target_name),
-      [OrganizationEventTargetType.DATABASE]: () =>
-        customLink(DATABASE_URL(organizationId, project_id!, environment_id!, target_id!) + DATABASE_GENERAL_URL),
-      [OrganizationEventTargetType.CLUSTER]: () =>
-        customLink(CLUSTER_URL(organizationId, target_id!) + CLUSTER_SETTINGS_URL),
-      [OrganizationEventTargetType.WEBHOOK]: () => customLink(SETTINGS_URL(organizationId) + SETTINGS_WEBHOOKS),
+        customLink(environmentUrl(organizationId, project_id!, target_id!), target_name),
+      [OrganizationEventTargetType.DATABASE]: generateServiceLink,
+      [OrganizationEventTargetType.CLUSTER]: () => customLink(clusterSettingsUrl(organizationId, target_id!)),
+      [OrganizationEventTargetType.WEBHOOK]: () => customLink(webhookSettingsUrl(organizationId)),
       [OrganizationEventTargetType.CONTAINER_REGISTRY]: () =>
-        customLink(SETTINGS_URL(organizationId) + SETTINGS_CONTAINER_REGISTRIES_URL),
-      [OrganizationEventTargetType.ENTERPRISE_CONNECTION]: () =>
-        customLink(SETTINGS_URL(organizationId) + SETTINGS_MEMBERS_URL),
-      [OrganizationEventTargetType.HELM_REPOSITORY]: () => <span>NOT_IMPLEMENTED</span>,
+        customLink(containerRegistriesSettingsUrl(organizationId)),
+      [OrganizationEventTargetType.ENTERPRISE_CONNECTION]: () => customLink(membersSettingsUrl(organizationId)),
+      [OrganizationEventTargetType.HELM_REPOSITORY]: () => customLink(helmRepositoriesSettingsUrl(organizationId)),
     }
 
     if (event_type !== OrganizationEventType.DELETE && targetExists) {

--- a/libs/domains/cluster-metrics/feature/src/lib/cluster-card-node-usage/cluster-card-node-usage.tsx
+++ b/libs/domains/cluster-metrics/feature/src/lib/cluster-card-node-usage/cluster-card-node-usage.tsx
@@ -64,7 +64,7 @@ export function ClusterCardNodeUsage({ organizationId, clusterId }: ClusterCardN
     <div className="flex flex-col gap-1">
       <div className="flex items-center">
         <div className="flex w-full items-center gap-1.5">
-          <Icon iconName="check-circle" iconStyle="regular" className="text-positive" />
+          <Icon iconName="check-circle" iconStyle="regular" className="text-positiveInvert" />
           <span>Healthy {pluralize(healthyNodes - warningNodes, 'node', 'nodes')}</span>
           <span className="ml-auto block font-semibold">{healthyNodes - warningNodes}</span>
         </div>

--- a/libs/domains/cluster-metrics/feature/src/lib/cluster-card-setup/cluster-card-setup.tsx
+++ b/libs/domains/cluster-metrics/feature/src/lib/cluster-card-setup/cluster-card-setup.tsx
@@ -102,7 +102,7 @@ export function ClusterCardSetup({ organizationId, clusterId }: ClusterCardSetup
         <Skeleton width="65%" height={20} show={isLoading}>
           <div
             title={cluster?.created_at && dateUTCString(cluster.created_at)}
-            className="flex h-8 items-center gap-2.5 p-1.5"
+            className="flex h-8 items-center gap-2.5 p-1.5 pl-0.5"
           >
             <Icon className="text-base text-neutral-subtle" iconName="calendar-day" iconStyle="regular" />
             Created {cluster?.created_at && timeAgo(new Date(cluster.created_at))} ago

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.tsx
@@ -62,11 +62,16 @@ export function ClusterAdvancedSettingsFeature() {
     })
 
     if (clusterAdvancedSettings) {
-      editClusterAdvancedSettings({
-        organizationId,
-        clusterId,
-        clusterAdvancedSettings: payload as ClusterAdvancedSettingsType,
-      })
+      editClusterAdvancedSettings(
+        {
+          organizationId,
+          clusterId,
+          clusterAdvancedSettings: payload as ClusterAdvancedSettingsType,
+        },
+        {
+          onSuccess: () => methods.reset(data),
+        }
+      )
     }
   })
 

--- a/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.spec.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.spec.tsx
@@ -4,6 +4,8 @@ import { EnvironmentLastDeploymentSection } from './environment-last-deployment-
 
 const mockUseEnvironment = jest.fn()
 const mockUseDeploymentHistory = jest.fn()
+const mockUseServiceCount = jest.fn()
+const mockDeployEnvironment = jest.fn()
 
 jest.mock('@tanstack/react-router', () => ({
   ...jest.requireActual('@tanstack/react-router'),
@@ -19,9 +21,13 @@ jest.mock('../hooks/use-deployment-history/use-deployment-history', () => ({
   useDeploymentHistory: () => mockUseDeploymentHistory(),
 }))
 
+jest.mock('../hooks/use-service-count/use-service-count', () => ({
+  useServiceCount: () => mockUseServiceCount(),
+}))
+
 jest.mock('../hooks/use-deploy-environment/use-deploy-environment', () => ({
   useDeployEnvironment: () => ({
-    mutate: jest.fn(),
+    mutate: mockDeployEnvironment,
   }),
 }))
 
@@ -75,6 +81,10 @@ describe('EnvironmentLastDeploymentSection', () => {
       data: mockEnvironment,
       isFetched: true,
     })
+    mockUseServiceCount.mockReturnValue({
+      data: 1,
+      isFetched: true,
+    })
   })
 
   it('renders the relative time for a finished deployment', () => {
@@ -116,5 +126,36 @@ describe('EnvironmentLastDeploymentSection', () => {
 
     expect(screen.getByText('No deployment recorded yet')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /deploy environment/i })).toBeInTheDocument()
+  })
+
+  it('does not render the deploy action when the environment has no services', () => {
+    mockUseDeploymentHistory.mockReturnValue({
+      data: [],
+      isFetched: true,
+    })
+    mockUseServiceCount.mockReturnValue({
+      data: 0,
+      isFetched: true,
+    })
+
+    renderWithProviders(<EnvironmentLastDeploymentSection />)
+
+    expect(screen.getByText('No deployment recorded yet')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /deploy environment/i })).not.toBeInTheDocument()
+  })
+
+  it('deploys the current environment from the empty state action', async () => {
+    mockUseDeploymentHistory.mockReturnValue({
+      data: [],
+      isFetched: true,
+    })
+
+    const { userEvent } = renderWithProviders(<EnvironmentLastDeploymentSection />)
+
+    await userEvent.click(screen.getByRole('button', { name: /deploy environment/i }))
+
+    expect(mockDeployEnvironment).toHaveBeenCalledWith({
+      environmentId: 'env-1',
+    })
   })
 })

--- a/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.tsx
@@ -21,6 +21,7 @@ import { isDeploymentHistory } from '../environment-deployment-list/environment-
 import { useDeployEnvironment } from '../hooks/use-deploy-environment/use-deploy-environment'
 import { useDeploymentHistory } from '../hooks/use-deployment-history/use-deployment-history'
 import { useEnvironment } from '../hooks/use-environment/use-environment'
+import { useServiceCount } from '../hooks/use-service-count/use-service-count'
 
 const DotSeparator = () => (
   <svg
@@ -63,6 +64,7 @@ const EnvironmentLastDeploymentContent = () => {
   const { setDevopsCopilotOpen, sendMessageRef } = useContext(DevopsCopilotContext)
   const { data: environment } = useEnvironment({ environmentId, suspense: true })
   const { data: deploymentHistory = [] } = useDeploymentHistory({ environmentId, suspense: true })
+  const { data: serviceCount = 0 } = useServiceCount({ environmentId })
   const lastDeployment = useMemo(
     () =>
       deploymentHistory.sort(
@@ -102,8 +104,10 @@ const EnvironmentLastDeploymentContent = () => {
   })
 
   const handleDeploy = () => {
+    if (!environment?.id) return
+
     deployEnvironment({
-      environmentId,
+      environmentId: environment.id,
     })
   }
 
@@ -201,10 +205,12 @@ const EnvironmentLastDeploymentContent = () => {
           description="Create and deploy your first service"
           className="h-auto p-8"
         >
-          <Button onClick={handleDeploy} color="neutral" size="md" className="gap-1.5">
-            <Icon iconName="rocket" />
-            Deploy environment
-          </Button>
+          {serviceCount > 0 && (
+            <Button onClick={handleDeploy} color="neutral" size="md" className="gap-1.5">
+              <Icon iconName="rocket" />
+              Deploy environment
+            </Button>
+          )}
         </EmptyState>
       )}
     </Section>

--- a/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.tsx
+++ b/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.tsx
@@ -49,9 +49,17 @@ function EnvRow({ overview }: { overview: EnvironmentOverviewResponse }) {
     >
       <Table.Cell className={twMerge(cellClassName, 'border-none p-0')}>
         <div className="flex h-full min-w-0 flex-col justify-center gap-1 px-4 py-2 xl:flex-row xl:items-center xl:justify-between xl:gap-2">
-          <Tooltip content={overview.name}>
-            <span className="block min-w-0 flex-1 truncate text-sm font-medium">{overview.name}</span>
-          </Tooltip>
+          <Link
+            to="/organization/$organizationId/project/$projectId/environment/$environmentId"
+            params={{ organizationId, projectId, environmentId: overview.id }}
+            onClick={stopRowNavigation}
+            onKeyDown={stopRowNavigation}
+            className="group min-w-0 max-w-full"
+          >
+            <Tooltip content={overview.name}>
+              <span className="block min-w-0 truncate text-sm font-medium group-hover:underline">{overview.name}</span>
+            </Tooltip>
+          </Link>
           <div className="flex flex-shrink-0 items-center gap-2">
             <span className="font-normal text-neutral-subtle">
               {pluralize(overview.services_overview.service_count, 'service')}

--- a/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
+++ b/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
@@ -891,7 +891,9 @@ export function ServiceActions({
   const isHeaderButton = ['header', 'deploy-dropdown-only'].includes(variant)
 
   if (!service || !deploymentStatus)
-    return <Skeleton height={variant === 'default' ? 26 : 28} width={isHeaderButton ? 96 : 67} />
+    return (
+      <Skeleton height={variant === 'default' ? 26 : 28} width={variant === 'default' || isHeaderButton ? 96 : 67} />
+    )
 
   return (
     <div className={twMerge('flex items-center gap-1.5', isHeaderButton && 'flex-row-reverse gap-2')}>

--- a/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
+++ b/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
@@ -70,6 +70,7 @@ function MenuManageDeployment({
   service: AnyService
   variant: ActionToolbarVariant
 }) {
+  const isHeaderButton = ['header', 'deploy-dropdown-only'].includes(variant)
   const { openModal, closeModal } = useModal()
   const { openModalConfirmation } = useModalConfirmation()
 
@@ -358,10 +359,10 @@ function MenuManageDeployment({
       <DropdownMenu.Trigger asChild>
         <Button
           aria-label="Manage Deployment"
-          color={displayYellowColor ? 'yellow' : variant === 'header' ? 'brand' : 'neutral'}
-          variant={variant === 'header' ? 'solid' : 'outline'}
-          size={variant === 'header' ? 'md' : 'sm'}
-          iconOnly={['default', 'deploy-dropdown-only'].includes(variant)}
+          color={displayYellowColor ? 'yellow' : isHeaderButton ? 'brand' : 'neutral'}
+          variant={isHeaderButton ? 'solid' : 'outline'}
+          size={isHeaderButton ? 'md' : 'sm'}
+          iconOnly={variant === 'default'}
         >
           <Tooltip content="Manage Deployment">
             <div className="flex h-full w-full items-center justify-center gap-1.5">
@@ -375,7 +376,7 @@ function MenuManageDeployment({
                 .otherwise(() => (
                   <Icon iconName="rocket" />
                 ))}
-              {variant === 'header' && (
+              {isHeaderButton && (
                 <>
                   <span>Deploy</span>
                   <Icon iconName="chevron-down" />
@@ -887,12 +888,13 @@ export function ServiceActions({
 }) {
   const { data: service } = useService({ environmentId: environment.id, serviceId })
   const { data: deploymentStatus } = useDeploymentStatus({ environmentId: environment.id, serviceId })
+  const isHeaderButton = ['header', 'deploy-dropdown-only'].includes(variant)
 
   if (!service || !deploymentStatus)
-    return <Skeleton height={variant === 'default' ? 26 : 28} width={variant === 'default' ? 96 : 67} />
+    return <Skeleton height={variant === 'default' ? 26 : 28} width={isHeaderButton ? 96 : 67} />
 
   return (
-    <div className={twMerge('flex items-center gap-1.5', variant === 'header' && 'flex-row-reverse gap-2')}>
+    <div className={twMerge('flex items-center gap-1.5', isHeaderButton && 'flex-row-reverse gap-2')}>
       <MenuManageDeployment
         deploymentStatus={deploymentStatus}
         environment={environment}

--- a/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { type Application } from '@qovery/domains/services/data-access'
 import { applicationFactoryMock } from '@qovery/shared/factories'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
 import { AdvancedSettings } from './service-advanced-settings'
 
 const mockMutateEdit = jest.fn()
@@ -131,16 +131,45 @@ describe('AdvancedSettings', () => {
     if (input) await userEvent.type(input, '79')
     await userEvent.click(screen.getByTestId('submit-button'))
 
-    expect(mockMutateEdit).toHaveBeenCalledWith({
-      payload: {
-        'cronjob.success_jobs_history_limit': 3,
-        'deployment.affinity.node.required': {},
-        'deployment.custom_domain_check_enabled': true,
-        'job.delete_ttl_seconds_after_finished': 3,
-        serviceType: 'APPLICATION',
-        test_empty: 79,
+    expect(mockMutateEdit).toHaveBeenCalledWith(
+      {
+        payload: {
+          'cronjob.success_jobs_history_limit': 3,
+          'deployment.affinity.node.required': {},
+          'deployment.custom_domain_check_enabled': true,
+          'job.delete_ttl_seconds_after_finished': 3,
+          serviceType: 'APPLICATION',
+          test_empty: 79,
+        },
+        serviceId: '0',
       },
-      serviceId: '0',
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      })
+    )
+  })
+
+  it('should hide the sticky toaster after a successful submit', async () => {
+    mockMutateEdit.mockImplementation((_variables, options) => {
+      options?.onSuccess?.()
+    })
+
+    const { userEvent, container } = renderWithProviders(
+      <AdvancedSettings
+        service={mockApplication}
+        advancedSettings={advancedSettings}
+        defaultAdvancedSettings={defaultAdvancedSettings}
+      />
+    )
+    const input = container.querySelector('textarea[name="test_empty"]')
+    if (input) await userEvent.type(input, '79')
+
+    expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible()
+
+    await userEvent.click(screen.getByTestId('submit-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sticky-action-form-toaster')).not.toHaveClass('animate-action-bar-fade-in')
     })
   })
 })

--- a/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.tsx
+++ b/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.tsx
@@ -130,7 +130,12 @@ export function AdvancedSettings({
       }
       dataFormatted[key] = JSON.parse(dataFormatted[key])
     })
-    editAdvancedSettings({ serviceId, payload: { serviceType, ...dataFormatted } })
+    editAdvancedSettings(
+      { serviceId, payload: { serviceType, ...dataFormatted } },
+      {
+        onSuccess: () => reset(data),
+      }
+    )
   })
 
   const columns = useMemo(() => {

--- a/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
@@ -215,12 +215,18 @@ exports[`ServiceList should match snapshot 1`] = `
                       <span
                         class="flex min-w-0 flex-1 flex-col overflow-hidden"
                       >
-                        <span
-                          class="block min-w-0 truncate"
-                          data-state="closed"
+                        <a
+                          class="group min-w-0"
+                          params="[object Object]"
+                          to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview"
                         >
-                          FRONT-END
-                        </span>
+                          <span
+                            class="block min-w-0 truncate group-hover:underline"
+                            data-state="closed"
+                          >
+                            FRONT-END
+                          </span>
+                        </a>
                       </span>
                     </div>
                     <div
@@ -596,12 +602,18 @@ exports[`ServiceList should match snapshot 1`] = `
                       <span
                         class="flex min-w-0 flex-1 flex-col overflow-hidden"
                       >
-                        <span
-                          class="block min-w-0 truncate"
-                          data-state="closed"
+                        <a
+                          class="group min-w-0"
+                          params="[object Object]"
+                          to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview"
                         >
-                          back-end-A
-                        </span>
+                          <span
+                            class="block min-w-0 truncate group-hover:underline"
+                            data-state="closed"
+                          >
+                            back-end-A
+                          </span>
+                        </a>
                       </span>
                     </div>
                     <div
@@ -1256,12 +1268,18 @@ exports[`ServiceList should match snapshot 1`] = `
                         <span
                           class="flex min-w-0 items-center gap-1.5"
                         >
-                          <span
-                            class="block min-w-0 flex-1 truncate"
-                            data-state="closed"
+                          <a
+                            class="group min-w-0"
+                            params="[object Object]"
+                            to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview"
                           >
-                            CRONJOB
-                          </span>
+                            <span
+                              class="block min-w-0 truncate group-hover:underline"
+                              data-state="closed"
+                            >
+                              CRONJOB
+                            </span>
+                          </a>
                           <span
                             class="shrink-0 truncate text-sm font-normal text-neutral-subtle"
                             data-state="closed"
@@ -1741,12 +1759,18 @@ exports[`ServiceList should match snapshot 1`] = `
                         <span
                           class="flex min-w-0 items-center gap-1.5"
                         >
-                          <span
-                            class="block min-w-0 flex-1 truncate"
-                            data-state="closed"
+                          <a
+                            class="group min-w-0"
+                            params="[object Object]"
+                            to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview"
                           >
-                            seed_script
-                          </span>
+                            <span
+                              class="block min-w-0 truncate group-hover:underline"
+                              data-state="closed"
+                            >
+                              seed_script
+                            </span>
+                          </a>
                           <span
                             class="shrink-0 truncate text-sm font-normal text-neutral-subtle"
                             data-state="closed"

--- a/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-name-cell.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-name-cell.tsx
@@ -1,4 +1,6 @@
+import { Link } from '@tanstack/react-router'
 import { type Environment } from 'qovery-typescript-axios'
+import { type KeyboardEvent, type MouseEvent } from 'react'
 import { match } from 'ts-pattern'
 import { type AnyService } from '@qovery/domains/services/data-access'
 import { Button, Icon, Tooltip } from '@qovery/shared/ui'
@@ -8,6 +10,16 @@ import ServiceLinksPopover from '../../service-links-popover/service-links-popov
 import ServiceTemplateIndicator from '../../service-template-indicator/service-template-indicator'
 
 export function ServiceNameCell({ service, environment }: { service: AnyService; environment: Environment }) {
+  const serviceLinkParams = {
+    organizationId: environment.organization.id,
+    projectId: environment.project.id,
+    environmentId: environment.id,
+    serviceId: service.id,
+  }
+  const stopRowNavigation = (event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
+    event.stopPropagation()
+  }
+
   return (
     <div className="flex h-full min-w-0 max-w-full items-center justify-between overflow-hidden">
       <div className="flex h-full min-w-0 flex-1 items-center gap-3">
@@ -20,9 +32,17 @@ export function ServiceNameCell({ service, environment }: { service: AnyService;
               return (
                 <span className="flex min-w-0 flex-1 flex-col overflow-hidden">
                   <span className="flex min-w-0 items-center gap-1.5">
-                    <Tooltip content={db.name}>
-                      <span className="block min-w-0 truncate">{db.name}</span>
-                    </Tooltip>
+                    <Link
+                      to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview"
+                      params={serviceLinkParams}
+                      onClick={stopRowNavigation}
+                      onKeyDown={stopRowNavigation}
+                      className="group min-w-0"
+                    >
+                      <Tooltip content={db.name}>
+                        <span className="block min-w-0 truncate group-hover:underline">{db.name}</span>
+                      </Tooltip>
+                    </Link>
                   </span>
                 </span>
               )
@@ -49,9 +69,17 @@ export function ServiceNameCell({ service, environment }: { service: AnyService;
               return (
                 <span className="flex min-w-0 flex-1 flex-col overflow-hidden">
                   <span className="flex min-w-0 items-center gap-1.5">
-                    <Tooltip content={service.name}>
-                      <span className="block min-w-0 flex-1 truncate">{service.name}</span>
-                    </Tooltip>
+                    <Link
+                      to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview"
+                      params={serviceLinkParams}
+                      onClick={stopRowNavigation}
+                      onKeyDown={stopRowNavigation}
+                      className="group min-w-0"
+                    >
+                      <Tooltip content={service.name}>
+                        <span className="block min-w-0 truncate group-hover:underline">{service.name}</span>
+                      </Tooltip>
+                    </Link>
                     <Tooltip content={schedule}>
                       <span className="shrink-0 truncate text-sm font-normal text-neutral-subtle">
                         <Icon iconName="info-circle" iconStyle="regular" />
@@ -63,9 +91,17 @@ export function ServiceNameCell({ service, environment }: { service: AnyService;
             })
             .otherwise(() => (
               <span className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                <Tooltip content={service.name}>
-                  <span className="block min-w-0 truncate">{service.name}</span>
-                </Tooltip>
+                <Link
+                  to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview"
+                  params={serviceLinkParams}
+                  onClick={stopRowNavigation}
+                  onKeyDown={stopRowNavigation}
+                  className="group min-w-0"
+                >
+                  <Tooltip content={service.name}>
+                    <span className="block min-w-0 truncate group-hover:underline">{service.name}</span>
+                  </Tooltip>
+                </Link>
               </span>
             ))}
         </div>


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

- Fix color Healthy nodes tooltip for cluster ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1776245893407289))
- Fix "deploy environment" button ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1776345413172729))
- Fix advanced settings save modification behavior ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1776244691549489))
- Add environment and service actions for deployment views ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1776519531513549))
- Add "last services opened" behavior in the service views for spotlight ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1775648942006579))
- Add "Service not found" page if service not available ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1776772870099069?thread_ts=1775648942.006579&cid=C0AML0VDUV8))
- Add link in the environment and service list for cmd+click ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1776699769768029))
- Fix audit logs links with services ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1776778359874059))
 
## Screenshots / Recordings

<img width="1460" height="805" alt="Screenshot 2026-04-21 at 14 35 44" src="https://github.com/user-attachments/assets/2115b002-5747-472c-8b8d-a1102c807d12" />

<img width="1460" height="695" alt="Screenshot 2026-04-21 at 14 35 57" src="https://github.com/user-attachments/assets/ac307960-192d-47e2-b4d7-d44b5acf1b71" />

<img width="1459" height="877" alt="Screenshot 2026-04-21 at 15 33 26" src="https://github.com/user-attachments/assets/1507c79a-ead6-404a-a62d-df0f2e03e2e6" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
