### PR TITLE
fix(clusters): hide clusters installation popover on logs and creation flows pages

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
@@ -39,6 +39,15 @@ const StatusWebSocketListenerMemo = memo(StatusWebSocketListener)
 const isDeployingStatus = (status?: ClusterStateEnum): boolean =>
   status === ClusterState.DEPLOYMENT_QUEUED || status === ClusterState.DEPLOYING
 
+const hiddenProgressCardRouteIds = [
+  '/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/logs/$executionId',
+  '/_authenticated/organization/$organizationId/cluster/new',
+  '/_authenticated/organization/$organizationId/cluster/create/$slug',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create',
+]
+
 function RouteComponent() {
   const matches = useMatches()
   const mergedParams = useMemo(() => {
@@ -87,6 +96,16 @@ function RouteComponent() {
     })
   }, [clusters, clusterStatuses])
 
+  const shouldHideProgressCard = useMemo(
+    () =>
+      matches.some((match) =>
+        hiddenProgressCardRouteIds.some(
+          (routeId) => match.routeId === routeId || match.routeId?.startsWith(routeId + '/')
+        )
+      ),
+    [matches]
+  )
+
   return (
     <>
       <Suspense fallback={<Loader />}>
@@ -112,7 +131,7 @@ function RouteComponent() {
             )
         )
       }
-      {deployingClusters && deployingClusters.length > 0 && (
+      {!shouldHideProgressCard && deployingClusters && deployingClusters.length > 0 && (
         <ClusterDeploymentProgressCard organizationId={organizationId} clusters={deployingClusters} />
       )}
     </>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
@@ -8,6 +8,7 @@ import { useEnvironment } from '@qovery/domains/environments/feature'
 import { LoaderSpinner } from '@qovery/shared/ui'
 import { StatusWebSocketListener } from '@qovery/shared/util-web-sockets'
 import { queries } from '@qovery/state/util-queries'
+import { type FileRouteTypes } from '../../../../routeTree.gen'
 
 export const Route = createFileRoute('/_authenticated/organization/$organizationId')({
   component: RouteComponent,
@@ -39,14 +40,19 @@ const StatusWebSocketListenerMemo = memo(StatusWebSocketListener)
 const isDeployingStatus = (status?: ClusterStateEnum): boolean =>
   status === ClusterState.DEPLOYMENT_QUEUED || status === ClusterState.DEPLOYING
 
-const hiddenProgressCardRouteIds = [
+const hiddenProgressCardRouteIds: FileRouteTypes['id'][] = [
   '/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs',
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs',
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs',
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/logs/$executionId',
   '/_authenticated/organization/$organizationId/cluster/new',
   '/_authenticated/organization/$organizationId/cluster/create/$slug',
-  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/cron-job',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/database',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/helm',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/lifecycle-job',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/terraform',
 ]
 
 function RouteComponent() {

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
@@ -41,6 +41,7 @@ const isDeployingStatus = (status?: ClusterStateEnum): boolean =>
 
 const hiddenProgressCardRouteIds = [
   '/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs',
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs',
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/logs/$executionId',
   '/_authenticated/organization/$organizationId/cluster/new',


### PR DESCRIPTION
## Summary

**Issue**: The cluster installation popover was displayed on top of the logs. In order to fix this, we decided to hide the popover on logs and creation flows pages.

[Slack thread](https://qovery.slack.com/archives/C0AML0VDUV8/p1777043485527679) for reference.

## Screenshots / Recordings

<img width="1105" height="1298" alt="image (25)" src="https://github.com/user-attachments/assets/b326629b-0e1d-4bd3-9be6-4bc619d77d4b" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
