### PR TITLE
fix(new-nav): "Deploying" text is not visible on Cluster card

### DIFF
--- a/libs/shared/ui/src/lib/components/animated-gradient-text/animated-gradient-text.tsx
+++ b/libs/shared/ui/src/lib/components/animated-gradient-text/animated-gradient-text.tsx
@@ -16,7 +16,7 @@ export function AnimatedGradientText({ children, className, shimmerWidth = 100 }
         } as CSSProperties
       }
       className={twMerge(
-        'from-brand-text via-brand-accent to-brand-text relative inline-flex animate-[shiny-text_3s_linear_infinite] items-center bg-gradient-to-r via-60% bg-clip-text text-transparent [background-position:0_0] [background-size:var(--shimmer-width)_100%]',
+        'relative inline-flex animate-[shiny-text_3s_linear_infinite] items-center bg-gradient-to-r from-[var(--brand-11)] via-[var(--brand-7)] via-60% to-[var(--brand-11)] bg-clip-text text-transparent [background-position:0_0] [background-size:var(--shiny-width)_100%]',
         className
       )}
     >


### PR DESCRIPTION
## Summary

**Issue**: the "deploying" text in the Cluster card was invisible until hovered. This PR fixes that.

[Slack thread](https://qovery.slack.com/archives/C0AML0VDUV8/p1778079187284899) 

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| https://github.com/user-attachments/assets/968c68a2-d905-4edc-bd44-cfa8955e84d0 | <img width="544" height="249" alt="Screenshot 2026-05-07 at 08 41 38" src="https://github.com/user-attachments/assets/bd6db567-3c14-498a-8dd0-a90c7b00ecf7" /> |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
