### PR TITLE
fix(new-nav): cluster mirroring registry data not loaded

### DIFF
--- a/apps/console-v5/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/image-registry.tsx
+++ b/apps/console-v5/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/image-registry.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useParams } from '@tanstack/react-router'
 import { type ContainerRegistryRequest } from 'qovery-typescript-axios'
+import { Suspense } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useCluster } from '@qovery/domains/clusters/feature'
 import {
@@ -8,7 +9,7 @@ import {
   useEditContainerRegistry,
 } from '@qovery/domains/organizations/feature'
 import { SettingsHeading } from '@qovery/shared/console-shared'
-import { Button, Callout, Icon, Section } from '@qovery/shared/ui'
+import { Button, Callout, Icon, LoaderSpinner, Section } from '@qovery/shared/ui'
 
 export const Route = createFileRoute(
   '/_authenticated/organization/$organizationId/cluster/$clusterId/settings/image-registry'
@@ -17,9 +18,34 @@ export const Route = createFileRoute(
 })
 
 function RouteComponent() {
+  return (
+    <div className="flex w-full flex-col justify-between">
+      <Section className="p-8">
+        <SettingsHeading
+          title="Mirroring registry"
+          description="This mirroring registry is used to store the built images or mirror the container images deployed on this cluster."
+        />
+        <div className="max-w-content-with-navigation-left">
+          <Suspense
+            fallback={
+              <div className="flex flex-1 items-center justify-center">
+                <LoaderSpinner className="w-6" />
+              </div>
+            }
+          >
+            <ImageRegistrySettings />
+          </Suspense>
+        </div>
+      </Section>
+    </div>
+  )
+}
+
+function ImageRegistrySettings() {
   const { organizationId = '', clusterId = '' } = useParams({ strict: false })
   const { data: containerRegistries } = useContainerRegistries({
     organizationId,
+    suspense: true,
   })
   const containerRegistry = containerRegistries?.find((registry) => registry.cluster?.id === clusterId)
   const { mutate: editContainerRegistry, isLoading: isLoadingEditContainerRegistry } = useEditContainerRegistry()
@@ -59,40 +85,30 @@ function RouteComponent() {
   })
 
   return (
-    <div className="flex w-full flex-col justify-between">
-      <Section className="p-8">
-        <SettingsHeading
-          title="Mirroring registry"
-          description="This mirroring registry is used to store the built images or mirror the container images deployed on this cluster."
-        />
-        <div className="max-w-content-with-navigation-left">
-          <FormProvider {...methods}>
-            <form className="flex flex-col" onSubmit={onSubmit}>
-              <ContainerRegistryForm fromEditClusterSettings cluster={cluster} />
-              {(methods.formState.dirtyFields.kind || methods.formState.dirtyFields.url) && (
-                <Callout.Root className="mt-4" color="yellow">
-                  <Callout.Icon>
-                    <Icon iconName="triangle-exclamation" iconStyle="regular" />
-                  </Callout.Icon>
-                  <Callout.Text>
-                    You will have to delete any image stored in the previous container registry manually
-                  </Callout.Text>
-                </Callout.Root>
-              )}
-              <div className="mt-2 flex justify-end">
-                <Button
-                  type="submit"
-                  size="lg"
-                  loading={isLoadingEditContainerRegistry}
-                  disabled={!methods.formState.isValid}
-                >
-                  Save
-                </Button>
-              </div>
-            </form>
-          </FormProvider>
+    <FormProvider {...methods}>
+      <form className="flex flex-col" onSubmit={onSubmit}>
+        <ContainerRegistryForm fromEditClusterSettings cluster={cluster} />
+        {(methods.formState.dirtyFields.kind || methods.formState.dirtyFields.url) && (
+          <Callout.Root className="mt-4" color="yellow">
+            <Callout.Icon>
+              <Icon iconName="triangle-exclamation" iconStyle="regular" />
+            </Callout.Icon>
+            <Callout.Text>
+              You will have to delete any image stored in the previous container registry manually
+            </Callout.Text>
+          </Callout.Root>
+        )}
+        <div className="mt-2 flex justify-end">
+          <Button
+            type="submit"
+            size="lg"
+            loading={isLoadingEditContainerRegistry}
+            disabled={!methods.formState.isValid}
+          >
+            Save
+          </Button>
         </div>
-      </Section>
-    </div>
+      </form>
+    </FormProvider>
   )
 }

--- a/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
@@ -450,7 +450,7 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
         <div className="mt-2 flex flex-col gap-5">
           {isLoading ? (
             <div className="flex justify-center">
-              <LoaderSpinner className="w-6" />
+              <LoaderSpinner className="w-4" />
             </div>
           ) : (
             <>

--- a/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
@@ -450,7 +450,7 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
         <div className="mt-2 flex flex-col gap-5">
           {isLoading ? (
             <div className="flex justify-center">
-              <LoaderSpinner className="w-4" />
+              <LoaderSpinner className="w-6" />
             </div>
           ) : (
             <>


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: The data of the cluster's "mirroring registry" settings section was not loading at all.
[Slack thread](https://qovery.slack.com/archives/C0AML0VDUV8/p1776869545153269) for reference.

## Screenshots / Recordings


| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="3164" height="2070" alt="image (21)" src="https://github.com/user-attachments/assets/1221a4b0-e5b1-4072-b690-ee89422a18c3" /> | <img width="2672" height="1522" alt="Screenshot 2026-04-23 at 10 30 23" src="https://github.com/user-attachments/assets/eb38ddc9-6b4b-4ced-ac54-be8dcf7d98b6" /> |
