### PR TITLE
feat(copilot): make feedback buttons visible at all times

### DIFF
--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.spec.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.spec.tsx
@@ -137,13 +137,6 @@ describe('AssistantMessage', () => {
       expect(messageContainer).toBeInTheDocument()
     })
 
-    it('should have invisible vote buttons by default', () => {
-      const { container } = render(<AssistantMessage {...defaultProps} />)
-
-      const voteContainer = container.querySelector('.invisible')
-      expect(voteContainer).toBeInTheDocument()
-    })
-
     it('should apply neutral color to completed step description', () => {
       const completedPlan: PlanStep[] = [
         { messageId: 'msg-1', description: 'Completed step', toolName: 'tool1', status: 'completed' },

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
@@ -24,7 +24,7 @@ function VoteButtons({ messageId }: { messageId: string }) {
   })
 
   return (
-    <div ref={triggerRef} className="invisible mt-2 flex gap-2 text-xs text-neutral-400 group-hover:visible">
+    <div ref={triggerRef} className="mt-2 flex gap-2 text-xs text-neutral-400">
       <Button
         type="button"
         variant="surface"


### PR DESCRIPTION
## Summary

**Issue**: [QOV-1899](https://qovery.atlassian.net/browse/QOV-1899)

The thumb up and thumb down feedback buttons of the AI copilot chat panel were only visible when hovered. We decided to make them visible at all times

## Screenshots / Recordings

<img width="509" height="626" alt="Screenshot 2026-05-07 at 10 44 58" src="https://github.com/user-attachments/assets/e4822bf1-75e1-4c84-8bc0-0455cd4ef841" />

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](htps://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code


[QOV-1899]: https://qovery.atlassian.net/browse/QOV-1899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ