### PR TITLE
feat(user-settings): add console preference toggle to user-modal and implement legacy console redirection logic

### DIFF
--- a/apps/console-v5/src/app/components/header/user-menu/user-menu.tsx
+++ b/apps/console-v5/src/app/components/header/user-menu/user-menu.tsx
@@ -1,4 +1,5 @@
 import * as ToggleGroup from '@radix-ui/react-toggle-group'
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { useState } from 'react'
 import { useAuth } from '@qovery/shared/auth'
 import { UserSettingsModal, useUserAccount } from '@qovery/shared/iam/feature'
@@ -16,6 +17,7 @@ export function UserMenu() {
   const { theme, setTheme } = useTheme()
   const { authLogout, user: userToken } = useAuth()
   const { data: user } = useUserAccount()
+  const isNewNavigationActivationEnabled = Boolean(useFeatureFlagEnabled('new-navigation-activation'))
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const { openModal } = useModal()
 
@@ -54,7 +56,11 @@ export function UserMenu() {
 
         <DropdownMenu.Separator />
 
-        <DropdownMenu.Item onClick={() => openModal({ content: <UserSettingsModal /> })}>
+        <DropdownMenu.Item
+          onClick={() =>
+            openModal({ content: <UserSettingsModal showConsolePreferenceToggle={isNewNavigationActivationEnabled} /> })
+          }
+        >
           Profile settings
         </DropdownMenu.Item>
 

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.spec.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.spec.ts
@@ -1,4 +1,5 @@
 import {
+  getLegacyConsoleUrl,
   getNewConsoleUrl,
   getStoredConsolePreference,
   shouldBypassLegacyConsoleRedirect,
@@ -19,6 +20,17 @@ describe('useConsoleRedirectPreference', () => {
   it('should return null when current host is not the legacy console', () => {
     expect(getNewConsoleUrl('https://new-console.qovery.com/organization/123')).toBeNull()
     expect(getNewConsoleUrl('http://localhost:4200/organization/123')).toBeNull()
+  })
+
+  it('should return the legacy console url for new console hosts', () => {
+    expect(getLegacyConsoleUrl('https://new-console.qovery.com/organization/123?foo=bar#hash')).toBe(
+      'https://console.qovery.com/organization/123?foo=bar#hash'
+    )
+  })
+
+  it('should return null when current host is not the new console', () => {
+    expect(getLegacyConsoleUrl('https://console.qovery.com/organization/123')).toBeNull()
+    expect(getLegacyConsoleUrl('http://localhost:4200/organization/123')).toBeNull()
   })
 
   it('should read the preference from local storage first', () => {

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
@@ -75,6 +75,18 @@ export function getNewConsoleUrl(currentUrl = window.location.href): string | nu
   return url.toString()
 }
 
+export function getLegacyConsoleUrl(currentUrl = window.location.href): string | null {
+  const url = new URL(currentUrl)
+
+  if (!url.hostname.startsWith('new-console.')) {
+    return null
+  }
+
+  url.hostname = url.hostname.replace(/^new-console\./, 'console.')
+
+  return url.toString()
+}
+
 export function shouldBypassLegacyConsoleRedirect(search = window.location.search): boolean {
   const searchParams = new URLSearchParams(search)
   return searchParams.get(LEGACY_CONSOLE_BYPASS_QUERY_PARAM) === '1'

--- a/libs/shared/iam/feature/src/lib/user-settings-modal/user-settings-modal.spec.tsx
+++ b/libs/shared/iam/feature/src/lib/user-settings-modal/user-settings-modal.spec.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
-import { UserSettingsModal } from './user-settings-modal'
+import { UserSettingsModal, type UserSettingsModalProps } from './user-settings-modal'
 
 const mockUser = {
   id: '1',
@@ -34,16 +34,18 @@ jest.mock('../use-user-edit-account/use-user-edit-account', () => ({
 }))
 
 describe('UserSettingsModal', () => {
-  const renderUserSettingsModal = () =>
+  const renderUserSettingsModal = (props?: UserSettingsModalProps) =>
     renderWithProviders(
       <Dialog.Root open>
         <Dialog.Content>
-          <UserSettingsModal />
+          <UserSettingsModal {...props} />
         </Dialog.Content>
       </Dialog.Root>
     )
 
   beforeEach(() => {
+    localStorage.clear()
+    document.cookie = 'qovery-console-preference=; Max-Age=0; Path=/'
     mockMutateAsync.mockResolvedValue(undefined)
   })
 
@@ -57,7 +59,28 @@ describe('UserSettingsModal', () => {
     expect(screen.getByLabelText(/communication email/i)).toHaveValue('john@example.com')
     expect(screen.getByLabelText(/account email/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/timezone/i)).toBeInTheDocument()
+    expect(screen.queryByText('Use legacy interface')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument()
+  })
+
+  it('should render the console preference toggle when enabled', async () => {
+    localStorage.setItem('qovery-console-preference', 'new')
+
+    renderUserSettingsModal({ showConsolePreferenceToggle: true })
+    await waitFor(() => expect(screen.getByRole('button', { name: /save/i })).toBeEnabled())
+
+    expect(screen.getByText('Use legacy interface')).toBeInTheDocument()
+    expect(screen.getByText(/redirected to the legacy console interface/i)).toBeInTheDocument()
+  })
+
+  it('should update the console preference from the toggle', async () => {
+    localStorage.setItem('qovery-console-preference', 'new')
+    const { userEvent } = renderUserSettingsModal({ showConsolePreferenceToggle: true })
+    await waitFor(() => expect(screen.getByRole('button', { name: /save/i })).toBeEnabled())
+
+    await userEvent.click(screen.getByText('Use legacy interface'))
+
+    expect(localStorage.getItem('qovery-console-preference')).toBe('legacy')
   })
 
   it('should call mutateAsync with updated email on submit', async () => {

--- a/libs/shared/iam/feature/src/lib/user-settings-modal/user-settings-modal.tsx
+++ b/libs/shared/iam/feature/src/lib/user-settings-modal/user-settings-modal.tsx
@@ -3,7 +3,11 @@ import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import { useAuth } from '@qovery/shared/auth'
 import { type IconEnum } from '@qovery/shared/enums'
-import { Button, Icon, InputSelect, InputText } from '@qovery/shared/ui'
+import { Button, Icon, InputSelect, InputText, InputToggle } from '@qovery/shared/ui'
+import {
+  getLegacyConsoleUrl,
+  useConsoleRedirectPreference,
+} from '../use-console-redirect-preference/use-console-redirect-preference'
 import { useUserAccount } from '../use-user-account/use-user-account'
 import { useEditUserAccount } from '../use-user-edit-account/use-user-edit-account'
 
@@ -24,10 +28,15 @@ function getUserGitProvider(sub?: string) {
     .otherwise((s) => s.split('|')[0])
 }
 
-export function UserSettingsModal() {
+export interface UserSettingsModalProps {
+  showConsolePreferenceToggle?: boolean
+}
+
+export function UserSettingsModal({ showConsolePreferenceToggle = false }: UserSettingsModalProps) {
   const { user: userToken } = useAuth()
   const { data: user } = useUserAccount()
   const { mutateAsync, isLoading: loading } = useEditUserAccount()
+  const { isNewConsoleDefault, setIsNewConsoleDefault } = useConsoleRedirectPreference()
 
   const methods = useForm({
     mode: 'onChange',
@@ -49,6 +58,18 @@ export function UserSettingsModal() {
   })
 
   const userGitProvider = getUserGitProvider(userToken?.sub)
+
+  const handleLegacyInterfaceChange = (value: boolean) => {
+    setIsNewConsoleDefault(!value)
+
+    if (value) {
+      const legacyConsoleUrl = getLegacyConsoleUrl()
+
+      if (legacyConsoleUrl) {
+        window.location.assign(legacyConsoleUrl)
+      }
+    }
+  }
 
   const accountOptions = [
     {
@@ -153,6 +174,17 @@ export function UserSettingsModal() {
           disabled
           hint="Timezone used to display timestamp within the interface"
         />
+        {showConsolePreferenceToggle && (
+          <InputToggle
+            className="mt-4"
+            value={!isNewConsoleDefault}
+            onChange={handleLegacyInterfaceChange}
+            title="Use legacy interface"
+            description="When enabled, you will be redirected to the legacy console interface."
+            align="top"
+            small
+          />
+        )}
         <div className="mt-6 flex justify-end">
           <Button size="lg" type="submit" disabled={!methods.formState.isValid} loading={loading}>
             Save


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Add toggle to redirect in the legacy console if needed under a ff

## Screenshots / Recordings

<img width="1459" height="863" alt="Screenshot 2026-04-21 at 16 08 38" src="https://github.com/user-attachments/assets/8fcbe114-33fd-40b6-9c0b-e4a2b22bf7ca" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
