### PR TITLE
fix(variables): redirection on variable creation conflict

### DIFF
--- a/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
+++ b/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
@@ -1,18 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from '@tanstack/react-router'
 import type { AxiosError } from 'axios'
 import { mutations } from '@qovery/domains/variables/data-access'
-import {
-  APPLICATION_URL,
-  APPLICATION_VARIABLES_URL,
-  ENVIRONMENTS_URL,
-  ENVIRONMENTS_VARIABLES_URL,
-  SERVICES_URL,
-  SERVICES_VARIABLES_URL,
-} from '@qovery/shared/routes'
 import { toastError } from '@qovery/shared/ui'
 import { queries } from '@qovery/state/util-queries'
 
 export function useCreateVariable() {
+  const { buildLocation } = useRouter()
   const queryClient = useQueryClient()
   return useMutation(mutations.createVariable, {
     onSuccess() {
@@ -34,10 +28,25 @@ export function useCreateVariable() {
             service_id: serviceId,
           } = error.response.data.existing_variable
           const url = serviceId
-            ? `${APPLICATION_URL(orgId, projectId, envId, serviceId)}${APPLICATION_VARIABLES_URL}`
+            ? buildLocation({
+                to: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables',
+                params: {
+                  organizationId: orgId,
+                  projectId,
+                  environmentId: envId,
+                  serviceId,
+                },
+              }).href
             : envId
-              ? `${SERVICES_URL(orgId, projectId, envId)}${SERVICES_VARIABLES_URL}`
-              : `${ENVIRONMENTS_URL(orgId, projectId)}${ENVIRONMENTS_VARIABLES_URL}`
+              ? buildLocation({
+                  to: '/organization/$organizationId/project/$projectId/environment/$environmentId/variables',
+                  params: {
+                    organizationId: orgId,
+                    projectId,
+                    environmentId: envId,
+                  },
+                }).href
+              : ''
           toastError(
             error,
             'Conflict',

--- a/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
+++ b/libs/domains/variables/feature/src/lib/hooks/use-create-variable/use-create-variable.ts
@@ -46,7 +46,13 @@ export function useCreateVariable() {
                     environmentId: envId,
                   },
                 }).href
-              : ''
+              : buildLocation({
+                  to: '/organization/$organizationId/project/$projectId/variables',
+                  params: {
+                    organizationId: orgId,
+                    projectId,
+                  },
+                }).href
           toastError(
             error,
             'Conflict',


### PR DESCRIPTION
## Summary

**Issue**: When creating a conflicting variable, we have a bug where the link to redirect to said variable redirects to a "Page not found". This PR fixes that.

[Slack thread](https://qovery.slack.com/archives/C0AML0VDUV8/p1777284844890219) 


## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
