### PR TITLE
fix(console-redirect): implement path migration logic for new console URLs

### DIFF
--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.spec.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.spec.ts
@@ -1,4 +1,5 @@
 import {
+  getNewConsolePathname,
   getNewConsoleUrl,
   getStoredConsolePreference,
   shouldBypassLegacyConsoleRedirect,
@@ -19,6 +20,82 @@ describe('useConsoleRedirectPreference', () => {
   it('should return null when current host is not the legacy console', () => {
     expect(getNewConsoleUrl('https://new-console.qovery.com/organization/123')).toBeNull()
     expect(getNewConsoleUrl('http://localhost:4200/organization/123')).toBeNull()
+  })
+
+  it('should migrate legacy application paths to new service paths', () => {
+    expect(
+      getNewConsolePathname('/organization/org/project/project/environment/environment/application/application/general')
+    ).toBe('/organization/org/project/project/environment/environment/service/application/overview')
+
+    expect(
+      getNewConsolePathname(
+        '/organization/org/project/project/environment/environment/application/application/settings/resources'
+      )
+    ).toBe('/organization/org/project/project/environment/environment/service/application/settings/resources')
+  })
+
+  it('should migrate legacy database paths to new service paths', () => {
+    expect(
+      getNewConsolePathname('/organization/org/project/project/environment/environment/database/database/general')
+    ).toBe('/organization/org/project/project/environment/environment/service/database/overview')
+
+    expect(
+      getNewConsolePathname(
+        '/organization/org/project/project/environment/environment/database/database/settings/danger-zone'
+      )
+    ).toBe('/organization/org/project/project/environment/environment/service/database/settings/danger-zone')
+  })
+
+  it('should migrate legacy environment services paths to singular service paths', () => {
+    expect(getNewConsolePathname('/organization/org/project/project/environment/environment/services/new')).toBe(
+      '/organization/org/project/project/environment/environment/service/new'
+    )
+
+    expect(
+      getNewConsolePathname(
+        '/organization/org/project/project/environment/environment/services/create/database/general'
+      )
+    ).toBe('/organization/org/project/project/environment/environment/service/create/database/general')
+  })
+
+  it('should migrate legacy service creation step paths', () => {
+    expect(
+      getNewConsolePathname(
+        '/organization/org/project/project/environment/environment/services/create/helm/values-override/repository-and-yaml'
+      )
+    ).toBe('/organization/org/project/project/environment/environment/service/create/helm/values-override-file')
+
+    expect(
+      getNewConsolePathname(
+        '/organization/org/project/project/environment/environment/services/create/helm/values-override/arguments'
+      )
+    ).toBe('/organization/org/project/project/environment/environment/service/create/helm/values-override-arguments')
+
+    expect(
+      getNewConsolePathname(
+        '/organization/org/project/project/environment/environment/services/create/terraform/basic-configuration'
+      )
+    ).toBe('/organization/org/project/project/environment/environment/service/create/terraform/terraform-configuration')
+  })
+
+  it('should migrate legacy monitoring metric creation paths', () => {
+    expect(
+      getNewConsolePathname(
+        '/organization/org/project/project/environment/environment/application/application/monitoring/metric/cpu'
+      )
+    ).toBe(
+      '/organization/org/project/project/environment/environment/service/application/monitoring/alerts/create/metric/cpu'
+    )
+  })
+
+  it('should migrate paths while building the new console url', () => {
+    expect(
+      getNewConsoleUrl(
+        'https://console.qovery.com/organization/org/project/project/environment/environment/application/application/general?foo=bar#hash'
+      )
+    ).toBe(
+      'https://new-console.qovery.com/organization/org/project/project/environment/environment/service/application/overview?foo=bar#hash'
+    )
   })
 
   it('should read the preference from local storage first', () => {

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
@@ -6,6 +6,7 @@ const CONSOLE_PREFERENCE_STORAGE_KEY = 'qovery-console-preference'
 const CONSOLE_PREFERENCE_COOKIE_KEY = 'qovery-console-preference'
 const LEGACY_CONSOLE_BYPASS_QUERY_PARAM = 'legacy'
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365
+const ENVIRONMENT_PATH_PATTERN = '/organization/[^/]+/project/[^/]+/environment/[^/]+'
 
 function isConsolePreference(value: string | null): value is ConsolePreference {
   return value === 'legacy' || value === 'new'
@@ -63,6 +64,29 @@ export function getStoredConsolePreference(): ConsolePreference {
   return 'legacy'
 }
 
+export function getNewConsolePathname(pathname: string): string {
+  return pathname
+    .replace(new RegExp(`^(${ENVIRONMENT_PATH_PATTERN})/(application|database)/([^/]+)(/|$)`), '$1/service/$3$4')
+    .replace(new RegExp(`^(${ENVIRONMENT_PATH_PATTERN})/services(/|$)`), '$1/service$2')
+    .replace(new RegExp(`^(${ENVIRONMENT_PATH_PATTERN}/service/[^/]+)/general(/|$)`), '$1/overview$2')
+    .replace(
+      new RegExp(`^(${ENVIRONMENT_PATH_PATTERN}/service/[^/]+)/monitoring/metric/([^/]+)(/|$)`),
+      '$1/monitoring/alerts/create/metric/$2$3'
+    )
+    .replace(
+      new RegExp(`^(${ENVIRONMENT_PATH_PATTERN}/service/create/helm)/values-override/repository-and-yaml(/|$)`),
+      '$1/values-override-file$2'
+    )
+    .replace(
+      new RegExp(`^(${ENVIRONMENT_PATH_PATTERN}/service/create/helm)/values-override/arguments(/|$)`),
+      '$1/values-override-arguments$2'
+    )
+    .replace(
+      new RegExp(`^(${ENVIRONMENT_PATH_PATTERN}/service/create/terraform)/basic-configuration(/|$)`),
+      '$1/terraform-configuration$2'
+    )
+}
+
 export function getNewConsoleUrl(currentUrl = window.location.href): string | null {
   const url = new URL(currentUrl)
 
@@ -71,6 +95,7 @@ export function getNewConsoleUrl(currentUrl = window.location.href): string | nu
   }
 
   url.hostname = url.hostname.replace(/^console\./, 'new-console.')
+  url.pathname = getNewConsolePathname(url.pathname)
 
   return url.toString()
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Adds the legacy-to-new console route gateway for redirects:
- Maps legacy service URLs (application, database, services) to v5 service routes
- Handles renamed sub-routes like general -> overview and creation steps
- Adds tests for URL migration and query/hash preservation

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
