### PR TITLE
fix(ui): add several feedback

### DIFF
--- a/apps/console/public/changelog/latest.json
+++ b/apps/console/public/changelog/latest.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "Qovery Changelogs",
-    "summary": "We're super excited to announce new features and improvements: Kube 1.34 and 1.35 upgrades, Terraform provider improvements, Standard Kube labels, Topology spread across zones",
-    "url": "https://www.qovery.com/changelog/2026-04-08",
-    "firstPublishedAt": "2026-04-08T00:00:00.000Z"
+    "name": "Demo Day, Qovery Skills, EFS Support, Nodepool for cronjob",
+    "summary": "Hey Team, We just wrapped our Q1 2026 Demo Day, a LinkedIn Live session where we walked through everything that shipped this quarter, including live demos of the AI Copilot, MCP server, and our NGINX migration progress. If you missed it, you can watch the full recording here(https://www...",
+    "url": "https://www.qovery.com/changelog/2026-04-22",
+    "firstPublishedAt": "2026-04-22T00:00:00.000Z"
   }
 ]

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-issues-modal/cluster-production-health-issues-modal.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-issues-modal/cluster-production-health-issues-modal.spec.tsx
@@ -18,7 +18,7 @@ const baseCluster = {
   production: true,
 } as unknown as Cluster
 
-const noop = () => {}
+const noop = jest.fn()
 
 describe('ClusterProductionHealthIssuesModal', () => {
   it('renders a calmer update report when clusters only have updates available', () => {

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-issues-modal/cluster-production-health-issues-modal.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-issues-modal/cluster-production-health-issues-modal.spec.tsx
@@ -1,0 +1,68 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import type { Cluster } from 'qovery-typescript-axios'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import {
+  type ClusterProductionHealthIssuesGroup,
+  ClusterProductionHealthIssuesModal,
+} from './cluster-production-health-issues-modal'
+
+const baseCluster = {
+  id: 'cluster-id',
+  name: 'prod-cluster',
+  organization: { id: 'org-id' },
+  cloud_provider: 'AWS',
+  region: 'us-east-1',
+  version: '1.27',
+  kubernetes: 'MANAGED',
+  deployment_status: 'UP_TO_DATE',
+  production: true,
+} as unknown as Cluster
+
+const noop = () => {}
+
+describe('ClusterProductionHealthIssuesModal', () => {
+  it('renders a calmer update report when clusters only have updates available', () => {
+    const groups: ClusterProductionHealthIssuesGroup[] = [
+      {
+        kind: 'update-available',
+        entries: [{ cluster: baseCluster, issues: ['update-available'] }],
+      },
+    ]
+
+    renderWithProviders(
+      <Dialog.Root open>
+        <Dialog.Content>
+          <ClusterProductionHealthIssuesModal groups={groups} count={1} onClose={noop} />
+        </Dialog.Content>
+      </Dialog.Root>
+    )
+
+    expect(screen.getByText('Cluster updates report')).toBeInTheDocument()
+    expect(screen.getByText(/updates are available on/i)).toBeInTheDocument()
+    expect(screen.getByText(/plan them when you are ready/i)).toBeInTheDocument()
+  })
+
+  it('keeps the broader health report copy when runtime issues are present', () => {
+    const groups: ClusterProductionHealthIssuesGroup[] = [
+      {
+        kind: 'deploy-failed',
+        entries: [{ cluster: baseCluster, issues: ['deploy-failed'] }],
+      },
+      {
+        kind: 'update-available',
+        entries: [{ cluster: baseCluster, issues: ['update-available'] }],
+      },
+    ]
+
+    renderWithProviders(
+      <Dialog.Root open>
+        <Dialog.Content>
+          <ClusterProductionHealthIssuesModal groups={groups} count={1} onClose={noop} />
+        </Dialog.Content>
+      </Dialog.Root>
+    )
+
+    expect(screen.getByText('Cluster health report')).toBeInTheDocument()
+    expect(screen.getByText(/that need your attention/i)).toBeInTheDocument()
+  })
+})

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-issues-modal/cluster-production-health-issues-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-issues-modal/cluster-production-health-issues-modal.tsx
@@ -58,7 +58,7 @@ export function ClusterProductionHealthIssuesModal({
               <strong className="text-neutral">
                 {count} {pluralize(count, 'cluster', 'clusters')}
               </strong>{' '}
-              that need your attention. Ongoing issues are listed first, and available updates appear below.
+              that need your attention.
             </>
           )}
         </Dialog.Description>

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-issues-modal/cluster-production-health-issues-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-issues-modal/cluster-production-health-issues-modal.tsx
@@ -31,20 +31,36 @@ export function ClusterProductionHealthIssuesModal({
   count,
   onClose,
 }: ClusterProductionHealthIssuesModalProps) {
+  const hasUpdateAvailable = groups.some((group) => group.kind === 'update-available')
+  const hasRuntimeIssue = groups.some((group) => CLUSTER_HEALTH_ISSUE_META[group.kind].severity === 'error')
+  const hasOnlyAvailableUpdates = hasUpdateAvailable && !hasRuntimeIssue && groups.length === 1
+
   return (
     <Section className="flex flex-col gap-5 p-5">
       <div className="flex flex-col gap-1.5">
         <Dialog.Title asChild>
           <Heading level={1} className="text-2xl text-neutral">
-            Clusters health issues report
+            {hasOnlyAvailableUpdates ? 'Cluster updates report' : 'Cluster health report'}
           </Heading>
         </Dialog.Title>
         <Dialog.Description className="text-ssm text-neutral-subtle">
-          We have detected{' '}
-          <strong className="text-neutral">
-            {count} {pluralize(count, 'cluster', 'clusters')}
-          </strong>{' '}
-          with ongoing {pluralize(count, 'issue', 'issues')} that are affecting their runtime.
+          {hasOnlyAvailableUpdates ? (
+            <>
+              Updates are available on{' '}
+              <strong className="text-neutral">
+                {count} {pluralize(count, 'cluster', 'clusters')}
+              </strong>
+              . Plan them when you are ready.
+            </>
+          ) : (
+            <>
+              We detected{' '}
+              <strong className="text-neutral">
+                {count} {pluralize(count, 'cluster', 'clusters')}
+              </strong>{' '}
+              that need your attention. Ongoing issues are listed first, and available updates appear below.
+            </>
+          )}
         </Dialog.Description>
       </div>
       <div className="flex flex-col gap-5">

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.spec.tsx
@@ -5,6 +5,11 @@ import { ClusterProductionHealthSummaryCard } from './cluster-production-health-
 
 const mockOpenModal = jest.fn()
 const mockCloseModal = jest.fn()
+const mockUseFeatureFlagVariantKey = jest.fn(() => true)
+
+jest.mock('posthog-js/react', () => ({
+  useFeatureFlagVariantKey: () => mockUseFeatureFlagVariantKey(),
+}))
 
 jest.mock('@qovery/shared/ui', () => ({
   ...jest.requireActual('@qovery/shared/ui'),
@@ -49,6 +54,7 @@ describe('ClusterProductionHealthSummaryCard', () => {
   beforeEach(() => {
     jest.useFakeTimers()
     jest.clearAllMocks()
+    mockUseFeatureFlagVariantKey.mockReturnValue(true)
     mockUseQueries.mockReturnValue([{ data: { computed_status: { global_status: 'RUNNING' } } }])
   })
 
@@ -95,6 +101,18 @@ describe('ClusterProductionHealthSummaryCard', () => {
         options: expect.objectContaining({ width: 676 }),
       })
     )
+  })
+
+  it('does not show running-status issues when the feature flag is disabled', () => {
+    mockUseFeatureFlagVariantKey.mockReturnValue(false)
+    mockUseQueries.mockReturnValue([{ data: { computed_status: { global_status: 'ERROR' } } }])
+
+    renderWithProviders(
+      <ClusterProductionHealthSummaryCard clusters={[baseCluster]} clusterStatuses={[deployedStatus]} />
+    )
+
+    expect(screen.getByText('All clusters healthy')).toBeInTheDocument()
+    expect(screen.queryByText(/cluster with ongoing issue/i)).not.toBeInTheDocument()
   })
 
   it('resets the skeleton timeout when the cluster scope changes', () => {

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.spec.tsx
@@ -65,6 +65,19 @@ describe('ClusterProductionHealthSummaryCard', () => {
     expect(screen.getByText('All clusters healthy')).toBeInTheDocument()
   })
 
+  it('renders the update-needed copy when clusters only have updates available', () => {
+    const outOfDateCluster = {
+      ...baseCluster,
+      deployment_status: 'OUT_OF_DATE',
+    } as Cluster
+
+    renderWithProviders(
+      <ClusterProductionHealthSummaryCard clusters={[outOfDateCluster]} clusterStatuses={[deployedStatus]} />
+    )
+
+    expect(screen.getByText('Update needed on 1 cluster')).toBeInTheDocument()
+  })
+
   it('renders the issues card and opens the modal when clusters have issues', async () => {
     const failingStatus = { ...deployedStatus, status: 'DEPLOYMENT_ERROR' } as ClusterStatus
 

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.tsx
@@ -1,3 +1,4 @@
+import type { IconName } from '@fortawesome/fontawesome-common-types'
 import type { Cluster, ClusterStatus } from 'qovery-typescript-axios'
 import { type ReactNode, memo, useEffect, useMemo, useState } from 'react'
 import { match } from 'ts-pattern'
@@ -35,7 +36,7 @@ const ClusterRunningStatusSubscription = memo(function ClusterRunningStatusSubsc
   return null
 })
 
-type HealthCardVariant = 'positive' | 'warning' | 'negative'
+type HealthCardVariant = 'positive' | 'warning' | 'negative' | 'brand'
 
 const VARIANT_STYLES: Record<
   HealthCardVariant,
@@ -55,6 +56,13 @@ const VARIANT_STYLES: Record<
     iconBgHover: 'group-hover:bg-surface-warning-component group-focus-visible:bg-surface-warning-component',
     iconColor: 'text-warning',
   },
+  brand: {
+    border: 'border-brand-subtle',
+    interactiveBorderHover: 'hover:border-brand-strong focus-visible:border-brand-strong',
+    iconBg: 'bg-surface-brand-subtle',
+    iconBgHover: 'group-hover:bg-surface-brand-component group-focus-visible:bg-surface-brand-component',
+    iconColor: 'text-brand',
+  },
   negative: {
     border: 'border-negative-subtle',
     interactiveBorderHover: 'hover:border-negative-strong focus-visible:border-negative-strong',
@@ -73,7 +81,7 @@ function HealthStatusCard({
 }: {
   clusters: Cluster[]
   variant: HealthCardVariant
-  iconName: 'circle-check' | 'circle-exclamation'
+  iconName: IconName
   title: ReactNode
   onClick?: () => void
 }) {
@@ -110,6 +118,34 @@ function HealthStatusCard({
   }
 
   return <div className={baseClassName}>{content}</div>
+}
+
+function getWarningTitle({
+  issuesCount,
+  groupedIssues,
+}: {
+  issuesCount: number
+  groupedIssues: { kind: ClusterHealthIssueKind }[]
+}): ReactNode {
+  const hasOnlyAvailableUpdates = groupedIssues.length === 1 && groupedIssues[0]?.kind === 'update-available'
+
+  if (hasOnlyAvailableUpdates) {
+    return (
+      <>
+        Update needed on {issuesCount} {pluralize(issuesCount, 'cluster', 'clusters')}
+      </>
+    )
+  }
+
+  return (
+    <>
+      {issuesCount} {pluralize(issuesCount, 'cluster', 'clusters')} {pluralize(issuesCount, 'need', 'needs')} attention
+    </>
+  )
+}
+
+function hasOnlyAvailableUpdates(groupedIssues: { kind: ClusterHealthIssueKind }[]) {
+  return groupedIssues.length === 1 && groupedIssues[0]?.kind === 'update-available'
 }
 
 export interface ClusterProductionHealthSummaryCardProps {
@@ -178,6 +214,8 @@ export function ClusterProductionHealthSummaryCard({
     }))
   }, [clustersWithIssues])
 
+  const isUpdateOnlyState = hasOnlyAvailableUpdates(groupedIssues)
+
   const handleOpenIssuesModal = () => {
     openModal({
       options: { width: 676 },
@@ -221,14 +259,9 @@ export function ClusterProductionHealthSummaryCard({
           .otherwise(() => (
             <HealthStatusCard
               clusters={clusters}
-              variant="warning"
-              iconName="circle-exclamation"
-              title={
-                <>
-                  {issuesCount} {pluralize(issuesCount, 'cluster', 'clusters')} need{issuesCount > 1 ? '' : 's'}{' '}
-                  attention
-                </>
-              }
+              variant={isUpdateOnlyState ? 'brand' : 'warning'}
+              iconName={isUpdateOnlyState ? 'rotate' : 'circle-exclamation'}
+              title={getWarningTitle({ issuesCount, groupedIssues })}
               onClick={handleOpenIssuesModal}
             />
           ))

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.tsx
@@ -1,15 +1,17 @@
 import type { IconName } from '@fortawesome/fontawesome-common-types'
+import { useQueries } from '@tanstack/react-query'
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
 import type { Cluster, ClusterStatus } from 'qovery-typescript-axios'
 import { type ReactNode, memo, useEffect, useMemo, useState } from 'react'
 import { match } from 'ts-pattern'
 import { Icon, Skeleton, useModal } from '@qovery/shared/ui'
 import { pluralize, twMerge } from '@qovery/shared/util-js'
+import { queries } from '@qovery/state/util-queries'
 import {
   ClusterProductionHealthIssuesModal,
   type ClusterWithHealthIssues,
 } from '../cluster-production-health-issues-modal/cluster-production-health-issues-modal'
 import useClusterRunningStatusSocket from '../hooks/use-cluster-running-status-socket/use-cluster-running-status-socket'
-import { useClusterRunningStatuses } from '../hooks/use-cluster-running-status/use-cluster-running-status'
 import {
   CLUSTER_HEALTH_ISSUE_ORDER,
   type ClusterHealthIssueKind,
@@ -22,6 +24,26 @@ import {
 // "status unavailable" issues). While waiting we display a skeleton to avoid
 // flashing incorrect states caused by temporarily missing running-status data.
 const RUNNING_STATUS_TIMEOUT_MS = 8_000
+const CLUSTER_RUNNING_STATUS_QUERY_OPTIONS = {
+  refetchOnMount: false,
+  refetchOnWindowFocus: false,
+  refetchOnReconnect: false,
+  staleTime: Infinity,
+} as const
+
+function useClusterRunningStatusQueries({ clusters, enabled }: { clusters: Cluster[]; enabled: boolean }) {
+  return useQueries({
+    queries: enabled
+      ? clusters.map((cluster) => ({
+          ...queries.clusters.runningStatus({
+            organizationId: cluster.organization.id,
+            clusterId: cluster.id,
+          }),
+          ...CLUSTER_RUNNING_STATUS_QUERY_OPTIONS,
+        }))
+      : [],
+  })
+}
 
 // Memoized so parent re-renders (e.g. from the 3s cluster-statuses polling) don't tear down
 // the websocket subscription when the cluster identity didn't change.
@@ -158,6 +180,7 @@ export function ClusterProductionHealthSummaryCard({
   clusterStatuses,
 }: ClusterProductionHealthSummaryCardProps) {
   const { openModal, closeModal } = useModal()
+  const isRunningStatusIssueEnabled = Boolean(useFeatureFlagVariantKey('cluster-running-status'))
   const runningStatusScopeKey = useMemo(
     () => clusters.map((cluster) => `${cluster.organization.id}:${cluster.id}`).join('|'),
     [clusters]
@@ -170,11 +193,14 @@ export function ClusterProductionHealthSummaryCard({
     return () => clearTimeout(timeoutId)
   }, [runningStatusScopeKey])
 
-  const runningStatusQueries = useClusterRunningStatuses({ clusters })
+  const runningStatusQueries = useClusterRunningStatusQueries({ clusters, enabled: isRunningStatusIssueEnabled })
 
   // Keep the skeleton up until every cluster has reported a running status
   // (real payload or explicit 'NotFound'), or the timeout fires as a safety net
-  const hasAllRunningStatuses = clusters.length === 0 || runningStatusQueries.every((query) => query.data !== undefined)
+  const hasAllRunningStatuses =
+    !isRunningStatusIssueEnabled ||
+    clusters.length === 0 ||
+    runningStatusQueries.every((query) => query.data !== undefined)
   const isReady = hasAllRunningStatuses || hasRunningStatusTimedOut
 
   const clustersWithIssues = useMemo<ClusterWithHealthIssues[]>(() => {
@@ -186,12 +212,13 @@ export function ClusterProductionHealthSummaryCard({
           cluster,
           deploymentStatus,
           runningStatus,
+          isRunningStatusIssueEnabled,
           hasRunningStatusTimedOut,
         })
         return { cluster, deploymentStatus, issues }
       })
       .filter((entry) => entry.issues.length > 0)
-  }, [clusters, clusterStatuses, runningStatusQueries, hasRunningStatusTimedOut])
+  }, [clusters, clusterStatuses, runningStatusQueries, isRunningStatusIssueEnabled, hasRunningStatusTimedOut])
 
   const issuesCount = clustersWithIssues.length
   const hasIssues = issuesCount > 0
@@ -225,13 +252,14 @@ export function ClusterProductionHealthSummaryCard({
 
   return (
     <>
-      {clusters.map((cluster) => (
-        <ClusterRunningStatusSubscription
-          key={cluster.id}
-          organizationId={cluster.organization.id}
-          clusterId={cluster.id}
-        />
-      ))}
+      {isRunningStatusIssueEnabled &&
+        clusters.map((cluster) => (
+          <ClusterRunningStatusSubscription
+            key={cluster.id}
+            organizationId={cluster.organization.id}
+            clusterId={cluster.id}
+          />
+        ))}
       {!isReady ? (
         <div className="flex w-full items-center gap-3 rounded-lg border border-neutral bg-background p-3">
           <Skeleton height={40} width={40} className="rounded-md" />

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/cluster-production-health-summary-card.tsx
@@ -139,7 +139,7 @@ function getWarningTitle({
 
   return (
     <>
-      {issuesCount} {pluralize(issuesCount, 'cluster', 'clusters')} {pluralize(issuesCount, 'need', 'needs')} attention
+      {issuesCount} {pluralize(issuesCount, 'cluster', 'clusters')} {pluralize(issuesCount, 'needs', 'need')} attention
     </>
   )
 }

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/get-cluster-health-issues.spec.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/get-cluster-health-issues.spec.ts
@@ -52,6 +52,19 @@ describe('getClusterHealthIssues', () => {
     ).toContain('running-error')
   })
 
+  it('ignores running status issues when the running-status feature is disabled', () => {
+    const issues = getClusterHealthIssues({
+      cluster: baseCluster,
+      deploymentStatus: baseDeploymentStatus,
+      runningStatus: { computed_status: { global_status: 'ERROR' } } as unknown as ClusterStatusDto,
+      isRunningStatusIssueEnabled: false,
+      hasRunningStatusTimedOut: true,
+    })
+
+    expect(issues).not.toContain('running-error')
+    expect(issues).not.toContain('status-unavailable')
+  })
+
   it('flags status-unavailable when running status is NotFound', () => {
     expect(
       getClusterHealthIssues({

--- a/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/get-cluster-health-issues.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-production-health-summary-card/get-cluster-health-issues.ts
@@ -67,6 +67,7 @@ export interface GetClusterHealthIssuesInput {
   cluster: Cluster
   deploymentStatus?: ClusterStatus
   runningStatus?: ClusterStatusDto | 'NotFound' | null
+  isRunningStatusIssueEnabled?: boolean
   // True once the running-status websocket has had enough time to report data.
   // When true and runningStatus is still missing, we treat it as unavailable.
   hasRunningStatusTimedOut: boolean
@@ -76,6 +77,7 @@ export function getClusterHealthIssues({
   cluster,
   deploymentStatus,
   runningStatus,
+  isRunningStatusIssueEnabled = true,
   hasRunningStatusTimedOut,
 }: GetClusterHealthIssuesInput): ClusterHealthIssueKind[] {
   const issues: ClusterHealthIssueKind[] = []
@@ -88,7 +90,7 @@ export function getClusterHealthIssues({
     issues.push('deploy-failed')
   }
 
-  if (isDeployed && !isStopped) {
+  if (isRunningStatusIssueEnabled && isDeployed && !isStopped) {
     const isRunningStatusObject = runningStatus && typeof runningStatus === 'object'
 
     if (isRunningStatusObject && runningStatus.computed_status?.global_status === 'ERROR') {

--- a/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.spec.tsx
@@ -75,6 +75,7 @@ describe('SectionProductionHealth', () => {
   it('should render the cluster option cards when no cluster exists', () => {
     renderWithProviders(<SectionProductionHealth />)
 
+    expect(screen.getByRole('heading', { name: 'Production health' })).toBeInTheDocument()
     expect(screen.getByText('Qovery managed')).toBeInTheDocument()
     expect(screen.getByText('Bring your own cluster')).toBeInTheDocument()
     expect(screen.getByText('Local machine (demo)')).toBeInTheDocument()

--- a/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.spec.tsx
@@ -89,6 +89,15 @@ describe('SectionProductionHealth', () => {
     expect(managedLink).toHaveAttribute('data-params', JSON.stringify({ organizationId: 'test-org-id' }))
   })
 
+  it('should keep the all clusters link pointing to the clusters list', () => {
+    renderWithProviders(<SectionProductionHealth />)
+
+    const allClustersLink = screen.getByText('All clusters').closest('a')
+    expect(allClustersLink).toBeInTheDocument()
+    expect(allClustersLink).toHaveAttribute('data-to', '/organization/$organizationId/clusters')
+    expect(allClustersLink).toHaveAttribute('data-params', JSON.stringify({ organizationId: 'test-org-id' }))
+  })
+
   it('should open the add credit card modal from self-managed during free trial restriction', async () => {
     mockUseClusterCreationRestriction.mockReturnValue({ isNoCreditCardRestriction: true })
     const { userEvent } = renderWithProviders(<SectionProductionHealth />)

--- a/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.tsx
+++ b/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.tsx
@@ -173,9 +173,21 @@ export function SectionProductionHealth() {
 
   return (
     <Section className="flex w-full flex-col gap-3">
-      <Heading className="flex items-center gap-2">
-        {clusterProduction.length > 0 ? 'Your production health' : 'Production health'}
-      </Heading>
+      <div className="flex items-center justify-between gap-3">
+        <Heading className="flex items-center gap-2">
+          {clusterProduction.length > 0 ? 'Your production health' : 'Production health'}
+        </Heading>
+        <Link
+          to="/organization/$organizationId/clusters"
+          params={{ organizationId }}
+          color="neutral"
+          size="ssm"
+          className="gap-0.5 text-neutral-subtle hover:text-neutral"
+        >
+          All clusters
+          <Icon iconName="angle-right" iconStyle="regular" />
+        </Link>
+      </div>
       {clusterProduction.length === 0 ? (
         (clusters?.length ?? 0) > 0 ? (
           <EmptyState

--- a/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.tsx
+++ b/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.tsx
@@ -174,9 +174,7 @@ export function SectionProductionHealth() {
   return (
     <Section className="flex w-full flex-col gap-3">
       <div className="flex items-center justify-between gap-3">
-        <Heading className="flex items-center gap-2">
-          {clusterProduction.length > 0 ? 'Your production health' : 'Production health'}
-        </Heading>
+        <Heading className="flex items-center gap-2">Production health</Heading>
         <Link
           to="/organization/$organizationId/clusters"
           params={{ organizationId }}

--- a/libs/domains/environments/feature/src/lib/environment-action-toolbar/environment-action-toolbar.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-action-toolbar/environment-action-toolbar.tsx
@@ -145,7 +145,9 @@ export function MenuManageDeployment({
             <div className="flex h-full w-full items-center justify-center gap-1.5">
               {match(state)
                 .with('DEPLOYING', 'RESTARTING', 'BUILDING', 'DELETING', 'CANCELING', 'STOPPING', () => (
-                  <Icon iconName="loader" className="animate-spin" />
+                  <span className="flex h-4 w-4 items-center justify-center">
+                    <Icon iconName="loader" className="block animate-spin leading-none" />
+                  </span>
                 ))
                 .with('DEPLOYMENT_QUEUED', 'DELETE_QUEUED', 'STOP_QUEUED', 'RESTART_QUEUED', () => (
                   <Icon iconName="clock" iconStyle="regular" />

--- a/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.spec.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.spec.tsx
@@ -132,6 +132,8 @@ describe('EnvironmentDeploymentList', () => {
     expect(screen.getByText('Trigger by')).toBeInTheDocument()
 
     expect(screen.getByText('exec-123')).toBeInTheDocument()
+    expect(screen.getByText(/30 Jan, \d{2}:00/)).toBeInTheDocument()
+    expect(screen.queryByText(/30 Jan, \d{2}:00 [AP]M/)).not.toBeInTheDocument()
     expect(screen.getAllByText('Deploy')[0]).toBeInTheDocument()
     expect(screen.getAllByText('User')[0]).toBeInTheDocument()
   })

--- a/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.spec.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.spec.tsx
@@ -82,6 +82,7 @@ const defaultDeploymentQueue = [
 
 let mockDeploymentHistory = defaultDeploymentHistory
 let mockDeploymentQueue = defaultDeploymentQueue
+const mockNavigate = jest.fn()
 
 jest.mock('../hooks/use-environment/use-environment', () => ({
   useEnvironment: () => ({
@@ -107,7 +108,7 @@ jest.mock('../hooks/use-deployment-queue/use-deployment-queue', () => ({
 jest.mock('@tanstack/react-router', () => {
   return {
     useParams: () => ({ organizationId: '1' }),
-    useNavigate: () => jest.fn(),
+    useNavigate: () => mockNavigate,
     useLocation: () => ({ pathname: '/', search: '' }),
     useRouter: () => ({
       buildLocation: () => ({ href: '/' }),
@@ -118,6 +119,7 @@ jest.mock('@tanstack/react-router', () => {
 
 describe('EnvironmentDeploymentList', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     mockDeploymentHistory = defaultDeploymentHistory
     mockDeploymentQueue = defaultDeploymentQueue
   })
@@ -142,6 +144,22 @@ describe('EnvironmentDeploymentList', () => {
     renderWithProviders(<EnvironmentDeploymentList />)
 
     expect(screen.getAllByText('In queue...')[0]).toBeInTheDocument()
+  })
+
+  it('should navigate to deployment details when clicking a deployment row', async () => {
+    const { userEvent } = renderWithProviders(<EnvironmentDeploymentList />)
+
+    await userEvent.click(screen.getByText('exec-123'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId',
+      params: {
+        organizationId: 'org-123',
+        projectId: 'proj-123',
+        environmentId: 'env-123',
+        deploymentId: 'exec-123',
+      },
+    })
   })
 
   it('should render empty state when no deployment data is available', async () => {

--- a/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
@@ -187,7 +187,9 @@ export function EnvironmentDeploymentList() {
                                   () => <Icon iconName="clock" iconStyle="regular" className="text-current" />
                                 )
                                 .otherwise(() => (
-                                  <Icon iconName="loader" className="animate-spin text-current" />
+                                  <span className="flex h-4 w-4 items-center justify-center">
+                                    <Icon iconName="loader" className="block animate-spin leading-none text-current" />
+                                  </span>
                                 ))}
                             </Tooltip>
                           </Button>

--- a/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
@@ -18,7 +18,7 @@ import {
   type QueuedDeploymentRequestWithStages,
   StateEnum,
 } from 'qovery-typescript-axios'
-import { Fragment, useCallback, useMemo, useState } from 'react'
+import { Fragment, type KeyboardEvent, type MouseEvent, useCallback, useMemo, useState } from 'react'
 import { P, match } from 'ts-pattern'
 // This import introduces a circular dependency with @qovery/shared/devops-copilot/feature.
 // Keep in mind for future refactoring if possible.
@@ -51,6 +51,15 @@ import { DropdownServices } from './dropdown-services/dropdown-services'
 import { TableFilterTriggerBy } from './table-filter-trigger-by/table-filter-trigger-by'
 
 const { Table } = TablePrimitives
+const interactiveRowTargetSelector = 'a,button,input,select,textarea,[role="button"],[role="menuitem"]'
+
+function stopRowNavigation(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) {
+  event.stopPropagation()
+}
+
+function shouldIgnoreRowNavigation(target: EventTarget | null) {
+  return target instanceof HTMLElement && Boolean(target.closest(interactiveRowTargetSelector))
+}
 
 export interface EnvironmentDeploymentListProps {
   environmentId: string
@@ -105,6 +114,7 @@ export function EnvironmentDeploymentList() {
   )
 
   const columnHelper = createColumnHelper<(typeof deploymentHistory | typeof deploymentHistoryQueue)[number]>()
+
   const columns = useMemo(
     () => [
       columnHelper.accessor('auditing_data.created_at', {
@@ -159,7 +169,7 @@ export function EnvironmentDeploymentList() {
                   </span>
                 </div>
               )}
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2" onClick={stopRowNavigation} onKeyDown={stopRowNavigation}>
                 {match(state)
                   .with(
                     'DEPLOYING',
@@ -298,13 +308,15 @@ export function EnvironmentDeploymentList() {
 
           return (
             environment && (
-              <DropdownServices
-                environment={environment}
-                deploymentHistory={data}
-                stages={match(data)
-                  .with(P.when(isDeploymentHistory), (d) => d.stages.filter((stage) => stage.services.length > 0))
-                  .otherwise((d) => d.stages)}
-              />
+              <div onClick={stopRowNavigation} onKeyDown={stopRowNavigation}>
+                <DropdownServices
+                  environment={environment}
+                  deploymentHistory={data}
+                  stages={match(data)
+                    .with(P.when(isDeploymentHistory), (d) => d.stages.filter((stage) => stage.services.length > 0))
+                    .otherwise((d) => d.stages)}
+                />
+              </div>
             )
           )
         },
@@ -425,10 +437,18 @@ export function EnvironmentDeploymentList() {
     )
   }
 
-  const handleRowClick = (row: Row<DeploymentHistoryEnvironmentV2 | QueuedDeploymentRequestWithStages>) => {
+  const getDeploymentExecutionId = (row: Row<DeploymentHistoryEnvironmentV2 | QueuedDeploymentRequestWithStages>) => {
     const data = row.original
+    return isDeploymentHistory(data) ? data.identifier.execution_id : undefined
+  }
 
-    if (!environment || !('execution_id' in data.identifier)) return
+  const handleRowClick = (
+    event: MouseEvent<HTMLElement>,
+    row: Row<DeploymentHistoryEnvironmentV2 | QueuedDeploymentRequestWithStages>
+  ) => {
+    const executionId = getDeploymentExecutionId(row)
+
+    if (!environment || !executionId || shouldIgnoreRowNavigation(event.target)) return
 
     navigate({
       to: '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId',
@@ -436,7 +456,26 @@ export function EnvironmentDeploymentList() {
         organizationId: environment?.organization.id,
         projectId: environment?.project.id,
         environmentId: environment?.id,
-        deploymentId: data.identifier.execution_id,
+        deploymentId: executionId,
+      },
+    })
+  }
+
+  const handleRowKeyDown = (
+    event: KeyboardEvent<HTMLElement>,
+    row: Row<DeploymentHistoryEnvironmentV2 | QueuedDeploymentRequestWithStages>
+  ) => {
+    const executionId = getDeploymentExecutionId(row)
+
+    if (event.key !== 'Enter' || !environment || !executionId || shouldIgnoreRowNavigation(event.target)) return
+
+    navigate({
+      to: '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId',
+      params: {
+        organizationId: environment?.organization.id,
+        projectId: environment?.project.id,
+        environmentId: environment?.id,
+        deploymentId: executionId,
       },
     })
   }
@@ -493,22 +532,35 @@ export function EnvironmentDeploymentList() {
           ))}
         </Table.Header>
         <Table.Body>
-          {table.getRowModel().rows.map((row) => (
-            <Fragment key={row.id}>
-              <Table.Row className="h-[68px] divide-x divide-neutral">
-                {row.getVisibleCells().map((cell) => (
-                  <Table.Cell
-                    key={cell.id}
-                    style={{
-                      width: `${cell.column.getSize()}px`,
-                    }}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </Table.Cell>
-                ))}
-              </Table.Row>
-            </Fragment>
-          ))}
+          {table.getRowModel().rows.map((row) => {
+            const executionId = getDeploymentExecutionId(row)
+
+            return (
+              <Fragment key={row.id}>
+                <Table.Row
+                  role={executionId ? 'link' : undefined}
+                  tabIndex={executionId ? 0 : undefined}
+                  className={twMerge(
+                    'h-[68px] divide-x divide-neutral',
+                    executionId ? 'cursor-pointer hover:bg-surface-neutral-subtle focus:bg-surface-neutral-subtle' : ''
+                  )}
+                  onClick={(event) => handleRowClick(event, row)}
+                  onKeyDown={(event) => handleRowKeyDown(event, row)}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <Table.Cell
+                      key={cell.id}
+                      style={{
+                        width: `${cell.column.getSize()}px`,
+                      }}
+                    >
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </Table.Cell>
+                  ))}
+                </Table.Row>
+              </Fragment>
+            )
+          })}
         </Table.Body>
       </Table.Root>
     </div>

--- a/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
@@ -151,7 +151,7 @@ export function EnvironmentDeploymentList() {
                     {dateFullFormat(
                       isDeploymentHistory(data) ? data.auditing_data.created_at : '',
                       undefined,
-                      'dd MMM, HH:mm a'
+                      'dd MMM, HH:mm'
                     )}
                   </span>
                   <span className="truncate text-ssm text-neutral-subtle">

--- a/libs/domains/observability/feature/src/lib/service/service-dashboard/card-log-errors/card-log-errors.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service/service-dashboard/card-log-errors/card-log-errors.spec.tsx
@@ -165,14 +165,22 @@ describe('CardLogErrors', () => {
     await userEvent.click(button)
 
     expect(mockedNavigate).toHaveBeenCalledWith({
-      to: expect.stringContaining(
-        `/organization/${defaultProps.organizationId}/project/${defaultProps.projectId}/environment/${defaultProps.environmentId}/logs/${defaultProps.serviceId}/service-logs?mode=history&startDate=`
-      ),
+      to: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs',
+      params: {
+        organizationId: defaultProps.organizationId,
+        projectId: defaultProps.projectId,
+        environmentId: defaultProps.environmentId,
+        serviceId: defaultProps.serviceId,
+      },
+      search: expect.objectContaining({
+        mode: 'history',
+        level: 'error',
+      }),
     })
 
-    const navigateUrl = mockedNavigate.mock.calls[0][0].to
-    expect(navigateUrl).toMatch(/startDate=[\d-]+T[\d:.%A-Z]+/)
-    expect(navigateUrl).toMatch(/endDate=[\d-]+T[\d:.%A-Z]+/)
+    const navigateSearch = mockedNavigate.mock.calls[0][0].search
+    expect(navigateSearch.startDate).toMatch(/[\d-]+T[\d:.]+Z/)
+    expect(navigateSearch.endDate).toMatch(/[\d-]+T[\d:.]+Z/)
   })
 
   it('should call useLokiMetrics with correct parameters for short time ranges', () => {

--- a/libs/domains/observability/feature/src/lib/service/service-dashboard/card-log-errors/card-log-errors.tsx
+++ b/libs/domains/observability/feature/src/lib/service/service-dashboard/card-log-errors/card-log-errors.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from '@tanstack/react-router'
-import { ENVIRONMENT_LOGS_URL, SERVICE_LOGS_URL } from '@qovery/shared/routes'
 import { pluralize } from '@qovery/shared/util-js'
 import { useInstantMetrics } from '../../../hooks/use-instant-metrics/use-instant-metrics'
 import { useLokiMetrics } from '../../../hooks/use-loki-metrics/use-loki-metrics'
@@ -69,11 +68,21 @@ export function CardLogErrors({
       isLoading={isLoading}
       icon="scroll"
       onClick={() => {
-        const targetUrl =
-          ENVIRONMENT_LOGS_URL(organizationId, projectId, environmentId) +
-          SERVICE_LOGS_URL(serviceId, undefined, undefined, 'history', startDate, endDate, 'error')
-
-        navigate({ to: targetUrl })
+        navigate({
+          to: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs',
+          params: {
+            organizationId,
+            projectId,
+            environmentId,
+            serviceId,
+          },
+          search: {
+            mode: 'history',
+            startDate,
+            endDate,
+            level: 'error',
+          },
+        })
       }}
     />
   )

--- a/libs/domains/observability/feature/src/lib/service/service-dashboard/card-metric/card-metric.tsx
+++ b/libs/domains/observability/feature/src/lib/service/service-dashboard/card-metric/card-metric.tsx
@@ -1,5 +1,4 @@
 import { type IconName } from '@fortawesome/fontawesome-common-types'
-import clsx from 'clsx'
 import { type ComponentProps } from 'react'
 import { Badge, Button, Heading, Icon, Section, Skeleton, Tooltip } from '@qovery/shared/ui'
 import { twMerge } from '@qovery/shared/util-js'

--- a/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
+++ b/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
@@ -367,7 +367,9 @@ function MenuManageDeployment({
             <div className="flex h-full w-full items-center justify-center gap-1.5">
               {match(state)
                 .with('DEPLOYING', 'RESTARTING', 'BUILDING', 'DELETING', 'CANCELING', 'STOPPING', () => (
-                  <Icon iconName="loader" className="animate-spin" />
+                  <span className="flex h-4 w-4 items-center justify-center">
+                    <Icon iconName="loader" className="block animate-spin leading-none" />
+                  </span>
                 ))
                 .with('DEPLOYMENT_QUEUED', 'DELETE_QUEUED', 'STOP_QUEUED', 'RESTART_QUEUED', () => (
                   <Icon iconName="clock" iconStyle="regular" />

--- a/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.spec.tsx
@@ -1,4 +1,5 @@
 import { type Environment } from 'qovery-typescript-axios'
+import { type ReactNode } from 'react'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { ServiceDeploymentList } from './service-deployment-list'
 
@@ -79,6 +80,18 @@ const defaultDeploymentQueue = [
 
 let mockDeploymentHistory = defaultDeploymentHistory
 let mockDeploymentQueue = defaultDeploymentQueue
+const mockNavigate = jest.fn()
+
+jest.mock('@tanstack/react-router', () => {
+  return {
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: '/', search: '' }),
+    useRouter: () => ({
+      buildLocation: () => ({ href: '/' }),
+    }),
+    Link: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => <a {...props}>{children}</a>,
+  }
+})
 
 jest.mock('../hooks/use-deployment-history/use-deployment-history', () => ({
   useDeploymentHistory: () => ({
@@ -107,6 +120,7 @@ jest.mock('../hooks/use-service/use-service', () => ({
 
 describe('ServiceDeploymentList', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     mockDeploymentHistory = defaultDeploymentHistory
     mockDeploymentQueue = defaultDeploymentQueue
   })
@@ -133,6 +147,25 @@ describe('ServiceDeploymentList', () => {
     renderWithProviders(<ServiceDeploymentList environment={mockEnvironment} serviceId="service-123" />)
 
     expect(screen.getAllByText('In queue...')[0]).toBeInTheDocument()
+  })
+
+  it('should navigate to deployment logs when clicking a deployment row', async () => {
+    const { userEvent } = renderWithProviders(
+      <ServiceDeploymentList environment={mockEnvironment} serviceId="service-123" />
+    )
+
+    await userEvent.click(screen.getByText('exec-123'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/logs/$executionId',
+      params: {
+        organizationId: 'org-123',
+        projectId: 'proj-123',
+        environmentId: 'env-123',
+        serviceId: 'service-123',
+        executionId: 'exec-123',
+      },
+    })
   })
 
   it('should render empty state when no deployment data is available', async () => {

--- a/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.spec.tsx
@@ -121,6 +121,8 @@ describe('ServiceDeploymentList', () => {
     expect(screen.getByText('Trigger by')).toBeInTheDocument()
 
     expect(screen.getByText('exec-123')).toBeInTheDocument()
+    expect(screen.getByText(/23 Jan, \d{2}:55/)).toBeInTheDocument()
+    expect(screen.queryByText(/23 Jan, \d{2}:55 [AP]M/)).not.toBeInTheDocument()
     expect(screen.getAllByText('Deploy')[0]).toBeInTheDocument()
     expect(screen.getByText('version')).toBeInTheDocument()
     expect(screen.getByText('John Doe')).toBeInTheDocument()

--- a/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx
@@ -1,4 +1,6 @@
+import { useNavigate } from '@tanstack/react-router'
 import {
+  type Row,
   type SortingState,
   createColumnHelper,
   flexRender,
@@ -11,7 +13,7 @@ import {
 } from '@tanstack/react-table'
 import clsx from 'clsx'
 import { type DeploymentHistoryService, type Environment, OrganizationEventOrigin } from 'qovery-typescript-axios'
-import { useCallback, useMemo, useState } from 'react'
+import { type KeyboardEvent, type MouseEvent, useCallback, useMemo, useState } from 'react'
 import { P, match } from 'ts-pattern'
 import { DevopsCopilotTroubleshootTrigger } from '@qovery/shared/devops-copilot/feature'
 import { IconEnum } from '@qovery/shared/enums'
@@ -42,6 +44,15 @@ import { ServiceDeploymentListSkeleton } from './service-deployment-list-skeleto
 import { TableFilterTriggerBy } from './table-filter-trigger-by/table-filter-trigger-by'
 
 const { Table } = TablePrimitives
+const interactiveRowTargetSelector = 'a,button,input,select,textarea,[role="button"],[role="menuitem"]'
+
+function stopRowNavigation(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) {
+  event.stopPropagation()
+}
+
+function shouldIgnoreRowNavigation(target: EventTarget | null) {
+  return target instanceof HTMLElement && Boolean(target.closest(interactiveRowTargetSelector))
+}
 
 export interface ServiceDeploymentListProps {
   serviceId: string
@@ -53,6 +64,7 @@ export const isDeploymentHistory = (data: unknown): data is DeploymentHistorySer
 }
 
 export function ServiceDeploymentList({ environment, serviceId }: ServiceDeploymentListProps) {
+  const navigate = useNavigate()
   const { data: service } = useService({ environmentId: environment?.id, serviceId, suspense: true })
 
   const { data: deploymentHistory = [], isFetched: isFetchedDeloymentHistory } = useDeploymentHistory({
@@ -94,6 +106,7 @@ export function ServiceDeploymentList({ environment, serviceId }: ServiceDeploym
   )
 
   const columnHelper = createColumnHelper<(typeof deploymentHistory | typeof deploymentHistoryQueue)[number]>()
+
   const columns = useMemo(
     () => [
       columnHelper.accessor('auditing_data.created_at', {
@@ -136,7 +149,11 @@ export function ServiceDeploymentList({ environment, serviceId }: ServiceDeploym
                   </span>
                 </div>
               )}
-              <div className="flex min-w-28 justify-end gap-1 text-right">
+              <div
+                className="flex min-w-28 justify-end gap-1 text-right"
+                onClick={stopRowNavigation}
+                onKeyDown={stopRowNavigation}
+              >
                 {match(state)
                   .with('ONGOING', 'CANCELING', 'QUEUED', () => (
                     <DropdownMenu.Root>
@@ -477,6 +494,51 @@ export function ServiceDeploymentList({ environment, serviceId }: ServiceDeploym
     )
   }
 
+  const getDeploymentExecutionId = (row: Row<DeploymentHistoryService | (typeof deploymentHistoryQueue)[number]>) => {
+    const data = row.original
+    return isDeploymentHistory(data) ? data.identifier.execution_id : undefined
+  }
+
+  const handleRowClick = (
+    event: MouseEvent<HTMLElement>,
+    row: Row<DeploymentHistoryService | (typeof deploymentHistoryQueue)[number]>
+  ) => {
+    const executionId = getDeploymentExecutionId(row)
+
+    if (!environment || !executionId || shouldIgnoreRowNavigation(event.target)) return
+
+    navigate({
+      to: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/logs/$executionId',
+      params: {
+        organizationId: environment.organization.id,
+        projectId: environment.project.id,
+        environmentId: environment.id,
+        serviceId,
+        executionId,
+      },
+    })
+  }
+
+  const handleRowKeyDown = (
+    event: KeyboardEvent<HTMLElement>,
+    row: Row<DeploymentHistoryService | (typeof deploymentHistoryQueue)[number]>
+  ) => {
+    const executionId = getDeploymentExecutionId(row)
+
+    if (event.key !== 'Enter' || !environment || !executionId || shouldIgnoreRowNavigation(event.target)) return
+
+    navigate({
+      to: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/logs/$executionId',
+      params: {
+        organizationId: environment.organization.id,
+        projectId: environment.project.id,
+        environmentId: environment.id,
+        serviceId,
+        executionId,
+      },
+    })
+  }
+
   return (
     <div className="flex grow flex-col justify-between">
       <Table.Root className="w-full min-w-[1080px] table-fixed overflow-x-scroll text-ssm">
@@ -522,20 +584,34 @@ export function ServiceDeploymentList({ environment, serviceId }: ServiceDeploym
           ))}
         </Table.Header>
         <Table.Body>
-          {table.getRowModel().rows.map((row) => (
-            <Table.Row key={row.id} className="h-[68px] divide-x divide-neutral border-neutral">
-              {row.getVisibleCells().map((cell, i) => (
-                <Table.Cell
-                  key={cell.id}
-                  style={{
-                    width: `${cell.column.getSize()}px`,
-                  }}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </Table.Cell>
-              ))}
-            </Table.Row>
-          ))}
+          {table.getRowModel().rows.map((row) => {
+            const executionId = getDeploymentExecutionId(row)
+
+            return (
+              <Table.Row
+                key={row.id}
+                role={executionId ? 'link' : undefined}
+                tabIndex={executionId ? 0 : undefined}
+                className={twMerge(
+                  'h-[68px] divide-x divide-neutral border-neutral',
+                  executionId ? 'cursor-pointer hover:bg-surface-neutral-subtle focus:bg-surface-neutral-subtle' : ''
+                )}
+                onClick={(event) => handleRowClick(event, row)}
+                onKeyDown={(event) => handleRowKeyDown(event, row)}
+              >
+                {row.getVisibleCells().map((cell, i) => (
+                  <Table.Cell
+                    key={cell.id}
+                    style={{
+                      width: `${cell.column.getSize()}px`,
+                    }}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </Table.Cell>
+                ))}
+              </Table.Row>
+            )
+          })}
         </Table.Body>
       </Table.Root>
     </div>

--- a/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx
@@ -146,7 +146,9 @@ export function ServiceDeploymentList({ environment, serviceId }: ServiceDeploym
                             {match(state)
                               .with('QUEUED', () => <Icon iconName="clock" iconStyle="regular" />)
                               .otherwise(() => (
-                                <Icon iconName="loader" className="animate-spin" />
+                                <span className="flex h-4 w-4 items-center justify-center">
+                                  <Icon iconName="loader" className="block animate-spin leading-none" />
+                                </span>
                               ))}
                           </Tooltip>
                         </Button>

--- a/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx
@@ -128,7 +128,7 @@ export function ServiceDeploymentList({ environment, serviceId }: ServiceDeploym
                     {dateFullFormat(
                       'created_at' in data.auditing_data ? data.auditing_data.created_at : '',
                       undefined,
-                      'dd MMM, HH:mm a'
+                      'dd MMM, HH:mm'
                     )}
                   </span>
                   <span className="truncate text-ssm text-neutral-subtle">

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -20,8 +20,8 @@ export function decodeXmlEntities(value) {
 
 export function decodeHtmlEntities(value) {
   return decodeXmlEntities(value)
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
-    .replace(/&#x([a-f0-9]+);/gi, (_, code) => String.fromCharCode(parseInt(code, 16)))
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([a-f0-9]+);/gi, (_, code) => String.fromCodePoint(parseInt(code, 16)))
     .replace(/&nbsp;/g, ' ')
     .trim()
 }

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 export const CHANGELOG_RSS_FEED_URL = 'https://www.qovery.com/changelog/rss.xml'
+export const CHANGELOG_PAGE_URL = 'https://www.qovery.com/changelog'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 export const CHANGELOG_ASSET_FILE = resolve(__dirname, '../apps/console/public/changelog/latest.json')
 
@@ -14,6 +15,23 @@ export function decodeXmlEntities(value) {
     .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+    .trim()
+}
+
+export function decodeHtmlEntities(value) {
+  return decodeXmlEntities(value)
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&#x([a-f0-9]+);/gi, (_, code) => String.fromCharCode(parseInt(code, 16)))
+    .replace(/&nbsp;/g, ' ')
+    .trim()
+}
+
+export function stripHtmlTags(value) {
+  return decodeHtmlEntities(value)
+    .replace(/<script\b[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
     .trim()
 }
 
@@ -80,6 +98,54 @@ export function parseLatestChangelogFromRssFeed(rssFeed) {
   ]
 }
 
+export function parseLatestChangelogFromHtmlPage(htmlPage) {
+  const changelogLinkRegex = /<a\b[^>]*href=["']([^"']*\/changelog\/\d{4}-\d{2}-\d{2}[^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi
+  const latestLink = changelogLinkRegex.exec(htmlPage)
+
+  if (!latestLink) {
+    return []
+  }
+
+  const [, rawUrl, rawName] = latestLink
+  const url = new URL(decodeHtmlEntities(rawUrl), CHANGELOG_PAGE_URL).href
+  const name = stripHtmlTags(rawName)
+  const firstPublishedAt = extractPublishedAtFromChangelogUrl(url)
+
+  if (!name || !firstPublishedAt) {
+    return []
+  }
+
+  const contentAfterTitle = htmlPage.slice(latestLink.index + latestLink[0].length)
+  const summary = stripHtmlTags(
+    contentAfterTitle
+      .split(/<a\b[^>]*href=["'][^"']*\/changelog\/\d{4}-\d{2}-\d{2}[^"']*["'][^>]*>/i)[0]
+      .split(/Read full release notes/i)[0]
+  )
+
+  return [
+    {
+      name,
+      summary,
+      url,
+      firstPublishedAt,
+    },
+  ]
+}
+
+async function fetchChangelogSource(fetchImpl, url, accept) {
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: accept,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Qovery changelog fetch error for ${url}: ${response.status} ${response.statusText}`)
+  }
+
+  return response.text()
+}
+
 export async function syncChangelogFeed({
   changelogAssetFile = CHANGELOG_ASSET_FILE,
   fetchImpl = fetch,
@@ -87,18 +153,28 @@ export async function syncChangelogFeed({
   consoleWarn = console.warn,
 } = {}) {
   try {
-    const response = await fetchImpl(CHANGELOG_RSS_FEED_URL, {
-      headers: {
-        Accept: 'application/rss+xml, application/xml, text/xml',
-      },
-    })
+    let changelogs = []
 
-    if (!response.ok) {
-      throw new Error(`Qovery changelog RSS error: ${response.status} ${response.statusText}`)
+    try {
+      const rssFeed = await fetchChangelogSource(
+        fetchImpl,
+        CHANGELOG_RSS_FEED_URL,
+        'application/rss+xml, application/xml, text/xml'
+      )
+      changelogs = parseLatestChangelogFromRssFeed(rssFeed)
+    } catch (error) {
+      consoleWarn('Unable to refresh Qovery changelog RSS asset. Falling back to the changelog page.', error)
     }
 
-    const rssFeed = await response.text()
-    const changelogs = parseLatestChangelogFromRssFeed(rssFeed)
+    if (changelogs.length === 0) {
+      const htmlPage = await fetchChangelogSource(fetchImpl, CHANGELOG_PAGE_URL, 'text/html')
+      changelogs = parseLatestChangelogFromHtmlPage(htmlPage)
+    }
+
+    if (changelogs.length === 0) {
+      throw new Error('Qovery changelog sync did not find any changelog entry')
+    }
+
     await writeChangelogAssetFile(changelogs, changelogAssetFile)
     return changelogs
   } catch (error) {


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

- Add "all clusters" link in the organization overview ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1777289637213059)) + fix feature flag ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1777578445871679))
- Add brand color for "update" for the production cluster modal in the organization overview + update modal wording ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1777295511058549))
- Fix link error monitoring card to service logs ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1777539490609739))
- Fix AM/PM for deployment dates ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1777704894666209))
- Fix Changelog generation
- Fix drunk spinner ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1777638650773189))
- Add click on row to access deployment details ([slack](https://qovery.slack.com/archives/C0AML0VDUV8/p1777716630129629))

## Screenshots / Recordings

<img width="873" height="141" alt="Screenshot 2026-04-30 at 16 56 27" src="https://github.com/user-attachments/assets/17c40d19-e4c2-4a42-aefe-720a67453698" />

<img width="967" height="491" alt="Screenshot 2026-04-30 at 16 56 34" src="https://github.com/user-attachments/assets/2930bcc3-8b32-44ef-b626-0b2d3a82591a" />

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
