### PR TITLE
fix(ui): components design update

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-card/__snapshots__/cluster-card.spec.tsx.snap
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/__snapshots__/cluster-card.spec.tsx.snap
@@ -85,7 +85,7 @@ exports[`ClusterCard should match snapshot 1`] = `
       class="mt-5 flex flex-wrap gap-2"
     >
       <span
-        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md"
+        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded"
         data-accent-color="neutral"
       >
         <svg
@@ -105,19 +105,19 @@ exports[`ClusterCard should match snapshot 1`] = `
         Qovery managed
       </span>
       <span
-        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md bg-surface-neutral-subtle"
+        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded bg-surface-neutral-subtle"
         data-accent-color="neutral"
       >
         EKS
       </span>
       <span
-        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md bg-surface-neutral-subtle"
+        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded bg-surface-neutral-subtle"
         data-accent-color="neutral"
       >
         us-east-1
       </span>
       <span
-        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md bg-surface-neutral-subtle"
+        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded bg-surface-neutral-subtle"
         data-accent-color="neutral"
       >
         1.21
@@ -190,7 +190,7 @@ exports[`ClusterCard should match snapshot 1`] = `
         </div>
       </div>
       <span
-        class="inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-negative-subtle border rounded-md bg-surface-negative-subtle text-negative"
+        class="inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-negative-subtle border rounded bg-surface-negative-subtle text-negative"
         data-accent-color="red"
       >
         Production

--- a/libs/domains/clusters/feature/src/lib/cluster-delete-modal/__snapshots__/cluster-delete-modal.spec.tsx.snap
+++ b/libs/domains/clusters/feature/src/lib/cluster-delete-modal/__snapshots__/cluster-delete-modal.spec.tsx.snap
@@ -51,11 +51,11 @@ exports[`ClusterDeleteModal should match snapshot 1`] = `
             class="mb-3"
           >
             <div
-              class="input input--select"
+              class="input input--select input--label-up"
               data-testid="select"
             >
               <label
-                class="!translate-y-0 !text-xs"
+                class="input__label translate-y-[7px] text-sm"
                 for="Delete mode"
               >
                 Delete mode

--- a/libs/domains/clusters/feature/src/lib/cluster-type/__snapshots__/cluster-type.spec.tsx.snap
+++ b/libs/domains/clusters/feature/src/lib/cluster-type/__snapshots__/cluster-type.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`ClusterType should render as AKS 1`] = `
 <body>
   <div>
     <span
-      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md bg-surface-neutral-subtle"
+      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded bg-surface-neutral-subtle"
       data-accent-color="neutral"
     >
       Self-managed
@@ -17,7 +17,7 @@ exports[`ClusterType should render as EKS 1`] = `
 <body>
   <div>
     <span
-      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md bg-surface-neutral-subtle"
+      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded bg-surface-neutral-subtle"
       data-accent-color="neutral"
     >
       EKS (Karpenter)
@@ -30,7 +30,7 @@ exports[`ClusterType should render as GCP 1`] = `
 <body>
   <div>
     <span
-      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md bg-surface-neutral-subtle"
+      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded bg-surface-neutral-subtle"
       data-accent-color="neutral"
     >
       GKE (Autopilot)
@@ -43,7 +43,7 @@ exports[`ClusterType should render as SCW 1`] = `
 <body>
   <div>
     <span
-      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md bg-surface-neutral-subtle"
+      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded bg-surface-neutral-subtle"
       data-accent-color="neutral"
     >
       Kapsule

--- a/libs/domains/environments/feature/src/lib/create-clone-environment-modal/__snapshots__/create-clone-environment-modal.spec.tsx.snap
+++ b/libs/domains/environments/feature/src/lib/create-clone-environment-modal/__snapshots__/create-clone-environment-modal.spec.tsx.snap
@@ -74,7 +74,7 @@ exports[`CreateCloneEnvironmentModal should match snapshots 1`] = `
             data-testid="input-select-cluster"
           >
             <label
-              class="top-1.5 translate-y-2 text-sm"
+              class="input__label translate-y-[7px] text-sm"
               for="Cluster"
             >
               Cluster
@@ -168,7 +168,7 @@ exports[`CreateCloneEnvironmentModal should match snapshots 1`] = `
           class="mb-3"
         >
           <div
-            class="input input--select input--has-icon"
+            class="input input--select input--has-icon input--label-up"
             data-testid="input-select-mode"
           >
             <div
@@ -183,7 +183,7 @@ exports[`CreateCloneEnvironmentModal should match snapshots 1`] = `
               </span>
             </div>
             <label
-              class="!translate-y-0 !text-xs ml-8"
+              class="input__label translate-y-[7px] text-sm ml-8"
               for="Type"
             >
               Type

--- a/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.spec.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.spec.tsx
@@ -124,7 +124,11 @@ describe('EnvironmentLastDeploymentSection', () => {
 
     renderWithProviders(<EnvironmentLastDeploymentSection />)
 
+    const emptyState = screen.getByText('No deployment recorded yet').closest('.rounded-lg')
+
     expect(screen.getByText('No deployment recorded yet')).toBeInTheDocument()
+    expect(emptyState).toHaveClass('px-4', 'py-4')
+    expect(emptyState).not.toHaveClass('h-56')
     expect(screen.getByRole('button', { name: /deploy environment/i })).toBeInTheDocument()
   })
 

--- a/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.tsx
@@ -200,7 +200,7 @@ const EnvironmentLastDeploymentContent = () => {
         </div>
       ) : (
         <EmptyState
-          size="small"
+          size="sm"
           icon="rocket"
           title="No deployment recorded yet"
           description="Create and deploy your first service"

--- a/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-last-deployment-section/environment-last-deployment-section.tsx
@@ -200,10 +200,10 @@ const EnvironmentLastDeploymentContent = () => {
         </div>
       ) : (
         <EmptyState
+          size="small"
           icon="rocket"
           title="No deployment recorded yet"
           description="Create and deploy your first service"
-          className="h-auto p-8"
         >
           {serviceCount > 0 && (
             <Button onClick={handleDeploy} color="neutral" size="md" className="gap-1.5">

--- a/libs/domains/environments/feature/src/lib/environment-mode/__snapshots__/environment-mode.spec.tsx.snap
+++ b/libs/domains/environments/feature/src/lib/environment-mode/__snapshots__/environment-mode.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`EnvironmentMode should render as development mode 1`] = `
 <body>
   <div>
     <span
-      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md"
+      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded"
       data-accent-color="neutral"
     >
       Development
@@ -17,7 +17,7 @@ exports[`EnvironmentMode should render as preview mode 1`] = `
 <body>
   <div>
     <span
-      class="inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-accent1-subtle border rounded-md text-accent1"
+      class="inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-accent1-subtle border rounded text-accent1"
       data-accent-color="purple"
     >
       Ephemeral
@@ -30,7 +30,7 @@ exports[`EnvironmentMode should render as production mode 1`] = `
 <body>
   <div>
     <span
-      class="inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-negative-subtle border rounded-md text-negative"
+      class="inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-negative-subtle border rounded text-negative"
       data-accent-color="red"
     >
       Production
@@ -43,7 +43,7 @@ exports[`EnvironmentMode should render as staging mode 1`] = `
 <body>
   <div>
     <span
-      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md"
+      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded"
       data-accent-color="neutral"
     >
       Staging

--- a/libs/domains/observability/feature/src/lib/service/service-dashboard/service-dashboard.tsx
+++ b/libs/domains/observability/feature/src/lib/service/service-dashboard/service-dashboard.tsx
@@ -309,7 +309,7 @@ function ServiceDashboardContent({ environmentId, serviceId }: { environmentId: 
               >
                 <Badge
                   variant="surface"
-                  color={resourcesMode === 'aggregate' ? 'sky' : 'purple'}
+                  color={resourcesMode === 'aggregate' ? 'sky' : 'neutral'}
                   radius="full"
                   size="sm"
                   className="h-6 gap-1 text-ssm"

--- a/libs/domains/organizations/feature/src/lib/annotation-create-edit-modal/__snapshots__/annotation-create-edit-modal.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/annotation-create-edit-modal/__snapshots__/annotation-create-edit-modal.spec.tsx.snap
@@ -34,7 +34,7 @@ exports[`AnnotationCreateEditModal should match with snatpshot 1`] = `
                 class=""
               >
                 <label
-                  class="input__label translate-y-2 text-sm"
+                  class="input__label translate-y-[7px] text-sm"
                   for="Group name"
                 >
                   Group name

--- a/libs/domains/organizations/feature/src/lib/annotation-setting/__snapshots__/annotation-setting.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/annotation-setting/__snapshots__/annotation-setting.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`AnnotationSetting should match snapshot 1`] = `
         data-testid="select"
       >
         <label
-          class="top-1.5 translate-y-2 text-sm"
+          class="input__label translate-y-[7px] text-sm"
           for="Annotation Groups (optional)"
         >
           Annotation Groups (optional)

--- a/libs/domains/organizations/feature/src/lib/annotation-setting/annotation-setting.tsx
+++ b/libs/domains/organizations/feature/src/lib/annotation-setting/annotation-setting.tsx
@@ -19,7 +19,7 @@ export function AnnotationSetting() {
           label="Annotation Groups (optional)"
           options={annotationsGroups.map((group) => ({
             label: (
-              <span className="flex items-center gap-3">
+              <span className="flex items-center gap-1">
                 <span>{group.name}</span>
                 <Tooltip
                   classNameContent="z-10"
@@ -34,7 +34,7 @@ export function AnnotationSetting() {
                   }
                 >
                   <span>
-                    <Icon iconName="circle-info" iconStyle="regular" className="text-base" />
+                    <Icon iconName="circle-info" iconStyle="regular" className="text-neutral-subtl text-sm" />
                   </span>
                 </Tooltip>
               </span>

--- a/libs/domains/organizations/feature/src/lib/git-branch-settings/__snapshots__/git-branch-settings.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/git-branch-settings/__snapshots__/git-branch-settings.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`GitBranchSettings should match snapshot 1`] = `
         data-testid="select"
       >
         <label
-          class="top-1.5 translate-y-2 text-sm"
+          class="input__label translate-y-[7px] text-sm"
           for="Branch"
         >
           Branch
@@ -125,7 +125,7 @@ exports[`GitBranchSettings should match snapshot 1`] = `
             class=""
           >
             <label
-              class="input__label translate-y-2 text-sm !transition-none"
+              class="input__label translate-y-[7px] text-sm !transition-none"
               for="Application root folder path"
             >
               Application root folder path

--- a/libs/domains/organizations/feature/src/lib/git-provider-setting/__snapshots__/git-provider-setting.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/git-provider-setting/__snapshots__/git-provider-setting.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`GitProviderSetting should match snapshot 1`] = `
         data-testid="select"
       >
         <label
-          class="top-1.5 translate-y-2 text-sm"
+          class="input__label translate-y-[7px] text-sm"
           for="Git account"
         >
           Git account

--- a/libs/domains/organizations/feature/src/lib/git-public-repository-settings/__snapshots__/git-public-repository-settings.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/git-public-repository-settings/__snapshots__/git-public-repository-settings.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`GitPublicRepositorySettings should match snapshot 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm"
+                class="input__label translate-y-[7px] text-sm"
                 for="Public repository URL (.git)"
               >
                 Public repository URL (.git)
@@ -65,7 +65,7 @@ exports[`GitPublicRepositorySettings should match snapshot 1`] = `
             class=""
           >
             <label
-              class="input__label translate-y-2 text-sm"
+              class="input__label translate-y-[7px] text-sm"
               for="Branch"
             >
               Branch
@@ -99,7 +99,7 @@ exports[`GitPublicRepositorySettings should match snapshot 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="Root service path"
               >
                 Root service path

--- a/libs/domains/organizations/feature/src/lib/git-repository-setting/__snapshots__/git-repository-setting.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/git-repository-setting/__snapshots__/git-repository-setting.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`GitRepositorySetting should match snapshot 1`] = `
           data-testid="select"
         >
           <label
-            class="top-1.5 translate-y-2 text-sm"
+            class="input__label translate-y-[7px] text-sm"
             for="Repository"
           >
             Repository

--- a/libs/domains/organizations/feature/src/lib/label-create-edit-modal/__snapshots__/label-create-edit-modal.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/label-create-edit-modal/__snapshots__/label-create-edit-modal.spec.tsx.snap
@@ -34,7 +34,7 @@ exports[`LabelCreateEditModal should match with snatpshot 1`] = `
                 class=""
               >
                 <label
-                  class="input__label translate-y-2 text-sm"
+                  class="input__label translate-y-[7px] text-sm"
                   for="Group name"
                 >
                   Group name

--- a/libs/domains/organizations/feature/src/lib/label-setting/__snapshots__/label-setting.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/label-setting/__snapshots__/label-setting.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`LabelSetting should match snapshot 1`] = `
         data-testid="select"
       >
         <label
-          class="top-1.5 translate-y-2 text-sm"
+          class="input__label translate-y-[7px] text-sm"
           for="Label Groups (optional)"
         >
           Label Groups (optional)

--- a/libs/domains/organizations/feature/src/lib/label-setting/label-setting.tsx
+++ b/libs/domains/organizations/feature/src/lib/label-setting/label-setting.tsx
@@ -31,7 +31,7 @@ export function LabelSetting({ filterPropagateToCloudProvider = false }: LabelSe
           label="Label Groups (optional)"
           options={filteredLabelsGroups.map((group) => ({
             label: (
-              <span className="flex items-center gap-3">
+              <span className="flex items-center gap-1">
                 <span>{group.name}</span>
                 <Tooltip
                   classNameContent="z-10"
@@ -46,7 +46,7 @@ export function LabelSetting({ filterPropagateToCloudProvider = false }: LabelSe
                   }
                 >
                   <span>
-                    <Icon iconName="circle-info" iconStyle="regular" className="text-base" />
+                    <Icon iconName="circle-info" iconStyle="regular" className="text-sm text-neutral-subtle" />
                   </span>
                 </Tooltip>
               </span>

--- a/libs/domains/service-helm/feature/src/lib/deployment-setting/__snapshots__/deployment-setting.spec.tsx.snap
+++ b/libs/domains/service-helm/feature/src/lib/deployment-setting/__snapshots__/deployment-setting.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`DeploymentSetting should match snapshot 1`] = `
                 class=""
               >
                 <label
-                  class="input__label translate-y-2 text-sm !transition-none"
+                  class="input__label translate-y-[7px] text-sm !transition-none"
                   for="Helm arguments"
                 >
                   Helm arguments
@@ -74,7 +74,7 @@ exports[`DeploymentSetting should match snapshot 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="Helm timeout"
               >
                 Helm timeout

--- a/libs/domains/service-helm/feature/src/lib/networking-port-setting-modal/__snapshots__/networking-port-setting-modal.spec.tsx.snap
+++ b/libs/domains/service-helm/feature/src/lib/networking-port-setting-modal/__snapshots__/networking-port-setting-modal.spec.tsx.snap
@@ -46,7 +46,7 @@ exports[`NetworkingPortSettingModal should match snapshot in create state 1`] = 
                   class=""
                 >
                   <label
-                    class="input__label translate-y-2 text-sm"
+                    class="input__label translate-y-[7px] text-sm"
                     for="Service name"
                   >
                     Service name
@@ -68,11 +68,11 @@ exports[`NetworkingPortSettingModal should match snapshot in create state 1`] = 
             class=""
           >
             <div
-              class="input input--select"
+              class="input input--select input--label-up"
               data-testid="select"
             >
               <label
-                class="!translate-y-0 !text-xs"
+                class="input__label translate-y-[7px] text-sm"
                 for="Select protocol"
               >
                 Select protocol
@@ -175,7 +175,7 @@ exports[`NetworkingPortSettingModal should match snapshot in create state 1`] = 
                   class="pointer-events-none"
                 >
                   <label
-                    class="input__label translate-y-2 text-sm !transition-none"
+                    class="input__label translate-y-[7px] text-sm !transition-none"
                     for="External port"
                   >
                     External port
@@ -209,7 +209,7 @@ exports[`NetworkingPortSettingModal should match snapshot in create state 1`] = 
                   class=""
                 >
                   <label
-                    class="input__label translate-y-2 text-sm"
+                    class="input__label translate-y-[7px] text-sm"
                     for="Namespace (optional)"
                   >
                     Namespace (optional)
@@ -243,7 +243,7 @@ exports[`NetworkingPortSettingModal should match snapshot in create state 1`] = 
                     class=""
                   >
                     <label
-                      class="input__label translate-y-2 text-sm"
+                      class="input__label translate-y-[7px] text-sm"
                       for="Port name"
                     >
                       Port name
@@ -340,7 +340,7 @@ exports[`NetworkingPortSettingModal should match snapshot in edit state 1`] = `
                   class=""
                 >
                   <label
-                    class="input__label translate-y-2 text-sm !transition-none"
+                    class="input__label translate-y-[7px] text-sm !transition-none"
                     for="Service name"
                   >
                     Service name
@@ -373,7 +373,7 @@ exports[`NetworkingPortSettingModal should match snapshot in edit state 1`] = `
                   class=""
                 >
                   <label
-                    class="input__label translate-y-2 text-sm !transition-none"
+                    class="input__label translate-y-[7px] text-sm !transition-none"
                     for="Service port"
                   >
                     Service port
@@ -395,11 +395,11 @@ exports[`NetworkingPortSettingModal should match snapshot in edit state 1`] = `
             class=""
           >
             <div
-              class="input input--select"
+              class="input input--select input--label-up"
               data-testid="select"
             >
               <label
-                class="!translate-y-0 !text-xs"
+                class="input__label translate-y-[7px] text-sm"
                 for="Select protocol"
               >
                 Select protocol
@@ -502,7 +502,7 @@ exports[`NetworkingPortSettingModal should match snapshot in edit state 1`] = `
                   class="pointer-events-none"
                 >
                   <label
-                    class="input__label translate-y-2 text-sm !transition-none"
+                    class="input__label translate-y-[7px] text-sm !transition-none"
                     for="External port"
                   >
                     External port
@@ -536,7 +536,7 @@ exports[`NetworkingPortSettingModal should match snapshot in edit state 1`] = `
                   class=""
                 >
                   <label
-                    class="input__label translate-y-2 text-sm !transition-none"
+                    class="input__label translate-y-[7px] text-sm !transition-none"
                     for="Namespace (optional)"
                   >
                     Namespace (optional)
@@ -570,7 +570,7 @@ exports[`NetworkingPortSettingModal should match snapshot in edit state 1`] = `
                     class=""
                   >
                     <label
-                      class="input__label translate-y-2 text-sm !transition-none"
+                      class="input__label translate-y-[7px] text-sm !transition-none"
                       for="Port name"
                     >
                       Port name

--- a/libs/domains/service-helm/feature/src/lib/source-setting/__snapshots__/source-setting.spec.tsx.snap
+++ b/libs/domains/service-helm/feature/src/lib/source-setting/__snapshots__/source-setting.spec.tsx.snap
@@ -10,11 +10,11 @@ exports[`SourceSetting should match snapshot 1`] = `
         class=""
       >
         <div
-          class="input input--select"
+          class="input input--select input--label-up"
           data-testid="select"
         >
           <label
-            class="!translate-y-0 !text-xs"
+            class="input__label translate-y-[7px] text-sm"
             for="Helm source"
           >
             Helm source
@@ -109,11 +109,11 @@ exports[`SourceSetting should match snapshot 1`] = `
           class=""
         >
           <div
-            class="input input--select"
+            class="input input--select input--label-up"
             data-testid="select"
           >
             <label
-              class="!translate-y-0 !text-xs"
+              class="input__label translate-y-[7px] text-sm"
               for="Repository"
             >
               Repository
@@ -218,7 +218,7 @@ exports[`SourceSetting should match snapshot 1`] = `
             data-testid="select"
           >
             <label
-              class="top-1.5 translate-y-2 text-sm"
+              class="input__label translate-y-[7px] text-sm"
               for="Chart name"
             >
               Chart name
@@ -330,11 +330,11 @@ exports[`SourceSetting should match snapshot helm chart settings with HTTPS kind
       class=""
     >
       <div
-        class="input input--select"
+        class="input input--select input--label-up"
         data-testid="select"
       >
         <label
-          class="!translate-y-0 !text-xs"
+          class="input__label translate-y-[7px] text-sm"
           for="Chart name"
         >
           Chart name
@@ -435,11 +435,11 @@ exports[`SourceSetting should match snapshot helm chart settings with HTTPS kind
       class=""
     >
       <div
-        class="input input--select"
+        class="input input--select input--label-up"
         data-testid="select"
       >
         <label
-          class="!translate-y-0 !text-xs"
+          class="input__label translate-y-[7px] text-sm"
           for="Version"
         >
           Version
@@ -558,7 +558,7 @@ exports[`SourceSetting should match snapshot helm chart settings with OCI kind 1
             class=""
           >
             <label
-              class="input__label translate-y-2 text-sm !transition-none"
+              class="input__label translate-y-[7px] text-sm !transition-none"
               for="Chart name"
             >
               Chart name
@@ -591,7 +591,7 @@ exports[`SourceSetting should match snapshot helm chart settings with OCI kind 1
             class=""
           >
             <label
-              class="input__label translate-y-2 text-sm !transition-none"
+              class="input__label translate-y-[7px] text-sm !transition-none"
               for="Version"
             >
               Version

--- a/libs/domains/service-helm/feature/src/lib/values-override-files-setting/__snapshots__/values-override-files-setting.spec.tsx.snap
+++ b/libs/domains/service-helm/feature/src/lib/values-override-files-setting/__snapshots__/values-override-files-setting.spec.tsx.snap
@@ -42,11 +42,11 @@ exports[`ValuesOverrideFilesSetting should match snapshot with GIT_REPOSITORY ty
             class=""
           >
             <div
-              class="input input--select"
+              class="input input--select input--label-up"
               data-testid="select"
             >
               <label
-                class="!translate-y-0 !text-xs"
+                class="input__label translate-y-[7px] text-sm"
                 for="File source"
               >
                 File source
@@ -204,11 +204,11 @@ exports[`ValuesOverrideFilesSetting should match snapshot with NONE type 1`] = `
             class=""
           >
             <div
-              class="input input--select"
+              class="input input--select input--label-up"
               data-testid="select"
             >
               <label
-                class="!translate-y-0 !text-xs"
+                class="input__label translate-y-[7px] text-sm"
                 for="File source"
               >
                 File source
@@ -345,11 +345,11 @@ exports[`ValuesOverrideFilesSetting should match snapshot with YAML type 1`] = `
             class=""
           >
             <div
-              class="input input--select"
+              class="input input--select input--label-up"
               data-testid="select"
             >
               <label
-                class="!translate-y-0 !text-xs"
+                class="input__label translate-y-[7px] text-sm"
                 for="File source"
               >
                 File source

--- a/libs/domains/service-job/feature/src/lib/dockerfile-settings/__snapshots__/dockerfile-settings.spec.tsx.snap
+++ b/libs/domains/service-job/feature/src/lib/dockerfile-settings/__snapshots__/dockerfile-settings.spec.tsx.snap
@@ -10,11 +10,11 @@ exports[`DockerfileSettings should match snapshot with children 1`] = `
         class=""
       >
         <div
-          class="input input--select"
+          class="input input--select input--label-up"
           data-testid="select"
         >
           <label
-            class="!translate-y-0 !text-xs"
+            class="input__label translate-y-[7px] text-sm"
             for="File source"
           >
             File source
@@ -132,7 +132,7 @@ exports[`DockerfileSettings should match snapshot with children 1`] = `
                 class=""
               >
                 <label
-                  class="input__label translate-y-2 text-sm !transition-none"
+                  class="input__label translate-y-[7px] text-sm !transition-none"
                   for="Dockerfile path"
                 >
                   Dockerfile path
@@ -185,7 +185,7 @@ exports[`DockerfileSettings should match snapshot with children 1`] = `
                 class=""
               >
                 <label
-                  class="input__label translate-y-2 text-sm"
+                  class="input__label translate-y-[7px] text-sm"
                   for="Dockerfile stage (optional)"
                 >
                   Dockerfile stage (optional)
@@ -229,11 +229,11 @@ exports[`DockerfileSettings should match snapshot without children 1`] = `
         class=""
       >
         <div
-          class="input input--select"
+          class="input input--select input--label-up"
           data-testid="select"
         >
           <label
-            class="!translate-y-0 !text-xs"
+            class="input__label translate-y-[7px] text-sm"
             for="File source"
           >
             File source
@@ -351,7 +351,7 @@ exports[`DockerfileSettings should match snapshot without children 1`] = `
                 class=""
               >
                 <label
-                  class="input__label translate-y-2 text-sm !transition-none"
+                  class="input__label translate-y-[7px] text-sm !transition-none"
                   for="Dockerfile path"
                 >
                   Dockerfile path
@@ -404,7 +404,7 @@ exports[`DockerfileSettings should match snapshot without children 1`] = `
                 class=""
               >
                 <label
-                  class="input__label translate-y-2 text-sm"
+                  class="input__label translate-y-[7px] text-sm"
                   for="Dockerfile stage (optional)"
                 >
                   Dockerfile stage (optional)

--- a/libs/domains/services/feature/src/lib/general-setting/__snapshots__/general-setting.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/general-setting/__snapshots__/general-setting.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`GeneralSetting should match snapshot 1`] = `
                 class=""
               >
                 <label
-                  class="input__label translate-y-2 text-sm"
+                  class="input__label translate-y-[7px] text-sm"
                   for="Name"
                 >
                   Name

--- a/libs/domains/services/feature/src/lib/last-version/__snapshots__/last-version.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/last-version/__snapshots__/last-version.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`LastVersion should match snapshot 1`] = `
       class="flex"
     >
       <span
-        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md min-w-7 max-w-[81px] rounded-r-none border-r-0 bg-surface-neutral"
+        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded min-w-7 max-w-[81px] rounded-r-none border-r-0 bg-surface-neutral"
       >
         <span
           class="flex h-full w-full items-center justify-center truncate"

--- a/libs/domains/services/feature/src/lib/select-version-modal/__snapshots__/select-version-modal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/select-version-modal/__snapshots__/select-version-modal.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`SelectVersionModal should match snapshot 1`] = `
         data-testid="select"
       >
         <label
-          class="top-1.5 translate-y-2 text-sm"
+          class="input__label translate-y-[7px] text-sm"
           for="Version"
         >
           Version
@@ -175,11 +175,11 @@ exports[`SelectVersionModal should match snapshot with helm version 1`] = `
       class=""
     >
       <div
-        class="input input--select"
+        class="input input--select input--label-up"
         data-testid="select"
       >
         <label
-          class="!translate-y-0 !text-xs"
+          class="input__label translate-y-[7px] text-sm"
           for="Version"
         >
           Version

--- a/libs/domains/services/feature/src/lib/service-clone-modal/__snapshots__/service-clone-modal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-clone-modal/__snapshots__/service-clone-modal.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`ServiceCloneModal should match snapshot 1`] = `
               class="pointer-events-none"
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="Service to clone"
               >
                 Service to clone
@@ -81,7 +81,7 @@ exports[`ServiceCloneModal should match snapshot 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="New service name"
               >
                 New service name
@@ -107,7 +107,7 @@ exports[`ServiceCloneModal should match snapshot 1`] = `
           data-testid="select"
         >
           <label
-            class="top-1.5 translate-y-2 text-sm"
+            class="input__label translate-y-[7px] text-sm"
             for="Project"
           >
             Project
@@ -214,7 +214,7 @@ exports[`ServiceCloneModal should match snapshot 1`] = `
           data-testid="select"
         >
           <label
-            class="top-1.5 translate-y-2 text-sm"
+            class="input__label translate-y-[7px] text-sm"
             for="Environment"
           >
             Environment

--- a/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`ServiceList should match snapshot 1`] = `
 <div>
   <div>
     <div
-      class="flex gap-2 bg-surface-neutral px-4 py-2"
+      class="flex gap-1.5 bg-surface-neutral px-4 py-3"
     >
       <div
         aria-busy="true"
@@ -801,7 +801,7 @@ exports[`ServiceList should match snapshot 1`] = `
                       class="flex"
                     >
                       <span
-                        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md min-w-7 max-w-[81px] rounded-r-none border-r-0 bg-surface-neutral"
+                        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded min-w-7 max-w-[81px] rounded-r-none border-r-0 bg-surface-neutral"
                       >
                         <span
                           class="flex h-full w-full items-center justify-center truncate"

--- a/libs/domains/services/feature/src/lib/service-list/service-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list.tsx
@@ -322,8 +322,10 @@ export function ServiceList({ className, containerClassName, environment, ...pro
         <Badge
           key={value}
           variant="surface"
+          radius="full"
           color={match(value)
             .with('RUNNING', () => 'green' as const)
+            .with('WARNING', () => 'yellow' as const)
             .with('ERROR', () => 'red' as const)
             .otherwise(() => 'neutral' as const)}
           className="text-ssm font-medium"
@@ -339,7 +341,7 @@ export function ServiceList({ className, containerClassName, environment, ...pro
       <EmptyState
         title="No service found"
         description="You can create a service from the button on the top"
-        className="border-none"
+        className="border-none bg-surface-neutral"
         icon="wave-pulse"
       >
         <Link
@@ -366,7 +368,7 @@ export function ServiceList({ className, containerClassName, environment, ...pro
 
   return (
     <div>
-      <div className="flex gap-2 bg-surface-neutral px-4 py-2">
+      <div className="flex gap-1.5 bg-surface-neutral px-4 py-3">
         <ServicesBadges />
       </div>
       <div className="flex grow flex-col justify-between">

--- a/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.spec.tsx
@@ -92,8 +92,12 @@ describe('ServiceLastDeployment', () => {
 
     renderWithProviders(<ServiceLastDeployment serviceId="service-123" serviceType="APPLICATION" />)
 
+    const emptyState = screen.getByText('Service has never been deployed').closest('.rounded-lg')
+
     expect(screen.getByText('Service has never been deployed')).toBeInTheDocument()
     expect(screen.getByText('Deploy the service first')).toBeInTheDocument()
+    expect(emptyState).toHaveClass('px-4', 'py-4')
+    expect(emptyState).not.toHaveClass('h-56')
     expect(screen.getByRole('button', { name: /deploy now/i })).toBeInTheDocument()
   })
 

--- a/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.tsx
+++ b/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.tsx
@@ -99,7 +99,7 @@ function ServiceLastDeploymentContent({ serviceId, serviceType, service }: Servi
   if (!lastDeployment) {
     return (
       <EmptyState
-        size="small"
+        size="sm"
         icon="play"
         iconStyle="solid"
         title={`${upperCaseFirstLetter(service?.service_type ?? 'Service')} has never been deployed`}

--- a/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.tsx
+++ b/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.tsx
@@ -99,6 +99,7 @@ function ServiceLastDeploymentContent({ serviceId, serviceType, service }: Servi
   if (!lastDeployment) {
     return (
       <EmptyState
+        size="small"
         icon="play"
         iconStyle="solid"
         title={`${upperCaseFirstLetter(service?.service_type ?? 'Service')} has never been deployed`}

--- a/libs/domains/services/feature/src/lib/timezone-setting/__snapshots__/timezone-setting.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/timezone-setting/__snapshots__/timezone-setting.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`TimezoneSetting should match snapshot 1`] = `
           data-testid="select"
         >
           <label
-            class="top-1.5 translate-y-2 text-sm"
+            class="input__label translate-y-[7px] text-sm"
             for="Timezone"
           >
             Timezone

--- a/libs/pages/cluster/src/lib/ui/page-settings-network/gcp-existing-vpc/__snapshots__/gcp-existing-vpc.spec.tsx.snap
+++ b/libs/pages/cluster/src/lib/ui/page-settings-network/gcp-existing-vpc/__snapshots__/gcp-existing-vpc.spec.tsx.snap
@@ -40,7 +40,7 @@ exports[`GcpExistingVPC should match snapshots 1`] = `
               class="pointer-events-none"
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="VPC Name"
               >
                 VPC Name
@@ -74,7 +74,7 @@ exports[`GcpExistingVPC should match snapshots 1`] = `
               class="pointer-events-none"
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="External project id"
               >
                 External project id
@@ -108,7 +108,7 @@ exports[`GcpExistingVPC should match snapshots 1`] = `
               class="pointer-events-none"
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="Subnetwork range name"
               >
                 Subnetwork range name
@@ -142,7 +142,7 @@ exports[`GcpExistingVPC should match snapshots 1`] = `
               class="pointer-events-none"
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="Pod IPv4 address range name"
               >
                 Pod IPv4 address range name
@@ -176,7 +176,7 @@ exports[`GcpExistingVPC should match snapshots 1`] = `
               class="pointer-events-none"
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="Additional cluster Pod IPv4 ranges names"
               >
                 Additional cluster Pod IPv4 ranges names
@@ -210,7 +210,7 @@ exports[`GcpExistingVPC should match snapshots 1`] = `
               class="pointer-events-none"
             >
               <label
-                class="input__label translate-y-2 text-sm !transition-none"
+                class="input__label translate-y-[7px] text-sm !transition-none"
                 for="IPv4 service range name"
               >
                 IPv4 service range name

--- a/libs/pages/clusters/src/lib/ui/page-clusters-create/step-features/gcp-vpc-feature/__snapshots__/gcp-vpc-feature.spec.tsx.snap
+++ b/libs/pages/clusters/src/lib/ui/page-clusters-create/step-features/gcp-vpc-feature/__snapshots__/gcp-vpc-feature.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`ButtonPopoverSubnets should match snapshots 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm"
+                class="input__label translate-y-[7px] text-sm"
                 for="VPC Name"
               >
                 VPC Name
@@ -77,7 +77,7 @@ exports[`ButtonPopoverSubnets should match snapshots 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm"
+                class="input__label translate-y-[7px] text-sm"
                 for="External project id (optional)"
               >
                 External project id (optional)
@@ -123,7 +123,7 @@ exports[`ButtonPopoverSubnets should match snapshots 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm"
+                class="input__label translate-y-[7px] text-sm"
                 for="Subnetwork range name (optional)"
               >
                 Subnetwork range name (optional)
@@ -156,7 +156,7 @@ exports[`ButtonPopoverSubnets should match snapshots 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm"
+                class="input__label translate-y-[7px] text-sm"
                 for="Pod IPv4 address range name (optional)"
               >
                 Pod IPv4 address range name (optional)
@@ -189,7 +189,7 @@ exports[`ButtonPopoverSubnets should match snapshots 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm"
+                class="input__label translate-y-[7px] text-sm"
                 for="Additional cluster Pod IPv4 ranges names (separated with a comma) (optional)"
               >
                 Additional cluster Pod IPv4 ranges names (separated with a comma) (optional)
@@ -222,7 +222,7 @@ exports[`ButtonPopoverSubnets should match snapshots 1`] = `
               class=""
             >
               <label
-                class="input__label translate-y-2 text-sm"
+                class="input__label translate-y-[7px] text-sm"
                 for="IPv4 service range name (optional)"
               >
                 IPv4 service range name (optional)

--- a/libs/pages/services/src/lib/feature/page-helm-create-feature/step-values-override-files-feature/__snapshots__/step-values-override-files-feature.spec.tsx.snap
+++ b/libs/pages/services/src/lib/feature/page-helm-create-feature/step-values-override-files-feature/__snapshots__/step-values-override-files-feature.spec.tsx.snap
@@ -54,11 +54,11 @@ exports[`StepValuesOverrideFilesFeature should submit a form with a git reposito
                   class=""
                 >
                   <div
-                    class="input input--select"
+                    class="input input--select input--label-up"
                     data-testid="select"
                   >
                     <label
-                      class="!translate-y-0 !text-xs"
+                      class="input__label translate-y-[7px] text-sm"
                       for="File source"
                     >
                       File source
@@ -188,7 +188,7 @@ exports[`StepValuesOverrideFilesFeature should submit a form with a git reposito
                             class=""
                           >
                             <label
-                              class="input__label translate-y-2 text-sm"
+                              class="input__label translate-y-[7px] text-sm"
                               for="Overrides path"
                             >
                               Overrides path
@@ -213,7 +213,7 @@ exports[`StepValuesOverrideFilesFeature should submit a form with a git reposito
                     </p>
                   </div>
                   <div
-                    class="flex flex-row gap-x-4 p-4 border rounded text-sm items-center border-info-component bg-surface-info-subtle text-info mt-3"
+                    class="flex flex-row gap-x-4 p-4 border rounded-md text-sm items-center border-info-component bg-surface-info-subtle text-info mt-3"
                     data-accent-color="sky"
                   >
                     <div

--- a/libs/shared/ui/src/lib/components/badge/__snapshots__/badge.spec.tsx.snap
+++ b/libs/shared/ui/src/lib/components/badge/__snapshots__/badge.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Badge shoud match color snapshot 1`] = `
 <body>
   <div>
     <span
-      class="inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-positive-subtle border rounded-md text-positive"
+      class="inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-positive-subtle border rounded text-positive"
       data-accent-color="green"
     >
       Foobar
@@ -17,7 +17,7 @@ exports[`Badge shoud match size snapshot 1`] = `
 <body>
   <div>
     <span
-      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 border-neutral border rounded-md"
+      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 border-neutral border rounded"
     >
       Foobar
     </span>
@@ -29,7 +29,7 @@ exports[`Badge shoud match variant snapshot 1`] = `
 <body>
   <div>
     <span
-      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded-md bg-surface-neutral-subtle"
+      class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded bg-surface-neutral-subtle"
     >
       Foobar
     </span>

--- a/libs/shared/ui/src/lib/components/badge/badge.tsx
+++ b/libs/shared/ui/src/lib/components/badge/badge.tsx
@@ -22,7 +22,7 @@ const badgeVariants = cva(['text-neutral', 'inline-flex', 'items-center', 'shrin
       surface: ['border'],
     },
     radius: {
-      rounded: ['rounded-md'],
+      rounded: ['rounded'],
       full: ['rounded-full'],
     },
   },

--- a/libs/shared/ui/src/lib/components/code-editor/code-editor.scss
+++ b/libs/shared/ui/src/lib/components/code-editor/code-editor.scss
@@ -36,6 +36,10 @@
   color: var(--accent-11);
 }
 
+.monaco-editor .mtk8 {
+  color: var(--positive-11);
+}
+
 .monaco-editor .mtk5,
 .monaco-editor .mtk6,
 .monaco-editor .mtk1,

--- a/libs/shared/ui/src/lib/components/empty-state/empty-state.stories.tsx
+++ b/libs/shared/ui/src/lib/components/empty-state/empty-state.stories.tsx
@@ -14,3 +14,11 @@ Primary.args = {
   icon: 'folder-open',
   description: 'Need help? You may find these links useful',
 }
+
+export const Small = Template.bind({})
+Small.args = {
+  title: 'No deployment recorded yet',
+  icon: 'rocket',
+  description: 'Create and deploy your first service',
+  size: 'small',
+}

--- a/libs/shared/ui/src/lib/components/empty-state/empty-state.stories.tsx
+++ b/libs/shared/ui/src/lib/components/empty-state/empty-state.stories.tsx
@@ -20,5 +20,5 @@ Small.args = {
   title: 'No deployment recorded yet',
   icon: 'rocket',
   description: 'Create and deploy your first service',
-  size: 'small',
+  size: 'sm',
 }

--- a/libs/shared/ui/src/lib/components/empty-state/empty-state.tsx
+++ b/libs/shared/ui/src/lib/components/empty-state/empty-state.tsx
@@ -8,7 +8,7 @@ export interface EmptyStateProps extends PropsWithChildren {
   icon?: IconName | ReactNode
   iconStyle?: IconStyle
   description?: ReactNode
-  size?: 'default' | 'small'
+  size?: 'sm' | 'base'
   className?: string
 }
 
@@ -18,7 +18,7 @@ export function EmptyState({
   className,
   icon,
   iconStyle,
-  size = 'default',
+  size = 'base',
   children,
 }: EmptyStateProps) {
   const emptyStateIcon =
@@ -54,7 +54,7 @@ export function EmptyState({
       icon
     ))
 
-  if (size === 'small') {
+  if (size === 'sm') {
     return (
       <div
         className={twMerge(

--- a/libs/shared/ui/src/lib/components/empty-state/empty-state.tsx
+++ b/libs/shared/ui/src/lib/components/empty-state/empty-state.tsx
@@ -8,10 +8,72 @@ export interface EmptyStateProps extends PropsWithChildren {
   icon?: IconName | ReactNode
   iconStyle?: IconStyle
   description?: ReactNode
+  size?: 'default' | 'small'
   className?: string
 }
 
-export function EmptyState({ title, description, className, icon, iconStyle, children }: EmptyStateProps) {
+export function EmptyState({
+  title,
+  description,
+  className,
+  icon,
+  iconStyle,
+  size = 'default',
+  children,
+}: EmptyStateProps) {
+  const emptyStateIcon =
+    icon &&
+    (typeof icon === 'string' ? (
+      <span className="relative inline-flex h-10 min-h-10 w-10 min-w-10 items-center justify-center">
+        <Icon
+          iconName={icon as IconName}
+          iconStyle={iconStyle}
+          className="absolute top-2 text-base text-neutral-disabled"
+        />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="40"
+          height="40"
+          fill="none"
+          viewBox="0 0 40 40"
+          className="h-10 w-10"
+        >
+          <path
+            className="fill-surface-neutral-component"
+            fill="currentColor"
+            d="M0 6a6 6 0 0 1 6-6h28a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H6a6 6 0 0 1-6-6z"
+          ></path>
+          <path
+            className="text-neutral-disabled"
+            stroke="currentColor"
+            d="M.5 7V4.5a4 4 0 0 1 4-4H7M39.5 33v2.5a4 4 0 0 1-4 4H33M.5 33v2.5a4 4 0 0 0 4 4H7M39.5 7V4.5a4 4 0 0 0-4-4H33"
+          ></path>
+        </svg>
+      </span>
+    ) : (
+      icon
+    ))
+
+  if (size === 'small') {
+    return (
+      <div
+        className={twMerge(
+          'flex items-center justify-between gap-4 rounded-lg border border-neutral bg-surface-neutral-subtle px-4 py-4 text-sm text-neutral-subtle',
+          className
+        )}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-4">
+          {emptyStateIcon}
+          <div className="flex min-w-0 flex-col gap-0.5 text-left">
+            <p className="font-medium">{title}</p>
+            {description && <p className="max-w-[520px]">{description}</p>}
+          </div>
+        </div>
+        {children && <div className="shrink-0">{children}</div>}
+      </div>
+    )
+  }
+
   return (
     <div
       className={twMerge(
@@ -19,37 +81,7 @@ export function EmptyState({ title, description, className, icon, iconStyle, chi
         className
       )}
     >
-      {icon &&
-        (typeof icon === 'string' ? (
-          <span className="relative inline-flex h-10 min-h-10 w-10 min-w-10 items-center justify-center">
-            <Icon
-              iconName={icon as IconName}
-              iconStyle={iconStyle}
-              className="absolute top-2 text-base text-neutral-disabled"
-            />
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="40"
-              height="40"
-              fill="none"
-              viewBox="0 0 40 40"
-              className="h-10 w-10"
-            >
-              <path
-                className="fill-surface-neutral-component"
-                fill="currentColor"
-                d="M0 6a6 6 0 0 1 6-6h28a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H6a6 6 0 0 1-6-6z"
-              ></path>
-              <path
-                className="text-neutral-disabled"
-                stroke="currentColor"
-                d="M.5 7V4.5a4 4 0 0 1 4-4H7M39.5 33v2.5a4 4 0 0 1-4 4H33M.5 33v2.5a4 4 0 0 0 4 4H7M39.5 7V4.5a4 4 0 0 0-4-4H33"
-              ></path>
-            </svg>
-          </span>
-        ) : (
-          icon
-        ))}
+      {emptyStateIcon}
 
       <div className="flex flex-col gap-1">
         <p className="font-medium">{title}</p>

--- a/libs/shared/ui/src/lib/components/inputs/input-select/__snapshots__/input-select.spec.tsx.snap
+++ b/libs/shared/ui/src/lib/components/inputs/input-select/__snapshots__/input-select.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`InputSelect should apply disabled classes to selected value, label and 
       class=""
     >
       <div
-        class="input input--select !pointer-events-none input--has-icon !border-neutral !bg-surface-neutral-subtle"
+        class="input input--select !pointer-events-none input--has-icon !border-neutral !bg-surface-neutral-subtle input--label-up"
         data-testid="select"
       >
         <div
@@ -40,7 +40,7 @@ exports[`InputSelect should apply disabled classes to selected value, label and 
           </svg>
         </div>
         <label
-          class="!translate-y-0 !text-xs ml-8 !text-neutral-subtle"
+          class="input__label translate-y-[7px] text-sm ml-8 !text-neutral-subtle"
           for="Select Multiple"
         >
           Select Multiple

--- a/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
@@ -84,8 +84,6 @@ export function InputSelect({
   const [selectedItems, setSelectedItems] = useState<MultiValue<Value> | SingleValue<Value>>([])
   const [selectedValue, setSelectedValue] = useState<string | string[]>([])
 
-  const selectedWithIconClassName = 'ml-8'
-
   const hasFocus = focused
   const hasError = error ? 'input--error' : ''
 
@@ -246,6 +244,8 @@ export function InputSelect({
 
   const currentIcon = options.find((option) => option.value === selectedValue)
   const hasIcon = !isMulti && currentIcon?.icon
+  const hasSelectedValue = Array.isArray(selectedValue) ? selectedValue.length > 0 : selectedValue.length > 0
+  const hasLabelUp = hasFocus || hasSelectedValue || Boolean(placeholder) || Boolean(hasIcon) ? 'input--label-up' : ''
 
   const inputActions =
     hasFocus && !disabled
@@ -255,12 +255,6 @@ export function InputSelect({
         : hasError
           ? 'input--error'
           : ''
-
-  const [hasLabelUp, setHasLabelUp] = useState(value?.length !== 0 ? 'input--label-up' : '')
-
-  useEffect(() => {
-    setHasLabelUp(hasFocus || selectedValue.length !== 0 ? 'input--label-up' : '')
-  }, [hasFocus, selectedValue, setHasLabelUp])
 
   const selectProps: SelectProps<Value, true, GroupBase<Value>> = {
     autoFocus,
@@ -334,7 +328,8 @@ export function InputSelect({
             'input--has-icon': hasIcon,
             '!border-neutral !bg-surface-neutral-subtle': disabled,
             'input--filter': isFilter,
-          })
+          }),
+          hasLabelUp
         )}
         data-testid={dataTestId || 'select'}
       >
@@ -350,12 +345,10 @@ export function InputSelect({
           <label
             htmlFor={label}
             className={twMerge(
-              clsx({
-                '!translate-y-0 !text-xs': hasIcon || hasLabelUp,
-                [selectedWithIconClassName]: hasIcon,
-                'top-1.5 translate-y-2 text-sm': !hasIcon && !hasLabelUp,
-                '!text-neutral-subtle': disabled,
-              })
+              'input__label',
+              hasFocus ? 'text-xs' : 'translate-y-[7px] text-sm',
+              hasIcon && 'ml-8',
+              disabled && '!text-neutral-subtle'
             )}
           >
             {label}

--- a/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
@@ -92,7 +92,7 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
   const isInputDate = type === 'time' || type === 'date' || type === 'datetime'
   const labelClassName = twMerge(
     'input__label',
-    hasFocus ? 'text-xs' : 'translate-y-2 text-sm',
+    hasFocus ? 'text-xs' : 'translate-y-[7px] text-sm',
     isLabelTransitionDisabled && '!transition-none'
   )
 

--- a/libs/shared/ui/src/lib/styles/components/input.scss
+++ b/libs/shared/ui/src/lib/styles/components/input.scss
@@ -1,13 +1,13 @@
 @use '../base/variable';
 
 .input {
-  @apply relative min-h-[52px] cursor-pointer rounded-md border border-neutral-component bg-surface-neutral px-3 py-2 hover:bg-surface-neutral-component;
+  @apply relative min-h-[52px] cursor-pointer rounded-md border border-neutral bg-surface-neutral px-3 py-2 hover:border-neutral-componentHover;
   transition:
     120ms all variable.$timing-cubic,
     0 outline;
 
   label {
-    @apply absolute translate-y-2 select-none text-sm text-neutral-subtle transition-label duration-[120ms] ease-in-out;
+    @apply absolute translate-y-[7px] select-none text-sm text-neutral-subtle transition-label duration-[120ms] ease-in-out;
   }
 
   input:focus,
@@ -120,10 +120,6 @@
 .input--success {
   @apply border-positive-strong;
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.05);
-}
-
-.input__label {
-  @apply h-full w-full;
 }
 
 .input__button {

--- a/tailwind-workspace-preset.js
+++ b/tailwind-workspace-preset.js
@@ -390,6 +390,7 @@ module.exports = {
         neutral: {
           DEFAULT: 'var(--neutral-6)',
           component: 'var(--neutral-7)',
+          componentHover: 'var(--neutral-8)',
           strong: 'var(--neutral-9)',
         },
         neutralInvert: {


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: 
- Added 'small' size variant to EmptyState component for lighter empty states when needed (like for the last deployment section)
- Updated styles in EnvironmentLastDeploymentSection and ServiceLastDeployment to utilize the new small size.
- Updated Badge radius to better match the radius used in the buttons of similar sizes
- Updated inputs and select hover state by removing background color changes and migrating to only a border color change. Added a new neutral border for it
- Updated the way labels are handled in select component to harmonize the behavior with the text inputs. Also updated the translate the have the label properly centered (was off by 1px)
- Updated labels and annotations select options for cleaner design
- Update to the pod-level badge color in monitoring dashboard [slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1776950301708659)

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
