### PR TITLE
fix(execution-id): add CopyToClipboardButtonIcon for execution IDs

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/route.tsx
@@ -86,13 +86,13 @@ const CLUSTER_TABS: NavigationTab[] = [
   },
   {
     id: 'cluster-logs',
-    label: 'Cluster deployment logs',
+    label: 'Cluster Deployment Logs',
     iconName: 'scroll',
     routeId: '/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs',
   },
   {
     id: 'cloud-shell',
-    label: 'Cloud shell',
+    label: 'Cloud Shell',
     iconName: 'terminal',
     routeId: '/_authenticated/organization/$organizationId/cluster/$clusterId/cloud-shell',
   },
@@ -113,7 +113,7 @@ const PROJECT_TABS: NavigationTab[] = [
   },
   {
     id: 'deployment-rules',
-    label: 'Deployment rules',
+    label: 'Deployment Rules',
     iconName: 'ruler',
     routeId: '/_authenticated/organization/$organizationId/project/$projectId/deployment-rules',
   },
@@ -175,14 +175,14 @@ const SERVICE_TABS: NavigationTab[] = [
   },
   {
     id: 'service-logs',
-    label: 'Service logs',
+    label: 'Service Logs',
     iconName: 'scroll',
     routeId:
       '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs',
   },
   {
     id: 'cloud-shell',
-    label: 'Cloud shell',
+    label: 'Cloud Shell',
     iconName: 'terminal',
     routeId:
       '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell',

--- a/apps/console/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/route.tsx
@@ -175,7 +175,7 @@ const SERVICE_TABS: NavigationTab[] = [
   },
   {
     id: 'service-logs',
-    label: 'Service Logs',
+    label: 'Service logs',
     iconName: 'scroll',
     routeId:
       '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs',

--- a/apps/console/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/route.tsx
@@ -86,7 +86,7 @@ const CLUSTER_TABS: NavigationTab[] = [
   },
   {
     id: 'cluster-logs',
-    label: 'Cluster Deployment Logs',
+    label: 'Cluster deployment logs',
     iconName: 'scroll',
     routeId: '/_authenticated/organization/$organizationId/cluster/$clusterId/cluster-logs',
   },

--- a/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.tsx
@@ -1,7 +1,7 @@
 import download from 'downloadjs'
 import { type Cluster, type ClusterLogs, type ClusterStatus } from 'qovery-typescript-axios'
 import { type RefObject } from 'react'
-import { Badge, Button, Icon, Tooltip } from '@qovery/shared/ui'
+import { Badge, Button, CopyToClipboardButtonIcon, Icon, Tooltip } from '@qovery/shared/ui'
 import { trimId } from '@qovery/shared/util-js'
 
 export interface ClusterHeaderLogsProps {
@@ -46,9 +46,19 @@ export function ClusterHeaderLogs({ cluster, clusterStatus, refScrollSection, da
           </Badge>
         </Tooltip>
         <Tooltip side="bottom" content={<span>Execution id: {lastExecutionId}</span>}>
-          <span className="flex items-center gap-1.5 truncate">
+          <span className="group flex items-center gap-1 truncate">
             <Icon iconName="code" iconStyle="regular" className="text-sm text-neutral-subtle" />
-            <span className="font-normal text-neutral">{trimId(lastExecutionId)}</span>
+            <span className="flex items-center gap-0.5 truncate">
+              <span className="font-normal text-neutral">{trimId(lastExecutionId)}</span>
+              {lastExecutionId && (
+                <CopyToClipboardButtonIcon
+                  content={lastExecutionId}
+                  tooltipContent="Copy execution id"
+                  className="opacity-0 transition-opacity group-hover:opacity-100"
+                  iconClassName="text-xs"
+                />
+              )}
+            </span>
           </span>
         </Tooltip>
       </div>

--- a/libs/domains/environment-logs/feature/src/lib/environment-stages/environment-stages.tsx
+++ b/libs/domains/environment-logs/feature/src/lib/environment-stages/environment-stages.tsx
@@ -11,6 +11,7 @@ import { type PropsWithChildren } from 'react'
 import { EnvironmentActionToolbar, useDeploymentHistory } from '@qovery/domains/environments/feature'
 import {
   Button,
+  CopyToClipboardButtonIcon,
   DropdownMenu,
   Icon,
   Link,
@@ -99,7 +100,17 @@ export function EnvironmentStages({
                     }}
                   >
                     <Tooltip content={deployment.identifier.execution_id}>
-                      <span>{trimId(deployment.identifier.execution_id ?? '')}</span>
+                      <span className="group flex items-center gap-0.5 truncate">
+                        <span>{trimId(deployment.identifier.execution_id ?? '')}</span>
+                        {deployment.identifier.execution_id && (
+                          <CopyToClipboardButtonIcon
+                            content={deployment.identifier.execution_id}
+                            tooltipContent="Copy execution id"
+                            className="opacity-0 transition-opacity group-hover:opacity-100"
+                            iconClassName="text-xs"
+                          />
+                        )}
+                      </span>
                     </Tooltip>
                     <span className="flex items-center gap-2.5 text-xs text-neutral-subtle">
                       {dateYearMonthDayHourMinuteSecond(new Date(deployment.auditing_data.created_at))}

--- a/libs/domains/environment-logs/feature/src/lib/header-pre-check-logs/header-pre-check-logs.tsx
+++ b/libs/domains/environment-logs/feature/src/lib/header-pre-check-logs/header-pre-check-logs.tsx
@@ -1,7 +1,7 @@
 import { useParams, useRouter } from '@tanstack/react-router'
 import { type EnvironmentStatusesWithStagesPreCheckStage } from 'qovery-typescript-axios'
 import { type PropsWithChildren } from 'react'
-import { Button, Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
+import { Button, CopyToClipboardButtonIcon, Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { trimId, upperCaseFirstLetter } from '@qovery/shared/util-js'
 
 export interface HeaderPreCheckLogsProps extends PropsWithChildren {
@@ -49,9 +49,19 @@ export function HeaderPreCheckLogs({ preCheckStage, children }: HeaderPreCheckLo
             <circle cx="2.5" cy="2.955" r="2.5" fill="var(--neutral-6)"></circle>
           </svg>
           <Tooltip side="bottom" content={<span>Execution id: {deploymentId}</span>}>
-            <span className="flex items-center gap-1.5 truncate">
+            <span className="group flex items-center gap-1 truncate">
               <Icon iconName="code" iconStyle="regular" className="text-sm text-neutral-subtle" />
-              <span className="font-normal text-neutral">{trimId(deploymentId)}</span>
+              <span className="flex items-center gap-0.5 truncate">
+                <span className="font-normal text-neutral">{trimId(deploymentId)}</span>
+                {deploymentId && (
+                  <CopyToClipboardButtonIcon
+                    content={deploymentId}
+                    tooltipContent="Copy execution id"
+                    className="opacity-0 transition-opacity group-hover:opacity-100"
+                    iconClassName="text-xs"
+                  />
+                )}
+              </span>
             </span>
           </Tooltip>
         </div>

--- a/libs/domains/environment-logs/feature/src/lib/list-pre-check-logs/list-pre-check-logs.tsx
+++ b/libs/domains/environment-logs/feature/src/lib/list-pre-check-logs/list-pre-check-logs.tsx
@@ -8,7 +8,17 @@ import {
 } from 'qovery-typescript-axios'
 import { memo, useEffect, useMemo, useRef } from 'react'
 import { useDeploymentHistory } from '@qovery/domains/environments/feature'
-import { Button, DropdownMenu, Icon, Link, LoaderDots, StatusChip, TablePrimitives, Tooltip } from '@qovery/shared/ui'
+import {
+  Button,
+  CopyToClipboardButtonIcon,
+  DropdownMenu,
+  Icon,
+  Link,
+  LoaderDots,
+  StatusChip,
+  TablePrimitives,
+  Tooltip,
+} from '@qovery/shared/ui'
 import { dateYearMonthDayHourMinuteSecond } from '@qovery/shared/util-dates'
 import { trimId } from '@qovery/shared/util-js'
 import { HeaderPreCheckLogs } from '../header-pre-check-logs/header-pre-check-logs'
@@ -121,7 +131,17 @@ export function ListPreCheckLogs({ environment, environmentStatus, preCheckStage
                       replace={true}
                     >
                       <Tooltip content={deployment.identifier.execution_id}>
-                        <span>{trimId(deployment.identifier.execution_id ?? '')}</span>
+                        <span className="group flex items-center gap-0.5 truncate">
+                          <span>{trimId(deployment.identifier.execution_id ?? '')}</span>
+                          {deployment.identifier.execution_id && (
+                            <CopyToClipboardButtonIcon
+                              content={deployment.identifier.execution_id}
+                              tooltipContent="Copy execution id"
+                              className="opacity-0 transition-opacity group-hover:opacity-100"
+                              iconClassName="text-xs"
+                            />
+                          )}
+                        </span>
                       </Tooltip>
                       <span className="flex items-center gap-2.5 text-xs text-neutral-subtle">
                         {dateYearMonthDayHourMinuteSecond(new Date(deployment.auditing_data.created_at))}

--- a/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-deployment-list/environment-deployment-list.tsx
@@ -28,6 +28,7 @@ import { IconEnum } from '@qovery/shared/enums'
 import { ENVIRONMENT_LOGS_URL, ENVIRONMENT_STAGES_URL } from '@qovery/shared/routes'
 import {
   Button,
+  CopyToClipboardButtonIcon,
   DeploymentAction,
   DropdownMenu,
   EmptyState,
@@ -165,8 +166,18 @@ export function EnvironmentDeploymentList() {
                       'dd MMM, HH:mm'
                     )}
                   </span>
-                  <span className="truncate text-ssm text-neutral-subtle">
-                    {isDeploymentHistory(data) ? data.identifier.execution_id : '--'}
+                  <span className="group flex min-w-0 items-center gap-0.5 text-ssm text-neutral-subtle">
+                    <span className="truncate">{isDeploymentHistory(data) ? data.identifier.execution_id : '--'}</span>
+                    {isDeploymentHistory(data) && data.identifier.execution_id && (
+                      <span onClick={stopRowNavigation} onMouseDown={stopRowNavigation} onKeyDown={stopRowNavigation}>
+                        <CopyToClipboardButtonIcon
+                          content={data.identifier.execution_id}
+                          tooltipContent="Copy execution id"
+                          className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                          iconClassName="text-xs"
+                        />
+                      </span>
+                    )}
                   </span>
                 </div>
               )}

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -9,7 +9,7 @@ import {
   useLinks,
   useService,
 } from '@qovery/domains/services/feature'
-import { Button, DeploymentAction, Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
+import { Button, CopyToClipboardButtonIcon, DeploymentAction, Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { dateUTCString } from '@qovery/shared/util-dates'
 import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { pluralize, trimId } from '@qovery/shared/util-js'
@@ -128,9 +128,19 @@ export function HeaderLogs({
                     <circle cx="2.5" cy="2.955" r="2.5" fill="var(--neutral-6)"></circle>
                   </svg>
                   <Tooltip side="bottom" content={<span>Execution id: {executionId}</span>}>
-                    <span className="flex items-center gap-1.5 truncate">
+                    <span className="group flex items-center gap-1 truncate">
                       <Icon iconName="code" iconStyle="regular" className="text-sm text-neutral-subtle" />
-                      <span className="font-normal text-neutral">{trimId(executionId ?? '')}</span>
+                      <span className="flex items-center gap-0.5 truncate">
+                        <span className="font-normal text-neutral">{trimId(executionId ?? '')}</span>
+                        {executionId && (
+                          <CopyToClipboardButtonIcon
+                            content={executionId}
+                            tooltipContent="Copy execution id"
+                            className="opacity-0 transition-opacity group-hover:opacity-100"
+                            iconClassName="text-xs"
+                          />
+                        )}
+                      </span>
                     </span>
                   </Tooltip>
                 </div>
@@ -143,8 +153,16 @@ export function HeaderLogs({
                   {service.name}
                 </span>
                 <Tooltip side="bottom" content={<span>Execution id: {environmentStatus?.last_deployment_id}</span>}>
-                  <span>
+                  <span className="group flex items-center gap-1">
                     <Icon className="text-base text-neutral-subtle" iconName="circle-info" iconStyle="regular" />
+                    {environmentStatus?.last_deployment_id && (
+                      <CopyToClipboardButtonIcon
+                        content={environmentStatus.last_deployment_id}
+                        tooltipContent="Copy execution id"
+                        className="ml-0.5 opacity-0 transition-opacity group-hover:opacity-100"
+                        iconClassName="text-xs"
+                      />
+                    )}
                   </span>
                 </Tooltip>
                 {!isNotDeployedOrStopped && !isManagedDatabase && filteredLinks.length > 0 && (

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/list-deployment-logs.tsx
@@ -23,7 +23,15 @@ import { P, match } from 'ts-pattern'
 import { useDeploymentStatus, useService } from '@qovery/domains/services/feature'
 import { DevopsCopilotContext } from '@qovery/shared/devops-copilot/context'
 import { isHelmRepositorySource, isJobContainerSource } from '@qovery/shared/enums'
-import { Button, DropdownMenu, Icon, StatusChip, TablePrimitives, Tooltip } from '@qovery/shared/ui'
+import {
+  Button,
+  CopyToClipboardButtonIcon,
+  DropdownMenu,
+  Icon,
+  StatusChip,
+  TablePrimitives,
+  Tooltip,
+} from '@qovery/shared/ui'
 import { dateYearMonthDayHourMinuteSecond } from '@qovery/shared/util-dates'
 import { trimId } from '@qovery/shared/util-js'
 import { DeploymentLogsPlaceholder } from '../deployment-logs/deployment-logs-placeholder/deployment-logs-placeholder'
@@ -212,7 +220,17 @@ const DeploymentLogsHeader = memo(function DeploymentLogsHeader({
                   replace={true}
                 >
                   <Tooltip content={deployment.identifier.execution_id}>
-                    <span>{trimId(deployment.identifier.execution_id ?? '')}</span>
+                    <span className="group flex items-center gap-0.5 truncate">
+                      <span>{trimId(deployment.identifier.execution_id ?? '')}</span>
+                      {deployment.identifier.execution_id && (
+                        <CopyToClipboardButtonIcon
+                          content={deployment.identifier.execution_id}
+                          tooltipContent="Copy execution id"
+                          className="opacity-0 transition-opacity group-hover:opacity-100"
+                          iconClassName="text-xs"
+                        />
+                      )}
+                    </span>
                   </Tooltip>
                   <span className="flex items-center gap-2.5 text-xs text-neutral-subtle">
                     {dateYearMonthDayHourMinuteSecond(new Date(deployment.auditing_data.created_at))}

--- a/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-deployment-list/service-deployment-list.tsx
@@ -20,6 +20,7 @@ import { IconEnum } from '@qovery/shared/enums'
 import {
   Button,
   CopyToClipboard,
+  CopyToClipboardButtonIcon,
   DeploymentAction,
   DropdownMenu,
   EmptyState,
@@ -146,8 +147,18 @@ export function ServiceDeploymentList({ environment, serviceId }: ServiceDeploym
                       'dd MMM, HH:mm'
                     )}
                   </span>
-                  <span className="truncate text-ssm text-neutral-subtle">
-                    {isDeploymentHistory(data) ? data.identifier.execution_id : '--'}
+                  <span className="group flex min-w-0 items-center gap-0.5 text-ssm text-neutral-subtle">
+                    <span className="truncate">{isDeploymentHistory(data) ? data.identifier.execution_id : '--'}</span>
+                    {isDeploymentHistory(data) && data.identifier.execution_id && (
+                      <span onClick={stopRowNavigation} onMouseDown={stopRowNavigation} onKeyDown={stopRowNavigation}>
+                        <CopyToClipboardButtonIcon
+                          content={data.identifier.execution_id}
+                          tooltipContent="Copy execution id"
+                          className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                          iconClassName="text-xs"
+                        />
+                      </span>
+                    )}
                   </span>
                 </div>
               )}


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Add execution id copie behavior (asked by backend team)

## Screenshots / Recordings

https://www.loom.com/share/284a824c75754bc3b0c403a6ac946d73?focus_title=1&muted=1&from_recorder=1

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
