### PR TITLE
fix(services): remove managed MongoDB option from services list

### DIFF
--- a/libs/domains/services/feature/src/lib/service-creation-flow/database/step-general/step-general.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/database/step-general/step-general.spec.tsx
@@ -60,6 +60,13 @@ const databaseConfigurations = [
       { name: '15', supported_mode: 'MANAGED' },
     ],
   },
+  {
+    database_type: 'MONGODB',
+    version: [
+      { name: '6.0', supported_mode: 'CONTAINER' },
+      { name: '5.0', supported_mode: 'MANAGED' },
+    ],
+  },
 ] as DatabaseConfiguration[]
 
 jest.mock('@qovery/shared/assistant/feature', () => ({
@@ -245,5 +252,52 @@ describe('DatabaseStepGeneral', () => {
         })
       )
     })
+  })
+
+  it('resets type and version when switching to managed mode with MongoDB selected', async () => {
+    const { userEvent } = renderComponent({
+      cloudProvider: 'AWS',
+      clusterVpcValue: clusterVpc,
+      generalValues: {
+        mode: DatabaseModeEnum.CONTAINER,
+        type: DatabaseTypeEnum.MONGODB,
+        version: '6.0',
+      },
+    })
+
+    const managedRadio = screen.getByRole('radio', { name: /managed mode/i })
+    await userEvent.click(managedRadio)
+
+    expect(screen.getByLabelText('Database type')).toHaveValue('')
+  })
+
+  it('does not include MongoDB in the database type options when managed mode is selected', async () => {
+    const { userEvent } = renderComponent({
+      cloudProvider: 'AWS',
+      clusterVpcValue: clusterVpc,
+      generalValues: {
+        mode: DatabaseModeEnum.MANAGED,
+      },
+    })
+
+    const typeSelect = screen.getByLabelText('Database type')
+    await userEvent.click(typeSelect)
+
+    expect(screen.queryByRole('option', { name: 'MongoDB' })).not.toBeInTheDocument()
+  })
+
+  it('does include MongoDB in the database type options when container mode is selected', async () => {
+    const { userEvent } = renderComponent({
+      cloudProvider: 'AWS',
+      clusterVpcValue: clusterVpc,
+      generalValues: {
+        mode: DatabaseModeEnum.CONTAINER,
+      },
+    })
+
+    const typeSelect = screen.getByLabelText('Database type')
+    await userEvent.click(typeSelect)
+
+    expect(screen.getByRole('option', { name: 'MongoDB' })).toBeInTheDocument()
   })
 })

--- a/libs/domains/services/feature/src/lib/service-creation-flow/database/step-general/step-general.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/database/step-general/step-general.tsx
@@ -62,14 +62,23 @@ export function DatabaseStepGeneral({
   const watchMode = methods.watch('mode')
   const watchAccessibility = methods.watch('accessibility')
 
-  const databaseOptions = useMemo(
-    () =>
-      generateDatabaseTypeAndVersionOptions(
-        databaseConfigurations,
-        watchMode === DatabaseModeEnum.MANAGED ? clusterVpc : undefined
-      ),
-    [clusterVpc, databaseConfigurations, watchMode]
-  )
+  const databaseOptions = useMemo(() => {
+    const options = generateDatabaseTypeAndVersionOptions(
+      databaseConfigurations,
+      watchMode === DatabaseModeEnum.MANAGED ? clusterVpc : undefined
+    )
+
+    // Filter out MongoDB option for managed mode (not supported)
+    // @see https://qovery.atlassian.net/browse/QOV-1898
+    if (watchMode === DatabaseModeEnum.MANAGED) {
+      return {
+        ...options,
+        databaseTypeOptions: options.databaseTypeOptions.filter(({ value }) => value !== DatabaseTypeEnum.MONGODB),
+      }
+    }
+
+    return options
+  }, [clusterVpc, databaseConfigurations, watchMode])
 
   const showManagedWithVpcOptions =
     generateDatabaseTypeAndVersionOptions(databaseConfigurations, clusterVpc).databaseTypeOptions.length > 0
@@ -162,7 +171,11 @@ export function DatabaseStepGeneral({
                         value={DatabaseModeEnum.MANAGED}
                         name={field.name}
                         description="Managed by your cloud provider. Back-ups and snapshots will be periodically created."
-                        onChange={field.onChange}
+                        onChange={(value) => {
+                          field.onChange(value)
+                          methods.resetField('type', { keepDirty: false, keepTouched: false })
+                          methods.resetField('version')
+                        }}
                         formValue={field.value}
                         label="Managed mode"
                       />

--- a/libs/domains/services/feature/src/lib/service-new/service-templates.ts
+++ b/libs/domains/services/feature/src/lib/service-new/service-templates.ts
@@ -497,15 +497,6 @@ export const serviceTemplates: ServiceTemplateType[] = [
         type: 'DATABASE',
       },
       {
-        slug: 'managed',
-        title: 'Managed',
-        description: 'Create a MongoDB database using a managed service.',
-        icon: AWS,
-        icon_uri: 'app://qovery-console/mongodb',
-        type: 'DATABASE',
-        cloud_provider: 'AWS',
-      },
-      {
         slug: 'terraform',
         template_id: TemplateIds.TERRAFORM,
         badge: 'NEW',

--- a/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-select/input-select.tsx
@@ -121,6 +121,8 @@ export function InputSelect({
     } else {
       if (items && items.length > 0) {
         setSelectedValue(items[0]?.value)
+      } else {
+        setSelectedValue([])
       }
     }
   }, [value, isMulti, options])


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: [QOV-1898](https://qovery.atlassian.net/browse/QOV-1898)

It has been decided to remove the managed MongoDB option from our list of services as stats show no one uses it.

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code


[QOV-1898]: https://qovery.atlassian.net/browse/QOV-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ