### PR TITLE
feat(audit-logs): fix z-index issue and update tests on audit logs

### DIFF
--- a/libs/domains/audit-logs/feature/src/lib/audit-logs/audit-logs.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/audit-logs/audit-logs.spec.tsx
@@ -191,3 +191,12 @@ describe.skip('PageGeneral', () => {
     expect(container).toBeTruthy()
   })
 })
+
+describe('AuditLogs layering', () => {
+  it('should apply dropdown z-index to the table header for filter popovers', () => {
+    renderWithProviders(<AuditLogs {...props} events={[]} isLoading={false} />)
+
+    const tableHeader = screen.getByTestId('table-container')
+    expect(tableHeader).toHaveClass('z-dropdown')
+  })
+})

--- a/libs/domains/audit-logs/feature/src/lib/audit-logs/audit-logs.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/audit-logs/audit-logs.tsx
@@ -288,7 +288,7 @@ export function AuditLogs({
         filter={filter}
         setFilter={setFilter}
         className="rounded border border-neutral"
-        classNameHead="rounded-t"
+        classNameHead="z-dropdown rounded-t"
         columnsWidth={columnsWidth}
       >
         <div>


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary
Fix z-index issues with pagination component on audit logs

**Before**
<img width="365" height="602" alt="image" src="https://github.com/user-attachments/assets/0b4298f1-4de0-4129-b37b-254d90351d22" />

**After**
<img width="483" height="611" alt="image" src="https://github.com/user-attachments/assets/f51da013-2181-4fe7-a7c0-ef5654a3a4d0" />

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
