### PR TITLE
refactor(logs): remove background color from log table rows and update selection color

### DIFF
--- a/libs/domains/environment-logs/feature/src/lib/list-pre-check-logs/row-pre-check-logs/row-pre-check-logs.tsx
+++ b/libs/domains/environment-logs/feature/src/lib/list-pre-check-logs/row-pre-check-logs/row-pre-check-logs.tsx
@@ -17,7 +17,7 @@ export function RowPreCheckLogs({ original }: RowPreCheckLogsProps) {
   const error = type === LogsType.ERROR || step === 'DeployedError'
 
   return (
-    <Table.Row className="mb-0.5 flex min-h-6 select-none bg-surface-neutral text-xs hover:bg-surface-neutral-subtle">
+    <Table.Row className="mb-0.5 flex min-h-6 select-none text-xs hover:bg-surface-neutral-subtle">
       <Table.Cell className="h-6 min-w-10 py-1 pl-2 pr-1 text-left font-code font-bold text-neutral">
         <span className="relative block text-neutral-subtle">{original.id}</span>
       </Table.Cell>

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/row-deployment-logs/row-deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/row-deployment-logs/row-deployment-logs.tsx
@@ -41,7 +41,7 @@ export function RowDeploymentLogs({ original }: RowDeploymentLogsProps) {
     <Table.Row
       id={rowId}
       className={twMerge(
-        clsx('group mb-0.5 flex min-h-6 select-none bg-surface-neutral text-xs', {
+        clsx('group mb-0.5 flex min-h-6 select-none text-xs', {
           'hover:bg-surface-neutral-subtle': !isHighlighted,
           'bg-surface-neutral-componentHover': isHighlighted,
         })

--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/row-service-logs/row-service-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/row-service-logs/row-service-logs.tsx
@@ -104,7 +104,7 @@ export function RowServiceLogs({ log, hasMultipleContainers, highlightedText, se
       <Table.Row
         onClick={() => !isNginx && !isEnvoy && setIsExpanded(!isExpanded)}
         className={twMerge(
-          clsx('sl-row sl-row-appear group relative mt-0.5 cursor-pointer bg-surface-neutral text-xs', {
+          clsx('sl-row sl-row-appear group relative mt-0.5 cursor-pointer text-xs hover:bg-surface-neutral-subtle', {
             'bg-surface-negative-component': isErrorOrCritical,
           })
         )}

--- a/libs/shared/ui/src/lib/styles/main.scss
+++ b/libs/shared/ui/src/lib/styles/main.scss
@@ -87,7 +87,7 @@ body {
   }
 
   ::selection {
-    background: theme('colors.surface.neutral.componentHover');
+    background: theme('colors.surface.info.component');
     color: theme('colors.surface.neutralInvert.DEFAULT');
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary
Fixing the selection color token to make it more obvious and easy to spot. Also removed the useless background class on the logs row. Related [slack thread](https://qovery.slack.com/archives/C0AML0VDUV8/p1778096286917179).

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings
**Before**
<img width="1470" height="829" alt="image" src="https://github.com/user-attachments/assets/760132b6-085e-4dcf-9789-4fe208e6041f" />

**After**
<img width="1469" height="831" alt="image" src="https://github.com/user-attachments/assets/c8ceb562-178a-4bb3-a8be-20d249f35144" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
