### PR TITLE
fix(new-nav): renaming "Cluster logs" tab to "Cluster deployment logs"

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/route.tsx
@@ -86,7 +86,7 @@ const CLUSTER_TABS: NavigationTab[] = [
   },
   {
     id: 'cluster-logs',
-    label: 'Cluster deployment logs',
+    label: 'Cluster Deployment Logs',
     iconName: 'scroll',
     routeId: '/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs',
   },

--- a/apps/console/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/route.tsx
@@ -86,7 +86,7 @@ const CLUSTER_TABS: NavigationTab[] = [
   },
   {
     id: 'cluster-logs',
-    label: 'Cluster Logs',
+    label: 'Cluster deployment logs',
     iconName: 'scroll',
     routeId: '/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs',
   },


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: 
PR that simply renames the "Cluster logs" tab to "Cluster deployment logs"

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
