### PR TITLE
feat(eksanywhere): hide some feature not available for eksa

### DIFF
--- a/libs/domains/cluster-metrics/feature/src/lib/cluster-card-node-usage/cluster-card-node-usage.spec.tsx
+++ b/libs/domains/cluster-metrics/feature/src/lib/cluster-card-node-usage/cluster-card-node-usage.spec.tsx
@@ -13,6 +13,7 @@ jest.mock('../hooks/use-cluster-metrics/use-cluster-metrics', () => ({
 }))
 
 describe('ClusterCardNodeUsage', () => {
+  const MAX_INT_32 = 2 ** 31 - 1
   const mockOrganizationId = 'org-123'
   const mockClusterId = 'cluster-456'
 
@@ -20,12 +21,19 @@ describe('ClusterCardNodeUsage', () => {
     jest.clearAllMocks()
   })
 
-  const setupMocks = (clusterProvider = 'AWS', instanceType = 'KARPENTER', runningStatus = null, metrics = null) => {
+  const setupMocks = (
+    clusterProvider = 'AWS',
+    instanceType = 'KARPENTER',
+    runningStatus = null,
+    metrics = null,
+    clusterOverrides = {}
+  ) => {
     const mockCluster = {
       cloud_provider: clusterProvider,
       instance_type: instanceType,
       min_running_nodes: 2,
       max_running_nodes: 5,
+      ...clusterOverrides,
     }
 
     const defaultRunningStatus = {
@@ -79,5 +87,18 @@ describe('ClusterCardNodeUsage', () => {
     renderWithProviders(<ClusterCardNodeUsage organizationId={mockOrganizationId} clusterId={mockClusterId} />)
     expect(screen.getByText('min: 2')).toBeInTheDocument()
     expect(screen.getByText('max: 5')).toBeInTheDocument()
+  })
+
+  it('should not display max when max running nodes is unknown', () => {
+    setupMocks('AWS', 'EC2', null, null, { max_running_nodes: MAX_INT_32 })
+    renderWithProviders(<ClusterCardNodeUsage organizationId={mockOrganizationId} clusterId={mockClusterId} />)
+    expect(screen.getByText('min: 2')).toBeInTheDocument()
+    expect(screen.queryByText(`max: ${MAX_INT_32}`)).not.toBeInTheDocument()
+  })
+
+  it('should not display resources settings link for EKS Anywhere cluster', () => {
+    setupMocks('AWS', 'MANAGED', null, null, { kubernetes: 'PARTIALLY_MANAGED' })
+    renderWithProviders(<ClusterCardNodeUsage organizationId={mockOrganizationId} clusterId={mockClusterId} />)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
 })

--- a/libs/domains/cluster-metrics/feature/src/lib/cluster-card-node-usage/cluster-card-node-usage.tsx
+++ b/libs/domains/cluster-metrics/feature/src/lib/cluster-card-node-usage/cluster-card-node-usage.tsx
@@ -6,6 +6,8 @@ import { Icon, Link, ProgressBar, Skeleton, Tooltip } from '@qovery/shared/ui'
 import { calculatePercentage, pluralize } from '@qovery/shared/util-js'
 import { useClusterMetrics } from '../hooks/use-cluster-metrics/use-cluster-metrics'
 
+const MAX_INT_32 = 2 ** 31 - 1
+
 export interface ClusterCardNodeUsageProps {
   organizationId: string
   clusterId: string
@@ -24,16 +26,20 @@ export function ClusterCardNodeUsage({ organizationId, clusterId }: ClusterCardN
   const metricsNotAvailable = typeof metrics !== 'object'
 
   const { data: cluster } = useCluster({ organizationId, clusterId })
+  const isEksAnywhereCluster = cluster?.cloud_provider === 'AWS' && cluster?.kubernetes === 'PARTIALLY_MANAGED'
+  const hasKnownMaxRunningNodes =
+    typeof cluster?.max_running_nodes === 'number' && cluster.max_running_nodes !== MAX_INT_32
 
-  const shouldDisplayMinMaxNodes = match(cluster)
+  const shouldDisplayNodeLimits = match(cluster)
     .with({ cloud_provider: 'GCP' }, () => false)
     .with({ cloud_provider: 'ON_PREMISE' }, () => false)
     .with({ cloud_provider: 'AWS', instance_type: 'KARPENTER' }, () => false)
     .otherwise(() => true)
+  const shouldUseMaxRunningNodes = shouldDisplayNodeLimits && hasKnownMaxRunningNodes
 
   const totalNodes = useMemo(
-    () => (!shouldDisplayMinMaxNodes ? metrics?.nodes?.length : cluster?.max_running_nodes) || 0,
-    [metrics?.nodes, cluster?.max_running_nodes, shouldDisplayMinMaxNodes]
+    () => (!shouldUseMaxRunningNodes ? metrics?.nodes?.length : cluster?.max_running_nodes) || 0,
+    [metrics?.nodes, cluster?.max_running_nodes, shouldUseMaxRunningNodes]
   )
 
   const healthyNodes = useMemo(
@@ -105,6 +111,10 @@ export function ClusterCardNodeUsage({ organizationId, clusterId }: ClusterCardN
         {match(cluster?.cloud_provider)
           .with('GCP', () => null)
           .with('ON_PREMISE', () => null)
+          .when(
+            () => isEksAnywhereCluster,
+            () => null
+          )
           .otherwise(() => (
             <Tooltip
               open={isMaxNodesSizeReached}
@@ -130,10 +140,10 @@ export function ClusterCardNodeUsage({ organizationId, clusterId }: ClusterCardN
       </div>
       <Skeleton width="100%" height={20} show={!cluster || metricsNotAvailable}>
         <div className="flex w-full flex-col gap-2.5">
-          {shouldDisplayMinMaxNodes && (
+          {shouldDisplayNodeLimits && (
             <div className="flex items-center justify-between text-sm text-neutral-350">
               <span>min: {cluster?.min_running_nodes}</span>
-              <span>max: {cluster?.max_running_nodes}</span>
+              {hasKnownMaxRunningNodes ? <span>max: {cluster?.max_running_nodes}</span> : null}
             </div>
           )}
           <Tooltip content={tooltipContent} classNameContent="w-[157px] px-2.5 py-1.5">

--- a/libs/pages/cluster/src/lib/feature/page-settings-feature/page-settings-feature.spec.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-feature/page-settings-feature.spec.tsx
@@ -1,8 +1,37 @@
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { Route, Routes } from 'react-router-dom'
-import { renderWithProviders } from '@qovery/shared/util-tests'
+import { useCluster } from '@qovery/domains/clusters/feature'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import PageSettingsFeature from './page-settings-feature'
 
+jest.mock('posthog-js/react', () => ({
+  useFeatureFlagEnabled: jest.fn(() => true),
+}))
+
+jest.mock('@qovery/domains/clusters/feature', () => ({
+  ...jest.requireActual('@qovery/domains/clusters/feature'),
+  useCluster: jest.fn(),
+}))
+
+jest.mock('../../router/router', () => ({
+  ROUTER_CLUSTER_SETTINGS: [],
+}))
+
+const useFeatureFlagEnabledMock = useFeatureFlagEnabled as jest.MockedFunction<typeof useFeatureFlagEnabled>
+const useClusterMock = useCluster as jest.MockedFunction<typeof useCluster>
+
 describe('PageSettingsFeature', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useFeatureFlagEnabledMock.mockReturnValue(true)
+    useClusterMock.mockReturnValue({
+      data: {
+        cloud_provider: 'AWS',
+        kubernetes: 'MANAGED',
+      },
+    })
+  })
+
   it('should render successfully', () => {
     const { baseElement } = renderWithProviders(
       <Routes location="/organization/1/cluster/2/general">
@@ -10,5 +39,23 @@ describe('PageSettingsFeature', () => {
       </Routes>
     )
     expect(baseElement).toBeTruthy()
+  })
+
+  it('should not display advanced settings for EKS Anywhere cluster', () => {
+    useClusterMock.mockReturnValue({
+      data: {
+        cloud_provider: 'AWS',
+        kubernetes: 'PARTIALLY_MANAGED',
+      },
+    })
+
+    renderWithProviders(
+      <Routes location="/organization/1/cluster/2/general">
+        <Route path="/organization/1/cluster/2/*" element={<PageSettingsFeature />} />
+      </Routes>
+    )
+
+    expect(screen.getByText('EKS Anywhere configuration')).toBeInTheDocument()
+    expect(screen.queryByText('Advanced settings')).not.toBeInTheDocument()
   })
 })

--- a/libs/pages/cluster/src/lib/feature/page-settings-feature/page-settings-feature.tsx
+++ b/libs/pages/cluster/src/lib/feature/page-settings-feature/page-settings-feature.tsx
@@ -90,7 +90,7 @@ export function PageSettingsFeature() {
           ...(eksAnywhereCluster ? [] : [resourcesLink]),
           imageRegistryLink,
           ...(eksAnywhereCluster ? [] : [networkLink]),
-          advancedSettingsLink,
+          ...(eksAnywhereCluster ? [] : [advancedSettingsLink]),
           dangerZoneLink,
         ]
       }


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: <!-- QOV-1234 -->

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
