### PR TITLE
feat(layout): update height calculations for page containers

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/cloud-shell.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/cloud-shell.tsx
@@ -21,7 +21,7 @@ function RouteComponent() {
   }
 
   return (
-    <div className="flex h-[calc(100dvh-108px)] min-h-0 flex-col overflow-hidden bg-background">
+    <div className="flex h-page-container min-h-0 flex-col overflow-hidden bg-background">
       <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
         <ClusterTerminal organizationId={cluster.organization.id} clusterId={cluster.id} />
       </div>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs.tsx
@@ -37,7 +37,7 @@ function RouteComponent() {
   }
 
   return (
-    <div className="flex h-[calc(100dvh-108px)] w-full flex-col overflow-hidden">
+    <div className="flex h-page-container w-full flex-col overflow-hidden">
       {isLogsLoading && !isLogsFetched ? (
         <div className="flex h-full flex-1 flex-col items-center justify-center">
           <div className="flex flex-col items-center justify-center gap-3">

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell.tsx
@@ -44,7 +44,7 @@ function RouteComponent() {
   }
 
   return (
-    <div className="flex h-[calc(100dvh-108px)] min-h-0 flex-col overflow-hidden bg-background">
+    <div className="flex h-page-container min-h-0 flex-col overflow-hidden bg-background">
       <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
         <ServiceTerminal
           organizationId={environment.organization.id}

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/logs/$executionId.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/deployments/logs/$executionId.tsx
@@ -13,7 +13,7 @@ function RouteComponent() {
   return (
     <Suspense
       fallback={
-        <div className="flex h-[calc(100vh-202px)] w-full flex-col justify-center">
+        <div className="flex h-page-container w-full flex-col justify-center">
           <LoaderPlaceholder />
         </div>
       }

--- a/apps/console/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/route.tsx
@@ -507,6 +507,7 @@ function OrganizationRoute() {
     enabled: Boolean(environmentId) && Boolean(serviceId),
   })
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const bannersRef = useRef<HTMLDivElement>(null)
   const assistantAnchorRef = useRef<HTMLDivElement>(null)
   const [devopsCopilotOpen, setDevopsCopilotOpen] = useState(false)
   const sendMessageRef = useRef<((message: string, createNewChat?: boolean) => void) | null>(null)
@@ -556,6 +557,28 @@ function OrganizationRoute() {
   useLayoutEffect(() => {
     scrollContainerRef.current?.scrollTo({ top: 0 })
   }, [location.pathname])
+
+  useLayoutEffect(() => {
+    const scrollContainer = scrollContainerRef.current
+    const banners = bannersRef.current
+
+    if (!scrollContainer || !banners) {
+      return
+    }
+
+    const update = () => {
+      scrollContainer.style.setProperty('--organization-banners-height', `${banners.offsetHeight}px`)
+    }
+
+    const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(update)
+    resizeObserver?.observe(banners)
+    update()
+
+    return () => {
+      resizeObserver?.disconnect()
+      scrollContainer.style.removeProperty('--organization-banners-height')
+    }
+  }, [])
 
   /**
    * Sync the assistant panel's available height with the sticky wrapper's actual top in the viewport.
@@ -637,7 +660,9 @@ function OrganizationRoute() {
           {/* TODO: Conflicts with body main:not(.h-screen, .layout-onboarding) */}
           <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
             <ErrorBoundary>
-              <OrganizationBanners />
+              <div ref={bannersRef}>
+                <OrganizationBanners />
+              </div>
               <Header />
 
               <Suspense fallback={<MainLoader />}>

--- a/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs-content/deployment-logs-content.tsx
+++ b/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs-content/deployment-logs-content.tsx
@@ -163,10 +163,11 @@ export function DeploymentLogsContent({
       .otherwise(() => false)
 
   return (
-    <>
+    <div className="flex h-page-container flex-col overflow-hidden">
       {showBannerNew && (
         <Banner
           color="brand"
+          className="shrink-0"
           buttonLabel="See latest"
           buttonIconRight="arrow-right"
           onClickButton={() =>
@@ -192,9 +193,8 @@ export function DeploymentLogsContent({
         environmentStatus={environmentStatus}
         stage={stageFromServiceId}
         preCheckStage={preCheckStage}
-        hasNewDeploymentBanner={showBannerNew}
       />
-    </>
+    </div>
   )
 }
 

--- a/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/deployment-logs/deployment-logs.tsx
@@ -26,7 +26,7 @@ const WebSocketListenerMemo = memo(MetricsWebSocketListener)
 
 function Loader() {
   return (
-    <div className="flex h-[calc(100vh-125px)] flex-col">
+    <div className="flex h-page-container flex-col">
       <div className="flex h-12 items-center gap-3 border-b border-neutral px-4">
         <Skeleton width={105} height={28} />
         <Skeleton width={124} height={28} />
@@ -34,7 +34,7 @@ function Loader() {
         <Skeleton width={305} height={28} />
       </div>
 
-      <div className="flex h-[calc(100%-48px)] flex-col items-center justify-between">
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-between">
         <div className="flex h-full flex-col items-center justify-center">
           <LoaderPlaceholder />
         </div>

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
@@ -142,7 +142,6 @@ export interface ListDeploymentLogsProps {
   stage?: Stage
   environmentStatus?: EnvironmentStatus
   preCheckStage?: EnvironmentStatusesWithStagesPreCheckStage
-  hasNewDeploymentBanner?: boolean
 }
 
 interface DeploymentLogsHeaderProps {
@@ -236,7 +235,6 @@ interface DeploymentLogsBodyProps {
   environmentStatus?: EnvironmentStatus
   preCheckStage?: EnvironmentStatusesWithStagesPreCheckStage
   deploymentHistory: DeploymentHistoryEnvironmentV2[]
-  hasNewDeploymentBanner: boolean
 }
 
 const PAUSE_SCROLL_THRESHOLD = 80
@@ -248,7 +246,6 @@ function DeploymentLogsBody({
   stage,
   preCheckStage,
   deploymentHistory,
-  hasNewDeploymentBanner,
 }: DeploymentLogsBodyProps) {
   const { hash } = useLocation()
   const { organizationId = '', projectId = '', serviceId = '', executionId = '' } = useParams({ strict: false })
@@ -394,9 +391,6 @@ function DeploymentLogsBody({
     () => (type: FilterType) => columnFilters.some((filter) => filter.value === type),
     [columnFilters]
   )
-  const emptyStateHeightClass = hasNewDeploymentBanner ? 'h-[calc(100vh-201px)]' : 'h-[calc(100vh-161px)]'
-  const logsViewportHeightClass = hasNewDeploymentBanner ? 'h-[calc(100vh-249px)]' : 'h-[calc(100vh-209px)]'
-
   const isLastVersion = deploymentHistory?.[0]?.identifier.execution_id === executionId || !executionId
   const currentDeployment = executionId
     ? deploymentHistory.find((d) => d.identifier.execution_id === executionId)
@@ -435,7 +429,7 @@ function DeploymentLogsBody({
 
   if (!logs || logs.length === 0 || !serviceStatus.is_part_last_deployment) {
     return (
-      <div className={clsx(emptyStateHeightClass, 'w-full')}>
+      <div className="min-h-0 w-full flex-1">
         <div className="flex h-full flex-col items-center justify-between bg-background">
           <div className="flex h-full flex-col items-center justify-center">
             <DeploymentLogsPlaceholder
@@ -527,7 +521,7 @@ function DeploymentLogsBody({
         </div>
       </div>
       <div
-        className={clsx(logsViewportHeightClass, 'w-full overflow-y-scroll')}
+        className="min-h-0 w-full flex-1 overflow-y-scroll"
         ref={refScrollSection}
         onScroll={handleScroll}
         onWheel={(event) => {
@@ -584,7 +578,6 @@ export function ListDeploymentLogs({
   serviceStatus,
   stage,
   preCheckStage,
-  hasNewDeploymentBanner = false,
 }: ListDeploymentLogsProps) {
   const { executionId = '', serviceId = '' } = useParams({ strict: false })
   const { data: deploymentHistory = [] } = useServiceDeploymentHistory({
@@ -594,25 +587,22 @@ export function ListDeploymentLogs({
   })
 
   return (
-    <div className="h-full w-full overflow-hidden">
-      <div className="relative h-full bg-background">
-        <DeploymentLogsHeader
-          environment={environment}
-          serviceStatus={serviceStatus}
-          environmentStatus={environmentStatus}
-          deploymentHistory={deploymentHistory}
-        />
-        <DeploymentLogsBody
-          key={executionId || 'latest'}
-          environment={environment}
-          serviceStatus={serviceStatus}
-          stage={stage}
-          environmentStatus={environmentStatus}
-          preCheckStage={preCheckStage}
-          deploymentHistory={deploymentHistory}
-          hasNewDeploymentBanner={hasNewDeploymentBanner}
-        />
-      </div>
+    <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-background">
+      <DeploymentLogsHeader
+        environment={environment}
+        serviceStatus={serviceStatus}
+        environmentStatus={environmentStatus}
+        deploymentHistory={deploymentHistory}
+      />
+      <DeploymentLogsBody
+        key={executionId || 'latest'}
+        environment={environment}
+        serviceStatus={serviceStatus}
+        stage={stage}
+        environmentStatus={environmentStatus}
+        preCheckStage={preCheckStage}
+        deploymentHistory={deploymentHistory}
+      />
     </div>
   )
 }

--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
@@ -234,104 +234,100 @@ function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; en
     (!isLogsFetched && !isLogsLoading)
   ) {
     return (
-      <div className="w-full">
-        <div>
-          <HeaderServiceLogs logs={logs} isLiveMode={isLiveMode} refetchHistoryLogs={refetchHistoryLogs} />
-          <div className="flex h-[calc(100vh-209px)] flex-col items-center justify-center">
-            <Placeholder
-              environment={environment}
-              hasMetricsEnabled={hasMetricsEnabled}
-              type={isLiveMode ? 'live' : 'history'}
-              isLogsFetched={isLogsFetched}
-              serviceName={service?.name}
-              itemsLength={logs.length}
-              databaseMode={service?.serviceType === 'DATABASE' ? service.mode : undefined}
-            />
-          </div>
+      <div className="flex h-page-container w-full flex-col overflow-hidden">
+        <HeaderServiceLogs logs={logs} isLiveMode={isLiveMode} refetchHistoryLogs={refetchHistoryLogs} />
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
+          <Placeholder
+            environment={environment}
+            hasMetricsEnabled={hasMetricsEnabled}
+            type={isLiveMode ? 'live' : 'history'}
+            isLogsFetched={isLogsFetched}
+            serviceName={service?.name}
+            itemsLength={logs.length}
+            databaseMode={service?.serviceType === 'DATABASE' ? service.mode : undefined}
+          />
         </div>
       </div>
     )
   }
 
   return (
-    <div className="relative w-full">
-      <div>
-        <HeaderServiceLogs logs={logs} isLiveMode={isLiveMode} refetchHistoryLogs={refetchHistoryLogs} />
-        {isLogsLoading && isLiveMode ? (
-          <div className="flex h-[calc(100vh-209px)] flex-col items-center justify-center">
-            <Placeholder
-              environment={environment}
-              hasMetricsEnabled={hasMetricsEnabled}
-              type="live"
-              isLogsFetched={isLogsFetched}
-              serviceName={service?.name}
-              itemsLength={logs.length}
-              databaseMode={service?.serviceType === 'DATABASE' ? service.mode : undefined}
-            />
-          </div>
-        ) : (
-          <div
-            className="h-[calc(100vh-209px)] w-full overflow-y-scroll "
-            ref={refScrollSection}
-            onScroll={handleScroll}
-            onWheel={(event) => {
-              if (!liveLogs || pauseLogs) return
+    <div className="relative flex h-page-container w-full flex-col overflow-hidden">
+      <HeaderServiceLogs logs={logs} isLiveMode={isLiveMode} refetchHistoryLogs={refetchHistoryLogs} />
+      {isLogsLoading && isLiveMode ? (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
+          <Placeholder
+            environment={environment}
+            hasMetricsEnabled={hasMetricsEnabled}
+            type="live"
+            isLogsFetched={isLogsFetched}
+            serviceName={service?.name}
+            itemsLength={logs.length}
+            databaseMode={service?.serviceType === 'DATABASE' ? service.mode : undefined}
+          />
+        </div>
+      ) : (
+        <div
+          className="min-h-0 w-full flex-1 overflow-y-scroll"
+          ref={refScrollSection}
+          onScroll={handleScroll}
+          onWheel={(event) => {
+            if (!liveLogs || pauseLogs) return
 
-              const section = refScrollSection.current
-              if (!section) return
+            const section = refScrollSection.current
+            if (!section) return
 
-              const hasScrollableContent = section.clientHeight !== section.scrollHeight
-              if (!hasScrollableContent) return
+            const hasScrollableContent = section.clientHeight !== section.scrollHeight
+            if (!hasScrollableContent) return
 
-              if (event.deltaY < 0) {
-                accumulatedScrollUp.current += Math.abs(event.deltaY)
-                if (accumulatedScrollUp.current >= PAUSE_SCROLL_THRESHOLD) {
-                  accumulatedScrollUp.current = 0
-                  setPauseLogs(true)
-                }
-              } else {
+            if (event.deltaY < 0) {
+              accumulatedScrollUp.current += Math.abs(event.deltaY)
+              if (accumulatedScrollUp.current >= PAUSE_SCROLL_THRESHOLD) {
                 accumulatedScrollUp.current = 0
+                setPauseLogs(true)
               }
-            }}
+            } else {
+              accumulatedScrollUp.current = 0
+            }
+          }}
+        >
+          {!isLiveMode && hasMoreLogs && historyLogs.length > 0 && (
+            <ShowPreviousLogsButton
+              showPreviousLogs={!hasMoreLogs}
+              setShowPreviousLogs={loadPreviousLogs}
+              setPauseLogs={setPauseLogs}
+            />
+          )}
+          <Table.Root
+            className="w-full border-separate border-spacing-y-0.5 text-xs"
+            containerClassName="rounded-none border-none bg-background"
           >
-            {!isLiveMode && hasMoreLogs && historyLogs.length > 0 && (
-              <ShowPreviousLogsButton
-                showPreviousLogs={!hasMoreLogs}
-                setShowPreviousLogs={loadPreviousLogs}
-                setPauseLogs={setPauseLogs}
-              />
-            )}
-            <Table.Root
-              className="w-full border-separate border-spacing-y-0.5 text-xs"
-              containerClassName="rounded-none border-none bg-background"
-            >
-              <Table.Body className="divide-y-0">
-                {logs.map((log, index) => {
-                  const timestamp = log.timestamp
-                  return (
-                    <MemoizedRowServiceLogs
-                      key={timestamp + index}
-                      service={service}
-                      log={log}
-                      hasMultipleContainers={hasMultipleContainers}
-                      highlightedText={queryParams.message || queryParams.search}
-                    />
-                  )
-                })}
-              </Table.Body>
-            </Table.Root>
-            {isLiveMode ? (
-              isServiceProgressing &&
-              isLogsFetched && <ProgressIndicator pauseLogs={pauseLogs} message="Streaming service logs" />
-            ) : (
-              <div className="h-8" />
-            )}
-          </div>
-        )}
-        {isLiveMode && (
-          <ShowNewLogsButton pauseLogs={pauseLogs} setPauseLogs={setPauseLogs} bufferedLogsCount={bufferedLogsCount} />
-        )}
-      </div>
+            <Table.Body className="divide-y-0">
+              {logs.map((log, index) => {
+                const timestamp = log.timestamp
+                return (
+                  <MemoizedRowServiceLogs
+                    key={timestamp + index}
+                    service={service}
+                    log={log}
+                    hasMultipleContainers={hasMultipleContainers}
+                    highlightedText={queryParams.message || queryParams.search}
+                  />
+                )
+              })}
+            </Table.Body>
+          </Table.Root>
+          {isLiveMode ? (
+            isServiceProgressing &&
+            isLogsFetched && <ProgressIndicator pauseLogs={pauseLogs} message="Streaming service logs" />
+          ) : (
+            <div className="h-8" />
+          )}
+        </div>
+      )}
+      {isLiveMode && (
+        <ShowNewLogsButton pauseLogs={pauseLogs} setPauseLogs={setPauseLogs} bufferedLogsCount={bufferedLogsCount} />
+      )}
     </div>
   )
 }

--- a/libs/domains/service-terraform/feature/src/lib/terraform-resources-section/terraform-resources-section.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-resources-section/terraform-resources-section.tsx
@@ -72,7 +72,7 @@ export function TerraformResourcesSection({ terraformId }: TerraformResourcesSec
   }
 
   return (
-    <div className="flex h-[calc(100dvh-theme(spacing.navbar-height)-4rem)] flex-col gap-4">
+    <div className="flex h-page-container flex-col gap-4">
       {/* Split panel: Tree list (with search) and Details */}
       <div className="flex h-full">
         {/* Left panel: Search + Resource tree list */}

--- a/tailwind-workspace-preset.js
+++ b/tailwind-workspace-preset.js
@@ -85,12 +85,17 @@ module.exports = {
       maxWidth: {
         'content-with-navigation-left': '44.5rem',
       },
+      height: {
+        'page-container':
+          'calc(100dvh - theme(spacing.navbar-height) - theme(spacing.breadcrumb-height) - var(--organization-banners-height, 0px))',
+      },
       minHeight: {
-        'page-container': 'calc(100vh - theme(spacing.navbar-height) - theme(spacing.breadcrumb-height))',
+        'page-container':
+          'calc(100dvh - theme(spacing.navbar-height) - theme(spacing.breadcrumb-height) - var(--organization-banners-height, 0px))',
         'page-container-wbanner':
-          'calc(100vh - theme(spacing.navbar-height) - theme(spacing.breadcrumb-height) - 40px)',
+          'calc(100dvh - theme(spacing.navbar-height) - theme(spacing.breadcrumb-height) - 40px)',
         'page-container-wprogressbar':
-          'calc(100vh - theme(spacing.navbar-height) - theme(spacing.breadcrumb-height) - 6px)',
+          'calc(100dvh - theme(spacing.navbar-height) - theme(spacing.breadcrumb-height) - 6px)',
       },
       fontFamily: {
         sans: ['Roboto', 'Helvetica', 'sans-serif'],


### PR DESCRIPTION
## Summary

Fix double scroll when organization banners are visible on standard-size screens.

The page container height now accounts for the rendered banner height, and logs/cloud-shell views use the shared page-container sizing instead of hardcoded viewport calculations. This keeps service logs, deployment logs, cluster logs, and terminals to a single intended scroll area on smaller screens

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
