### PR TITLE
fix(console-redirect): enhance unit tests for console redirection preferences

### DIFF
--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.spec.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.spec.tsx
@@ -147,4 +147,20 @@ describe('LayoutPage', () => {
       expect(redirectToUrl).toHaveBeenCalledWith('https://new-console.qovery.com/organization/123')
     })
   })
+
+  it('should not automatically redirect when the new navigation activation feature flag is disabled', async () => {
+    useFeatureFlagEnabledMock.mockReturnValue(false)
+    jest.spyOn(iamFeature, 'useConsoleRedirectPreference').mockReturnValue({
+      preferredConsole: 'new',
+      isNewConsoleDefault: true,
+      setPreferredConsole: jest.fn(),
+      setIsNewConsoleDefault: jest.fn(),
+    })
+
+    renderWithProviders(renderComponent({ ...props }))
+
+    await waitFor(() => {
+      expect(redirectToUrl).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.spec.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.spec.tsx
@@ -3,7 +3,7 @@ import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { CloudProviderEnum } from 'qovery-typescript-axios'
 import { type ReactNode } from 'react'
 import * as iamFeature from '@qovery/shared/iam/feature'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
 import LayoutPage, { type LayoutPageProps } from './layout-page'
 import { redirectToUrl } from './layout-page.utils'
 
@@ -131,5 +131,20 @@ describe('LayoutPage', () => {
       target_url: 'https://new-console.qovery.com/organization/123',
     })
     expect(redirectToUrl).toHaveBeenCalledWith('https://new-console.qovery.com/organization/123')
+  })
+
+  it('should automatically redirect to the new console when the preference is enabled', async () => {
+    jest.spyOn(iamFeature, 'useConsoleRedirectPreference').mockReturnValue({
+      preferredConsole: 'new',
+      isNewConsoleDefault: true,
+      setPreferredConsole: jest.fn(),
+      setIsNewConsoleDefault: jest.fn(),
+    })
+
+    renderWithProviders(renderComponent({ ...props }))
+
+    await waitFor(() => {
+      expect(redirectToUrl).toHaveBeenCalledWith('https://new-console.qovery.com/organization/123')
+    })
   })
 })

--- a/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
+++ b/libs/pages/layout/src/lib/ui/layout-page/layout-page.tsx
@@ -153,14 +153,19 @@ export function LayoutPage(props: PropsWithChildren<LayoutPageProps>) {
   )
 
   useEffect(() => {
-    if (!isNewConsoleDefault || shouldBypassLegacyConsoleRedirect() || !newConsoleUrl) {
+    if (
+      !isNewNavigationActivationEnabled ||
+      !isNewConsoleDefault ||
+      shouldBypassLegacyConsoleRedirect() ||
+      !newConsoleUrl
+    ) {
       return
     }
 
     if (window.location.href !== newConsoleUrl) {
       redirectToUrl(newConsoleUrl)
     }
-  }, [newConsoleUrl, isNewConsoleDefault])
+  }, [isNewNavigationActivationEnabled, isNewConsoleDefault, newConsoleUrl])
 
   const handleConsoleMigration = () => {
     if (!newConsoleUrl) {

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.spec.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.spec.ts
@@ -1,8 +1,10 @@
+import { act, renderHook, waitFor } from '@qovery/shared/util-tests'
 import {
   getNewConsolePathname,
   getNewConsoleUrl,
   getStoredConsolePreference,
   shouldBypassLegacyConsoleRedirect,
+  useConsoleRedirectPreference,
 } from './use-console-redirect-preference'
 
 const ORGANIZATION_ID = '3d542888-3d2c-474a-b1ad-712556db66da'
@@ -213,6 +215,11 @@ describe('useConsoleRedirectPreference', () => {
     ).toBe(`https://new-console.qovery.com${ENVIRONMENT_PATH}/service/${SERVICE_ID}/overview?foo=bar#hash`)
   })
 
+  it('should redirect organization fallback targets to the new console root', () => {
+    expect(getNewConsoleUrl('https://console.qovery.com/user/general')).toBe('https://new-console.qovery.com/')
+    expect(getNewConsoleUrl('https://console.qovery.com/organization')).toBe('https://new-console.qovery.com/')
+  })
+
   it('should read the preference from local storage first', () => {
     localStorage.setItem('qovery-console-preference', 'new')
     document.cookie = 'qovery-console-preference=legacy; Path=/'
@@ -224,6 +231,21 @@ describe('useConsoleRedirectPreference', () => {
     document.cookie = 'qovery-console-preference=new; Path=/'
 
     expect(getStoredConsolePreference()).toBe('new')
+  })
+
+  it('should sync preference changes across hook instances', async () => {
+    const { result: layoutPreference } = renderHook(() => useConsoleRedirectPreference())
+    const { result: userSettingsPreference } = renderHook(() => useConsoleRedirectPreference())
+
+    expect(layoutPreference.current.isNewConsoleDefault).toBe(false)
+
+    act(() => {
+      userSettingsPreference.current.setIsNewConsoleDefault(true)
+    })
+
+    await waitFor(() => {
+      expect(layoutPreference.current.isNewConsoleDefault).toBe(true)
+    })
   })
 
   it('should detect the redirect bypass query param', () => {

--- a/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
+++ b/libs/shared/iam/feature/src/lib/use-console-redirect-preference/use-console-redirect-preference.ts
@@ -1,16 +1,17 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 export type ConsolePreference = 'legacy' | 'new'
 
 const CONSOLE_PREFERENCE_STORAGE_KEY = 'qovery-console-preference'
 const CONSOLE_PREFERENCE_COOKIE_KEY = 'qovery-console-preference'
+const CONSOLE_PREFERENCE_CHANGED_EVENT = 'qovery-console-preference-changed'
 const LEGACY_CONSOLE_BYPASS_QUERY_PARAM = 'legacy'
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365
 const ORGANIZATION_PATH_PATTERN = '/organization/[^/]+'
 const PROJECT_PATH_PATTERN = `${ORGANIZATION_PATH_PATTERN}/project/[^/]+`
 const ENVIRONMENT_PATH_PATTERN = `${PROJECT_PATH_PATTERN}/environment/[^/]+`
 
-function isConsolePreference(value: string | null): value is ConsolePreference {
+function isConsolePreference(value: string | null | undefined): value is ConsolePreference {
   return value === 'legacy' || value === 'new'
 }
 
@@ -44,6 +45,7 @@ function persistConsolePreference(preference: ConsolePreference) {
   document.cookie = `${CONSOLE_PREFERENCE_COOKIE_KEY}=${encodeURIComponent(preference)}; Path=/; Max-Age=${ONE_YEAR_IN_SECONDS}; SameSite=Lax${
     domain ? `; Domain=${domain}` : ''
   }`
+  window.dispatchEvent(new CustomEvent<ConsolePreference>(CONSOLE_PREFERENCE_CHANGED_EVENT, { detail: preference }))
 }
 
 export function getStoredConsolePreference(): ConsolePreference {
@@ -147,6 +149,10 @@ export function getNewConsolePathname(pathname: string): string {
     )
 }
 
+function getNewConsoleRedirectPathname(pathname: string): string {
+  return /^\/organization\/?$/.test(pathname) ? '/' : pathname
+}
+
 export function getNewConsoleUrl(currentUrl = window.location.href): string | null {
   const url = new URL(currentUrl)
 
@@ -155,7 +161,7 @@ export function getNewConsoleUrl(currentUrl = window.location.href): string | nu
   }
 
   url.hostname = url.hostname.replace(/^console\./, 'new-console.')
-  url.pathname = getNewConsolePathname(url.pathname)
+  url.pathname = getNewConsoleRedirectPathname(getNewConsolePathname(url.pathname))
 
   return url.toString()
 }
@@ -167,6 +173,27 @@ export function shouldBypassLegacyConsoleRedirect(search = window.location.searc
 
 export function useConsoleRedirectPreference() {
   const [preferredConsole, setPreferredConsoleState] = useState<ConsolePreference>(() => getStoredConsolePreference())
+
+  useEffect(() => {
+    const syncConsolePreference = (event?: Event) => {
+      const preference = (event as CustomEvent<ConsolePreference> | undefined)?.detail
+      setPreferredConsoleState(isConsolePreference(preference) ? preference : getStoredConsolePreference())
+    }
+
+    const syncConsolePreferenceFromStorage = (event: StorageEvent) => {
+      if (event.key === CONSOLE_PREFERENCE_STORAGE_KEY) {
+        syncConsolePreference()
+      }
+    }
+
+    window.addEventListener(CONSOLE_PREFERENCE_CHANGED_EVENT, syncConsolePreference)
+    window.addEventListener('storage', syncConsolePreferenceFromStorage)
+
+    return () => {
+      window.removeEventListener(CONSOLE_PREFERENCE_CHANGED_EVENT, syncConsolePreference)
+      window.removeEventListener('storage', syncConsolePreferenceFromStorage)
+    }
+  }, [])
 
   const setPreferredConsole = useCallback((preference: ConsolePreference) => {
     persistConsolePreference(preference)


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: <!-- QOV-1234 -->

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
