### PR TITLE
fix(new-nav): look of the "ctrl k" button

### DIFF
--- a/libs/shared/spotlight/feature/src/lib/spotlight-trigger/spotlight-trigger.tsx
+++ b/libs/shared/spotlight/feature/src/lib/spotlight-trigger/spotlight-trigger.tsx
@@ -35,7 +35,7 @@ const SpotlightTriggerBase = ({ organizationId }: { organizationId: string }) =>
         />
         <span className="text-neutral-subtle">Search</span>
         <div className="ml-auto flex gap-1 text-neutral-subtle">
-          <Kbd className="pt-[1px]">{metaKey}</Kbd>
+          <Kbd className={`px-1 pt-[1px] ${metaKey === 'Ctrl' ? 'text-2xs' : 'text-sm'}`}>{metaKey}</Kbd>
           <Kbd>
             <svg xmlns="http://www.w3.org/2000/svg" width="6" height="8" fill="none" viewBox="0 0 6 8">
               <path

--- a/libs/shared/ui/src/lib/components/kbd/kbd.tsx
+++ b/libs/shared/ui/src/lib/components/kbd/kbd.tsx
@@ -8,7 +8,7 @@ export const Kbd = forwardRef<ElementRef<'kbd'>, KbdProps>(function Kbd({ childr
     <kbd
       ref={ref}
       className={twMerge(
-        'flex h-4 w-4 items-center justify-center rounded-sm bg-surface-neutral-component text-xs text-neutral-subtle',
+        'flex h-4 min-w-4 items-center justify-center rounded-sm bg-surface-neutral-component text-xs text-neutral-subtle',
         className
       )}
     >


### PR DESCRIPTION
## Summary

PR fixing the look of the "ctrl K" button.

[Slack thread](https://qovery.slack.com/archives/C0AML0VDUV8/p1777890331242789)

## Screenshots / Recordings

<img width="283" height="59" alt="Screenshot 2026-05-04 at 15 21 34" src="https://github.com/user-attachments/assets/3b767e8d-2462-498a-aedc-92c8c4413220" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
