### PR TITLE
fix(new-nav): add missing buttons to env list

### DIFF
--- a/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.spec.tsx
+++ b/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.spec.tsx
@@ -78,4 +78,27 @@ describe('EnvironmentSection', () => {
 
     expect(mockNavigate).not.toHaveBeenCalled()
   })
+
+  it('should display both action buttons when there are no services', async () => {
+    const noServiceOverview = {
+      ...overview,
+      services_overview: {
+        service_count: 0,
+      },
+      deployment_status: undefined,
+    } as EnvironmentOverviewResponse
+
+    const { userEvent } = renderWithProviders(
+      <EnvironmentSection type={EnvironmentModeEnum.DEVELOPMENT} items={[noServiceOverview]} />
+    )
+
+    const manageDeploymentButton = screen.getByRole('button', { name: /manage deployment/i })
+    expect(manageDeploymentButton).toBeDisabled()
+
+    await userEvent.hover(manageDeploymentButton.parentElement as HTMLElement)
+    expect(
+      await screen.findByRole('tooltip', { name: 'Add at least one service to deploy this environment' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /delete environment/i })).toBeInTheDocument()
+  })
 })

--- a/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.tsx
+++ b/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate, useParams } from '@tanstack/react-router'
-import { EnvironmentModeEnum, type EnvironmentOverviewResponse } from 'qovery-typescript-axios'
+import { EnvironmentModeEnum, type EnvironmentOverviewResponse, StateEnum } from 'qovery-typescript-axios'
 import { type KeyboardEvent, type MouseEvent } from 'react'
 import { match } from 'ts-pattern'
 import { ClusterAvatar } from '@qovery/domains/clusters/feature'
@@ -15,6 +15,20 @@ const { Table } = TablePrimitives
 
 const gridLayoutClassName =
   'grid w-full grid-cols-[minmax(280px,2fr)_minmax(220px,1.4fr)_minmax(240px,1.2fr)_minmax(140px,1fr)_96px]'
+
+function DisabledManageDeploymentButton() {
+  return (
+    <Tooltip content="Add at least one service to deploy this environment">
+      <div>
+        <Button aria-label="Manage Deployment" color="neutral" variant="outline" size="sm" iconOnly disabled>
+          <div className="flex h-full w-full items-center justify-center gap-1.5">
+            <Icon iconName="rocket" />
+          </div>
+        </Button>
+      </div>
+    </Tooltip>
+  )
+}
 
 function EnvRow({ overview }: { overview: EnvironmentOverviewResponse }) {
   const navigate = useNavigate()
@@ -113,10 +127,17 @@ function EnvRow({ overview }: { overview: EnvironmentOverviewResponse }) {
           onClick={stopRowNavigation}
           onKeyDown={stopRowNavigation}
         >
-          {environment && overview.deployment_status && overview.services_overview.service_count > 0 && (
+          {environment && (
             <>
-              <MenuManageDeployment environment={environment} deploymentStatus={overview.deployment_status} />
-              <MenuOtherActions environment={environment} state={overview.deployment_status?.last_deployment_state} />
+              {overview.services_overview.service_count > 0 && overview.deployment_status ? (
+                <MenuManageDeployment environment={environment} deploymentStatus={overview.deployment_status} />
+              ) : (
+                <DisabledManageDeploymentButton />
+              )}
+              <MenuOtherActions
+                environment={environment}
+                state={overview.deployment_status?.last_deployment_state ?? StateEnum.READY}
+              />
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary

**Issue**: When an environment does not have any services yet, we should still have button in the environments list.

[Slack thread](https://qovery.slack.com/archives/C0AML0VDUV8/p1776861689673199) for reference.

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="3164" height="2070" alt="Capture d’écran 2026-04-22 à 14 39 42 (2)" src="https://github.com/user-attachments/assets/a864a12d-02a4-4b05-87d9-028431782599" /> | <img width="1628" height="407" alt="Screenshot 2026-04-23 at 16 03 08" src="https://github.com/user-attachments/assets/9c398794-8641-4488-b871-47d175ce1476" /> |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
