### PR TITLE
fix(new-nav): env overview statuses glitch issue

### DIFF
--- a/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
+++ b/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { type EnvironmentStatus, type EnvironmentStatusesWithStages } from 'qovery-typescript-axios'
 import {
   type ApplicationStatusDto,
@@ -5,7 +6,7 @@ import {
   type ServiceStatusDto,
   type TerraformStatusDto,
 } from 'qovery-ws-typescript-axios'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { v7 as uuidv7 } from 'uuid'
 import { QOVERY_WS } from '@qovery/shared/util-node-env'
 import { useReactQueryWsSubscription } from '@qovery/state/util-queries'
@@ -32,6 +33,21 @@ export function useStatusWebSockets({
   versionId,
 }: UseStatusWebSocketsProps) {
   const [externalRequestId] = useState(() => uuidv7())
+  const queryClient = useQueryClient()
+  const wsEnabled = Boolean(organizationId) && Boolean(clusterId) && Boolean(projectId)
+
+  // NOTE: remove running status cache when the environment is changed to avoid stale data
+  // @see https://qovery.atlassian.net/browse/QOV-1886
+  useEffect(() => {
+    return () => {
+      if (environmentId) {
+        queryClient.removeQueries({
+          queryKey: queries.environments.runningStatus(environmentId).queryKey,
+          exact: true,
+        })
+      }
+    }
+  }, [environmentId, queryClient])
 
   useReactQueryWsSubscription({
     url: QOVERY_WS + '/deployment/status',
@@ -42,7 +58,7 @@ export function useStatusWebSockets({
       project: projectId,
       version: versionId,
     },
-    enabled: Boolean(organizationId) && Boolean(clusterId) && Boolean(projectId),
+    enabled: wsEnabled,
     shouldReconnect: true,
     onMessage(queryClient, message: WSDeploymentStatus) {
       if (environmentId) {
@@ -87,7 +103,7 @@ export function useStatusWebSockets({
       external_request_id: externalRequestId,
     },
     // NOTE: projectId is not required by the API but it limits WS messages when cluster handles my environments / services
-    enabled: Boolean(organizationId) && Boolean(clusterId) && Boolean(projectId),
+    enabled: wsEnabled,
     onMessage(queryClient, message: ServiceStatusDto) {
       for (const env of message.environments) {
         // TODO [To update once rust-backed will be deployed]: check against current value and update it only if it has changed (to avoid too many re-render)


### PR DESCRIPTION
## Summary

**Issue**: [QOV-1886](https://qovery.atlassian.net/browse/QOV-1886)

UI inconsistency between the environment’s aggregated status and the individual service running statuses

→ [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1777368505997529)

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code


[QOV-1886]: https://qovery.atlassian.net/browse/QOV-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ