### PR TITLE
fix(service): remove suspense from useLifecycleTemplates hook in service creation component

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/new.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/new.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute(
 function ServiceNewContent() {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams({ strict: false })
   const { data: environment } = useEnvironment({ environmentId, suspense: true })
-  const { data: availableTemplates = [] } = useLifecycleTemplates({ environmentId, suspense: true })
+  const { data: availableTemplates = [] } = useLifecycleTemplates({ environmentId })
   const cloudProvider = environment?.cloud_provider?.provider
 
   useDocumentTitle('Create new service - Qovery')


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Align new service creation with staging: lifecycle templates no longer block page rendering, so demo clusters still show the service template list

https://qovery.slack.com/archives/C0AML0VDUV8/p1777973815334849

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
