### PR TITLE
fix(terraform): preserve tf_vars when updating service settings

### DIFF
--- a/libs/domains/services/feature/src/lib/service-general-settings/service-general-settings-payloads.ts
+++ b/libs/domains/services/feature/src/lib/service-general-settings/service-general-settings-payloads.ts
@@ -298,6 +298,6 @@ export const handleTerraformSubmit = (data: TerraformGeneralData, terraform: Ter
   },
   terraform_variables_source: {
     ...terraform.terraform_variables_source,
-    tf_vars: [],
+    tf_vars: terraform.terraform_variables_source?.tf_vars ?? [],
   },
 })


### PR DESCRIPTION
## Summary

**Issue**: Updating settings of a Terraform service was overriding any existing tf_vars.


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
