### PR TITLE
fix(new-nav): wrong redirection on logout

### DIFF
--- a/apps/console-v5/src/routes/_authenticated.tsx
+++ b/apps/console-v5/src/routes/_authenticated.tsx
@@ -1,11 +1,10 @@
-import { Outlet, createFileRoute } from '@tanstack/react-router'
+import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_authenticated')({
   beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated && !context.auth.isLoading) {
-      // Pass current pathname as returnTo so Auth0 can restore it after login
-      context.auth.login(location.href)
-      return
+      // Route to the in-app login page instead of forcing Auth0 hosted login.
+      throw redirect({ to: '/login', search: { redirect: location.href } })
     }
   },
   component: () => <Outlet />,

--- a/apps/console-v5/src/routes/login/index.tsx
+++ b/apps/console-v5/src/routes/login/index.tsx
@@ -189,6 +189,7 @@ export const Route = createFileRoute('/login/')({
 
 function RouteComponent() {
   const { authLogin } = useAuth()
+  const search = Route.useSearch()
   const [ssoFormVisible, setSsoFormVisible] = useState(false)
   const { auth0Error, setAuth0Error } = useAuth0Error()
   const [loading, setLoading] = useState<{ provider: string; active: boolean } | undefined>()
@@ -244,7 +245,7 @@ function RouteComponent() {
       if (document.cookie.split(';').some((item) => item.trim().startsWith('jwtToken='))) {
         document.cookie = 'jwtToken=; Max-Age=-99999999; domain=.qovery.com'
       }
-      await authLogin(provider)
+      await authLogin(provider, getSafeRedirect(search.redirect))
     } catch (error) {
       console.error(error)
     }

--- a/libs/shared/auth/src/lib/use-auth/use-auth.tsx
+++ b/libs/shared/auth/src/lib/use-auth/use-auth.tsx
@@ -8,11 +8,12 @@ export function useAuth() {
    * Authentification login
    * Gitlab uppercase is needed
    */
-  const authLogin = async (provider?: string) => {
+  const authLogin = async (provider?: string, returnTo?: string) => {
     await loginWithRedirect({
       authorizationParams: {
         connection: provider,
       },
+      appState: returnTo ? { returnTo } : undefined,
     })
   }
 


### PR DESCRIPTION
## Summary

**Issue**: When automatically logged out, users are redirected to `https://auth.qovery.com/login` instead of the Qovery `/login` page.

[Slack thread](https://qovery.slack.com/archives/C0AML0VDUV8/p1777020609122539) for reference.

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
