### PR TITLE
feat(new-nav): order database versions

### DIFF
--- a/libs/domains/service-settings/feature/src/lib/service-general-settings/service-general-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/service-general-settings/service-general-settings.tsx
@@ -75,13 +75,14 @@ function ServiceGeneralSettingsContent({ organization }: ServiceGeneralSettingsP
   const databaseVersionOptions =
     service?.serviceType === 'DATABASE'
       ? sortDatabaseVersionValues(
-          databaseConfigurations
-            ?.find((configuration) => configuration.database_type === service.type)
-            ?.version?.filter((version) => version.supported_mode === service.mode)
-            .map((version) => ({
-              label: version.name || '',
-              value: version.name || '',
-            }))
+          (
+            databaseConfigurations
+              ?.find((configuration) => configuration.database_type === service.type)
+              ?.version?.filter((version) => version.supported_mode === service.mode) ?? []
+          ).map((version) => ({
+            label: version.name || '',
+            value: version.name || '',
+          }))
         )
       : undefined
 

--- a/libs/domains/service-settings/feature/src/lib/service-general-settings/service-general-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/service-general-settings/service-general-settings.tsx
@@ -13,6 +13,7 @@ import {
   type ServiceGeneralData,
   buildServiceGeneralPayload,
   getServiceGeneralDefaultValues,
+  sortDatabaseVersionValues,
   useEditService,
   useService,
 } from '@qovery/domains/services/feature'
@@ -73,13 +74,15 @@ function ServiceGeneralSettingsContent({ organization }: ServiceGeneralSettingsP
 
   const databaseVersionOptions =
     service?.serviceType === 'DATABASE'
-      ? databaseConfigurations
-          ?.find((configuration) => configuration.database_type === service.type)
-          ?.version?.filter((version) => version.supported_mode === service.mode)
-          .map((version) => ({
-            label: version.name || '',
-            value: version.name || '',
-          }))
+      ? sortDatabaseVersionValues(
+          databaseConfigurations
+            ?.find((configuration) => configuration.database_type === service.type)
+            ?.version?.filter((version) => version.supported_mode === service.mode)
+            .map((version) => ({
+              label: version.name || '',
+              value: version.name || '',
+            }))
+        )
       : undefined
 
   const methods = useForm<ServiceGeneralData>({

--- a/libs/domains/services/feature/src/lib/service-creation-flow/database/database-create-utils/database-create-utils.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/database/database-create-utils/database-create-utils.spec.tsx
@@ -14,6 +14,7 @@ import {
   generateDatabaseTypeAndVersionOptions,
   getDefaultDatabaseMode,
   getDefaultManagedDatabaseInstanceType,
+  sortDatabaseVersionValues,
 } from './database-create-utils'
 
 describe('database-create-utils', () => {
@@ -70,12 +71,12 @@ describe('database-create-utils', () => {
         database_type: 'POSTGRESQL',
         version: [
           {
-            name: '16',
+            name: '10',
             supported_mode: DatabaseModeEnum.CONTAINER,
           },
           {
-            name: '15',
-            supported_mode: DatabaseModeEnum.MANAGED,
+            name: '16',
+            supported_mode: DatabaseModeEnum.CONTAINER,
           },
         ],
       },
@@ -89,9 +90,25 @@ describe('database-create-utils', () => {
       }),
     ])
     expect(options.databaseVersionOptions).toEqual({
-      'POSTGRESQL-CONTAINER': [{ label: '16', value: '16' }],
-      'POSTGRESQL-MANAGED': [{ label: '15', value: '15' }],
+      'POSTGRESQL-CONTAINER': [
+        { label: '16', value: '16' },
+        { label: '10', value: '10' },
+      ],
     })
+  })
+
+  it('sorts database versions from latest to oldest', () => {
+    expect(
+      sortDatabaseVersionValues([
+        { label: '11', value: '11' },
+        { label: '9.6', value: '9.6' },
+        { label: '12', value: '12' },
+      ])
+    ).toEqual([
+      { label: '12', value: '12' },
+      { label: '11', value: '11' },
+      { label: '9.6', value: '9.6' },
+    ])
   })
 
   it('returns the expected default database mode', () => {

--- a/libs/domains/services/feature/src/lib/service-creation-flow/database/database-create-utils/database-create-utils.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/database/database-create-utils/database-create-utils.tsx
@@ -64,6 +64,15 @@ export function formatDatabaseTypeLabel(value: string) {
   return formattedValue
 }
 
+export function sortDatabaseVersionValues(versions?: Value[]) {
+  return [...(versions ?? [])].sort((a, b) =>
+    String(b.value).localeCompare(String(a.value), undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    })
+  )
+}
+
 export function findDatabaseTemplateMatch(template?: string, option?: string): DatabaseTemplateMatch {
   if (!template) {
     return {}
@@ -136,9 +145,13 @@ export function generateDatabaseTypeAndVersionOptions(
     }
   })
 
+  const sortedDatabaseVersionOptions = Object.fromEntries(
+    Object.entries(databaseVersionOptions).map(([key, versions]) => [key, sortDatabaseVersionValues(versions)])
+  )
+
   return {
     databaseTypeOptions: clusterVpc ? filterDatabaseTypes(databaseTypeOptions, clusterVpc) : databaseTypeOptions,
-    databaseVersionOptions,
+    databaseVersionOptions: sortedDatabaseVersionOptions,
   }
 }
 


### PR DESCRIPTION
## Summary

**Issue**: The databases versions were not ordered correctly.

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings


| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="754" height="532" alt="Screenshot 2026-04-24 at 09 27 50" src="https://github.com/user-attachments/assets/16dd22da-7f38-4cd0-b4a3-9bbc9502071e" /> | <img width="724" height="530" alt="Screenshot 2026-04-24 at 09 27 27" src="https://github.com/user-attachments/assets/fae6d149-b651-408a-a40f-6c38d58b1456" /> |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
