### PR TITLE
fix: Properly extract connection name from domain on sso login

### DIFF
--- a/libs/pages/login/src/lib/hooks/use-redirect-if-logged/use-redirect-if-logged.tsx
+++ b/libs/pages/login/src/lib/hooks/use-redirect-if-logged/use-redirect-if-logged.tsx
@@ -35,7 +35,8 @@ export function useRedirectIfLogged() {
   useEffect(() => {
     const connectionParam = searchParams.get('connection')
     if (connectionParam && !isAuthenticated) {
-      const domainWithoutDots = connectionParam.trim().replace(/\./g, '')
+      const trimmed = connectionParam.trim()
+      const domainWithoutDots = trimmed.includes('.') ? trimmed.substring(0, trimmed.lastIndexOf('.')) : trimmed
 
       // Trigger the auth login with the domain from URL parameter
       authLogin(domainWithoutDots).catch((error) => {


### PR DESCRIPTION
## Summary

Connection name on auth0 side are mapped to the customers domain names (without the top level domain part, i.e `.com`)

Initially the connection name was mapped to the full domain name, but in practice this is not the case.
