### PR TITLE
fix(organization): hide alerting into navigation

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/route.tsx
@@ -2,6 +2,7 @@ import { type IconName } from '@fortawesome/fontawesome-common-types'
 import { Outlet, createFileRoute, useLocation, useMatches, useParams } from '@tanstack/react-router'
 import posthog from 'posthog-js'
 import { Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useClusters } from '@qovery/domains/clusters/feature'
 import { useEnvironment } from '@qovery/domains/environments/feature'
 import { useProject } from '@qovery/domains/projects/feature'
 import { useRecentServices, useServiceSummary } from '@qovery/domains/services/feature'
@@ -266,11 +267,17 @@ function useNavigationContext(): NavigationContext | null {
   const location = useLocation()
   const params = useParams({ strict: false })
   const pathname = location.pathname
+  const organizationId = typeof params.organizationId === 'string' ? params.organizationId : ''
   const { data: service } = useServiceSummary({
     environmentId: params.environmentId,
     serviceId: params.serviceId,
     enabled: Boolean(params.environmentId) && Boolean(params.serviceId),
   })
+  const { data: clusters = [] } = useClusters({
+    organizationId,
+    enabled: Boolean(organizationId),
+  })
+  const hasAlerting = clusters.some((cluster) => cluster.metrics_parameters?.configuration?.alerting?.enabled)
 
   for (const context of NAVIGATION_CONTEXTS) {
     const patternRegex = createRoutePatternRegex(context.routeIdPattern)
@@ -301,7 +308,9 @@ function useNavigationContext(): NavigationContext | null {
             ? context.tabs.filter(
                 (tab) => !(isDatabase && tab.id === 'variables') && !(isManagedDatabase && tab.id === 'cloud-shell')
               )
-            : context.tabs
+            : context.type === 'organization'
+              ? context.tabs.filter((tab) => hasAlerting || tab.id !== 'alerts')
+              : context.tabs
 
         return {
           type: context.type,
@@ -312,12 +321,11 @@ function useNavigationContext(): NavigationContext | null {
     }
   }
 
-  const organizationId = params.organizationId
-  if (typeof organizationId === 'string' && organizationId.length > 0 && pathname.startsWith('/organization/')) {
+  if (organizationId.length > 0 && pathname.startsWith('/organization/')) {
     return {
       type: 'organization',
       params: { organizationId },
-      tabs: ORGANIZATION_TABS,
+      tabs: ORGANIZATION_TABS.filter((tab) => hasAlerting || tab.id !== 'alerts'),
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Fix to hide "Alerting" pages for customers without the feature

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
