### PR TITLE
feat(announcement-banner): enhance banner functionality with tooltip and multiple banner support

### DIFF
--- a/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
+++ b/libs/shared/posthog/feature/src/lib/announcement-banner/announcement-banner.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Banner, Button, Icon } from '@qovery/shared/ui'
+import { Banner, Button, Icon, Tooltip } from '@qovery/shared/ui'
 import { useLocalStorage } from '@qovery/shared/util-hooks'
 import {
   type AnnouncementBannerPayload,
@@ -19,6 +19,7 @@ const VARIANT_PRIORITY: Record<AnnouncementBannerPayload['variant'], number> = {
 }
 
 const BANNER_ICON_BUTTON_CLASSNAME = 'flex h-7 w-7 items-center justify-center p-0'
+const MULTIPLE_BANNERS_CONTENT_CLASSNAME = 'pl-4 pr-[170px] sm:px-[170px]'
 
 const LEGACY_DISMISSED_KEY = 'announcement_banner_dismissed'
 const DISMISSED_MESSAGES_KEY = 'announcement_banners_dismissed'
@@ -68,6 +69,7 @@ export function AnnouncementBanner() {
   const hasActionButton = Boolean(buttonLabel && buttonUrl)
   const hasMultiple = visibleBanners.length > 1
   const usesBannerDismissButton = dismissible && !hasMultiple
+  const bannerText = title ? `${title} ${message}` : message
 
   const handlePrev = () => {
     const previousIndex = (currentIndex - 1 + visibleBanners.length) % visibleBanners.length
@@ -96,19 +98,25 @@ export function AnnouncementBanner() {
   return (
     <Banner
       color={color}
+      className={hasMultiple ? MULTIPLE_BANNERS_CONTENT_CLASSNAME : undefined}
       buttonLabel={hasActionButton ? buttonLabel : undefined}
       buttonIconRight={hasActionButton ? 'arrow-up-right-from-square' : undefined}
       onClickButton={hasActionButton ? () => window.open(buttonUrl, '_blank', 'noopener,noreferrer') : undefined}
       dismissible={usesBannerDismissButton}
       onDismiss={usesBannerDismissButton ? handleDismiss : undefined}
     >
-      {title && <strong className="mr-2">{title}</strong>}
-      {message}
+      <Tooltip content={bannerText} side="bottom" classNameContent="max-w-[480px] text-center whitespace-normal">
+        <span className="min-w-0 truncate text-center" title={bannerText}>
+          {title && <strong className="mr-2">{title}</strong>}
+          {message}
+        </span>
+      </Tooltip>
       {hasMultiple && (
         <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
           <Button
             type="button"
             className={BANNER_ICON_BUTTON_CLASSNAME}
+            variant="plain"
             color={color}
             onClick={handlePrev}
             aria-label="Previous"
@@ -121,6 +129,7 @@ export function AnnouncementBanner() {
           <Button
             type="button"
             className={BANNER_ICON_BUTTON_CLASSNAME}
+            variant="plain"
             color={color}
             onClick={handleNext}
             aria-label="Next"
@@ -132,6 +141,7 @@ export function AnnouncementBanner() {
             <Button
               type="button"
               className={BANNER_ICON_BUTTON_CLASSNAME}
+              variant="plain"
               color={color}
               onClick={handleDismiss}
               aria-label="Dismiss"


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Improve banner announcement responsive and boutons colors

## Screenshots / Recordings

<img width="1459" height="872" alt="Screenshot 2026-04-21 at 18 59 56" src="https://github.com/user-attachments/assets/7914f62c-b104-4c39-b8a1-e36be46d8887" />

<img width="1128" height="863" alt="Screenshot 2026-04-21 at 19 02 31" src="https://github.com/user-attachments/assets/0474c715-a39f-4790-85b0-ed0f561731e8" />

<img width="983" height="855" alt="Screenshot 2026-04-21 at 19 03 38" src="https://github.com/user-attachments/assets/41fd59f0-0395-4af5-9296-2af6135126b6" />

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
