### PR TITLE
fix(clusters): front-end not reflecting actual labels_groups value

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
@@ -14,12 +14,19 @@ export const Route = createFileRoute(
 })
 
 const handleSubmit = (data: FieldValues, cluster: Cluster) => {
+  const labelsGroupIds = data['labels_groups']
+  const labels_groups =
+    Array.isArray(labelsGroupIds) && labelsGroupIds.every((id) => typeof id === 'string')
+      ? (labelsGroupIds as string[]).map((id) => ({ id }))
+      : cluster.labels_groups
+
   return {
     ...cluster,
     name: data['name'],
     description: data['description'] || '',
     production: data['production'],
     keda: data.keda ?? cluster.keda,
+    labels_groups,
   }
 }
 
@@ -30,7 +37,12 @@ function ClusterGeneralSettingsForm({ cluster }: { cluster: Cluster }) {
 
   const methods = useForm({
     mode: 'onChange',
-    defaultValues: cluster,
+    defaultValues: {
+      ...cluster,
+      // Form + LabelSetting use string[]; API returns { id }[].
+      labels_groups:
+        cluster.labels_groups?.map((g) => g.id).filter((id): id is string => typeof id === 'string') ?? [],
+    } as FieldValues,
   })
 
   const onSubmit = methods.handleSubmit((data) => {

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useParams } from '@tanstack/react-router'
 import { type Cluster, KubernetesEnum } from 'qovery-typescript-axios'
-import { type FieldValues, FormProvider, useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import { ClusterGeneralSettings, useCluster, useEditCluster } from '@qovery/domains/clusters/feature'
 import { LabelSetting } from '@qovery/domains/organizations/feature'
 import { SettingsHeading } from '@qovery/shared/console-shared'
@@ -16,21 +16,16 @@ export const Route = createFileRoute(
 const isLabelsFieldVisible = (cluster: Cluster) =>
   cluster.cloud_provider === 'AWS' && cluster.kubernetes !== KubernetesEnum.PARTIALLY_MANAGED
 
-const handleSubmit = (data: FieldValues, cluster: Cluster) => {
-  let labels_groups = cluster.labels_groups
-  if (isLabelsFieldVisible(cluster)) {
-    const labelsGroupIds = data['labels_groups']
-    labels_groups =
-      Array.isArray(labelsGroupIds) && labelsGroupIds.every((id) => typeof id === 'string')
-        ? (labelsGroupIds as string[]).map((id) => ({ id }))
-        : cluster.labels_groups
-  }
+type ClusterFormValues = Omit<Cluster, 'labels_groups'> & { labels_groups: string[] }
+
+const handleSubmit = (data: ClusterFormValues, cluster: Cluster) => {
+  const labels_groups = isLabelsFieldVisible(cluster) ? data.labels_groups.map((id) => ({ id })) : cluster.labels_groups
 
   return {
     ...cluster,
-    name: data['name'],
-    description: data['description'] || '',
-    production: data['production'],
+    name: data.name,
+    description: data.description || '',
+    production: data.production,
     keda: data.keda ?? cluster.keda,
     labels_groups,
   }
@@ -41,13 +36,13 @@ function ClusterGeneralSettingsForm({ cluster }: { cluster: Cluster }) {
   const { mutateAsync: editCluster, isLoading: isEditClusterLoading } = useEditCluster()
   const { isQoveryAdminUser } = useUserRole()
 
-  const methods = useForm({
+  const methods = useForm<ClusterFormValues>({
     mode: 'onChange',
     defaultValues: {
       ...cluster,
       // Form + LabelSetting use string[]; API returns { id }[].
       labels_groups: cluster.labels_groups?.map((g) => g.id).filter((id): id is string => typeof id === 'string') ?? [],
-    } as FieldValues,
+    },
   })
 
   const onSubmit = methods.handleSubmit((data) => {

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
@@ -13,12 +13,18 @@ export const Route = createFileRoute(
   component: RouteComponent,
 })
 
+const isLabelsFieldVisible = (cluster: Cluster) =>
+  cluster.cloud_provider === 'AWS' && cluster.kubernetes !== KubernetesEnum.PARTIALLY_MANAGED
+
 const handleSubmit = (data: FieldValues, cluster: Cluster) => {
-  const labelsGroupIds = data['labels_groups']
-  const labels_groups =
-    Array.isArray(labelsGroupIds) && labelsGroupIds.every((id) => typeof id === 'string')
-      ? (labelsGroupIds as string[]).map((id) => ({ id }))
-      : cluster.labels_groups
+  let labels_groups = cluster.labels_groups
+  if (isLabelsFieldVisible(cluster)) {
+    const labelsGroupIds = data['labels_groups']
+    labels_groups =
+      Array.isArray(labelsGroupIds) && labelsGroupIds.every((id) => typeof id === 'string')
+        ? (labelsGroupIds as string[]).map((id) => ({ id }))
+        : cluster.labels_groups
+  }
 
   return {
     ...cluster,
@@ -115,7 +121,7 @@ function ClusterGeneralSettingsForm({ cluster }: { cluster: Cluster }) {
               <BlockContent title="General information">
                 <ClusterGeneralSettings fromDetail />
               </BlockContent>
-              {cluster.cloud_provider === 'AWS' && cluster.kubernetes !== KubernetesEnum.PARTIALLY_MANAGED && (
+              {isLabelsFieldVisible(cluster) && (
                 <Section className="mb-10 gap-3">
                   <Heading>Extra tags</Heading>
                   <LabelSetting filterPropagateToCloudProvider={true} />

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/general.tsx
@@ -40,8 +40,7 @@ function ClusterGeneralSettingsForm({ cluster }: { cluster: Cluster }) {
     defaultValues: {
       ...cluster,
       // Form + LabelSetting use string[]; API returns { id }[].
-      labels_groups:
-        cluster.labels_groups?.map((g) => g.id).filter((id): id is string => typeof id === 'string') ?? [],
+      labels_groups: cluster.labels_groups?.map((g) => g.id).filter((id): id is string => typeof id === 'string') ?? [],
     } as FieldValues,
   })
 

--- a/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/__snapshots__/label-annotation-items-list-modal.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/__snapshots__/label-annotation-items-list-modal.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`LabelAnnotationItemsListModal should match snapshots with annotation 1`
       <h1
         class="font-medium mb-6 text-2xl text-neutral"
       >
-        Associated services (
+        Associated items (
         3
         )
       </h1>
@@ -24,131 +24,142 @@ exports[`LabelAnnotationItemsListModal should match snapshots with annotation 1`
           class="w-full rounded border border-neutral bg-surface-neutral pl-10 pr-6 text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color] h-9 text-sm"
           data-testid="input-search"
           name="search"
-          placeholder="Search by project, environment, service name"
+          placeholder="Search by project, environment, service, or cluster name"
           type="text"
         />
       </div>
       <div
-        class="rounded border border-neutral bg-surface-neutral-subtle px-4 py-2"
-        data-orientation="vertical"
+        class="flex flex-col gap-3"
       >
-        <div
-          class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
-          data-orientation="vertical"
-          data-state="open"
-        >
-          <div
-            class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
+        <div>
+          <h3
+            class="text-sm font-medium mb-2 text-neutral"
           >
-            <button
-              aria-controls="radix-:r7:"
-              aria-expanded="true"
-              class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
-              data-orientation="vertical"
-              data-radix-collection-item=""
-              data-state="open"
-              id="radix-:r6:"
-              type="button"
-            >
-              <i
-                aria-hidden="true"
-                class="fa-regular fa-minus "
-              />
-            </button>
-            Project 1
-          </div>
+            Services
+          </h3>
           <div
-            aria-labelledby="radix-:r6:"
-            class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
+            class="rounded border border-neutral bg-surface-neutral-subtle px-4 py-2"
             data-orientation="vertical"
-            data-state="open"
-            id="radix-:r7:"
-            role="region"
-            style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
           >
             <div
+              class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
               data-orientation="vertical"
+              data-state="open"
             >
               <div
-                class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
+                class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
+              >
+                <button
+                  aria-controls="radix-:r7:"
+                  aria-expanded="true"
+                  class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
+                  data-orientation="vertical"
+                  data-radix-collection-item=""
+                  data-state="open"
+                  id="radix-:r6:"
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="fa-regular fa-minus "
+                  />
+                </button>
+                Project 1
+              </div>
+              <div
+                aria-labelledby="radix-:r6:"
+                class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
                 data-orientation="vertical"
-                data-state="closed"
+                data-state="open"
+                id="radix-:r7:"
+                role="region"
+                style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
               >
                 <div
-                  class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
-                >
-                  <button
-                    aria-controls="radix-:rb:"
-                    aria-expanded="false"
-                    class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
-                    data-orientation="vertical"
-                    data-radix-collection-item=""
-                    data-state="closed"
-                    id="radix-:ra:"
-                    type="button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="fa-regular fa-plus "
-                    />
-                  </button>
-                  <a
-                    class="cursor-pointer transition duration-100 font-medium inline-flex items-center gap-1 text-brand hover:text-brand-hover text-sm"
-                    params="[object Object]"
-                    to="/organization/$organizationId/project/$projectId/environment/$environmentId"
-                  >
-                    Development
-                  </a>
-                </div>
-                <div
-                  aria-labelledby="radix-:ra:"
-                  class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
                   data-orientation="vertical"
-                  data-state="closed"
-                  hidden=""
-                  id="radix-:rb:"
-                  role="region"
-                  style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
-                />
+                >
+                  <div
+                    class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
+                    data-orientation="vertical"
+                    data-state="closed"
+                  >
+                    <div
+                      class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
+                    >
+                      <button
+                        aria-controls="radix-:rb:"
+                        aria-expanded="false"
+                        class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
+                        data-orientation="vertical"
+                        data-radix-collection-item=""
+                        data-state="closed"
+                        id="radix-:ra:"
+                        type="button"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="fa-regular fa-plus "
+                        />
+                      </button>
+                      <a
+                        class="cursor-pointer transition duration-100 font-medium inline-flex items-center gap-1 text-brand hover:text-brand-hover text-sm"
+                        params="[object Object]"
+                        to="/organization/$organizationId/project/$projectId/environment/$environmentId"
+                      >
+                        Development
+                      </a>
+                    </div>
+                    <div
+                      aria-labelledby="radix-:ra:"
+                      class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
+                      data-orientation="vertical"
+                      data-state="closed"
+                      hidden=""
+                      id="radix-:rb:"
+                      role="region"
+                      style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
+                    />
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-        <div
-          class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
-          data-orientation="vertical"
-          data-state="closed"
-        >
-          <div
-            class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
-          >
-            <button
-              aria-controls="radix-:r9:"
-              aria-expanded="false"
-              class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
+            <div
+              class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
               data-orientation="vertical"
-              data-radix-collection-item=""
               data-state="closed"
-              id="radix-:r8:"
-              type="button"
             >
-              <i
-                aria-hidden="true"
-                class="fa-regular fa-plus "
+              <div
+                class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
+              >
+                <button
+                  aria-controls="radix-:r9:"
+                  aria-expanded="false"
+                  class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
+                  data-orientation="vertical"
+                  data-radix-collection-item=""
+                  data-state="closed"
+                  id="radix-:r8:"
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="fa-regular fa-plus "
+                  />
+                </button>
+                Project 2
+              </div>
+              <div
+                aria-labelledby="radix-:r8:"
+                class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
+                data-orientation="vertical"
+                data-state="closed"
+                hidden=""
+                id="radix-:r9:"
+                role="region"
+                style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
               />
-            </button>
-            Project 2
+            </div>
           </div>
-          <div
-            aria-labelledby="radix-:r8:"
-            class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
-            data-orientation="vertical"
-            data-state="closed"
-            hidden=""
-            id="radix-:r9:"
-            role="region"
-            style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
-          />
         </div>
       </div>
     </section>
@@ -165,7 +176,7 @@ exports[`LabelAnnotationItemsListModal should match snapshots with label 1`] = `
       <h1
         class="font-medium mb-6 text-2xl text-neutral"
       >
-        Associated services (
+        Associated items (
         3
         )
       </h1>
@@ -180,131 +191,142 @@ exports[`LabelAnnotationItemsListModal should match snapshots with label 1`] = `
           class="w-full rounded border border-neutral bg-surface-neutral pl-10 pr-6 text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color] h-9 text-sm"
           data-testid="input-search"
           name="search"
-          placeholder="Search by project, environment, service name"
+          placeholder="Search by project, environment, service, or cluster name"
           type="text"
         />
       </div>
       <div
-        class="rounded border border-neutral bg-surface-neutral-subtle px-4 py-2"
-        data-orientation="vertical"
+        class="flex flex-col gap-3"
       >
-        <div
-          class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
-          data-orientation="vertical"
-          data-state="open"
-        >
-          <div
-            class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
+        <div>
+          <h3
+            class="text-sm font-medium mb-2 text-neutral"
           >
-            <button
-              aria-controls="radix-:rj:"
-              aria-expanded="true"
-              class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
-              data-orientation="vertical"
-              data-radix-collection-item=""
-              data-state="open"
-              id="radix-:ri:"
-              type="button"
-            >
-              <i
-                aria-hidden="true"
-                class="fa-regular fa-minus "
-              />
-            </button>
-            Project 1
-          </div>
+            Services
+          </h3>
           <div
-            aria-labelledby="radix-:ri:"
-            class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
+            class="rounded border border-neutral bg-surface-neutral-subtle px-4 py-2"
             data-orientation="vertical"
-            data-state="open"
-            id="radix-:rj:"
-            role="region"
-            style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
           >
             <div
+              class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
               data-orientation="vertical"
+              data-state="open"
             >
               <div
-                class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
+                class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
+              >
+                <button
+                  aria-controls="radix-:rj:"
+                  aria-expanded="true"
+                  class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
+                  data-orientation="vertical"
+                  data-radix-collection-item=""
+                  data-state="open"
+                  id="radix-:ri:"
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="fa-regular fa-minus "
+                  />
+                </button>
+                Project 1
+              </div>
+              <div
+                aria-labelledby="radix-:ri:"
+                class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
                 data-orientation="vertical"
-                data-state="closed"
+                data-state="open"
+                id="radix-:rj:"
+                role="region"
+                style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
               >
                 <div
-                  class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
-                >
-                  <button
-                    aria-controls="radix-:rn:"
-                    aria-expanded="false"
-                    class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
-                    data-orientation="vertical"
-                    data-radix-collection-item=""
-                    data-state="closed"
-                    id="radix-:rm:"
-                    type="button"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="fa-regular fa-plus "
-                    />
-                  </button>
-                  <a
-                    class="cursor-pointer transition duration-100 font-medium inline-flex items-center gap-1 text-brand hover:text-brand-hover text-sm"
-                    params="[object Object]"
-                    to="/organization/$organizationId/project/$projectId/environment/$environmentId"
-                  >
-                    Development
-                  </a>
-                </div>
-                <div
-                  aria-labelledby="radix-:rm:"
-                  class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
                   data-orientation="vertical"
-                  data-state="closed"
-                  hidden=""
-                  id="radix-:rn:"
-                  role="region"
-                  style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
-                />
+                >
+                  <div
+                    class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
+                    data-orientation="vertical"
+                    data-state="closed"
+                  >
+                    <div
+                      class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
+                    >
+                      <button
+                        aria-controls="radix-:rn:"
+                        aria-expanded="false"
+                        class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
+                        data-orientation="vertical"
+                        data-radix-collection-item=""
+                        data-state="closed"
+                        id="radix-:rm:"
+                        type="button"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="fa-regular fa-plus "
+                        />
+                      </button>
+                      <a
+                        class="cursor-pointer transition duration-100 font-medium inline-flex items-center gap-1 text-brand hover:text-brand-hover text-sm"
+                        params="[object Object]"
+                        to="/organization/$organizationId/project/$projectId/environment/$environmentId"
+                      >
+                        Development
+                      </a>
+                    </div>
+                    <div
+                      aria-labelledby="radix-:rm:"
+                      class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
+                      data-orientation="vertical"
+                      data-state="closed"
+                      hidden=""
+                      id="radix-:rn:"
+                      role="region"
+                      style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
+                    />
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-        <div
-          class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
-          data-orientation="vertical"
-          data-state="closed"
-        >
-          <div
-            class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
-          >
-            <button
-              aria-controls="radix-:rl:"
-              aria-expanded="false"
-              class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
+            <div
+              class="mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b"
               data-orientation="vertical"
-              data-radix-collection-item=""
               data-state="closed"
-              id="radix-:rk:"
-              type="button"
             >
-              <i
-                aria-hidden="true"
-                class="fa-regular fa-plus "
+              <div
+                class="flex w-full items-center py-2 pr-5 text-sm text-neutral outline-none"
+              >
+                <button
+                  aria-controls="radix-:rl:"
+                  aria-expanded="false"
+                  class="mr-4 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-neutral text-3xs"
+                  data-orientation="vertical"
+                  data-radix-collection-item=""
+                  data-state="closed"
+                  id="radix-:rk:"
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="fa-regular fa-plus "
+                  />
+                </button>
+                Project 2
+              </div>
+              <div
+                aria-labelledby="radix-:rk:"
+                class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
+                data-orientation="vertical"
+                data-state="closed"
+                hidden=""
+                id="radix-:rl:"
+                role="region"
+                style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
               />
-            </button>
-            Project 2
+            </div>
           </div>
-          <div
-            aria-labelledby="radix-:rk:"
-            class="data-[state=closed]:slidein-up-sm-faded ml-2 overflow-hidden border-l border-neutral pl-[26px] data-[state=open]:animate-slidein-down-sm-faded retina:border-l-[0.5px]"
-            data-orientation="vertical"
-            data-state="closed"
-            hidden=""
-            id="radix-:rl:"
-            role="region"
-            style="--radix-accordion-content-height: var(--radix-collapsible-content-height); --radix-accordion-content-width: var(--radix-collapsible-content-width);"
-          />
         </div>
       </div>
     </section>

--- a/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/__snapshots__/label-annotation-items-list-modal.spec.tsx.snap
+++ b/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/__snapshots__/label-annotation-items-list-modal.spec.tsx.snap
@@ -9,7 +9,9 @@ exports[`LabelAnnotationItemsListModal should match snapshots with annotation 1`
       <h1
         class="font-medium mb-6 text-2xl text-neutral"
       >
-        Associated items (
+        Associated 
+        items
+         (
         3
         )
       </h1>
@@ -176,7 +178,9 @@ exports[`LabelAnnotationItemsListModal should match snapshots with label 1`] = `
       <h1
         class="font-medium mb-6 text-2xl text-neutral"
       >
-        Associated items (
+        Associated 
+        items
+         (
         3
         )
       </h1>

--- a/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.spec.tsx
@@ -152,7 +152,7 @@ describe('LabelAnnotationItemsListModal', () => {
 
     renderWithProviders(<LabelAnnotationItemsListModal {...props} type="annotation" associatedItemsCount={1} />)
 
-    expect(screen.getByRole('heading', { name: /associated items \(1\)/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /associated item \(1\)/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /^clusters$/i })).toBeInTheDocument()
     expect(screen.getByText('cluster-for-obs-team')).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^services$/i })).not.toBeInTheDocument()

--- a/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.spec.tsx
@@ -5,6 +5,8 @@ import * as useLabelsGroupAssociatedItems from '../hooks/use-labels-group-associ
 import {
   LabelAnnotationItemsListModal,
   type LabelAnnotationItemsListModalProps,
+  filterClustersForAssociatedItemsModal,
+  getServiceAssociatedItems,
   groupByProjectEnvironmentsServices,
 } from './label-annotation-items-list-modal'
 
@@ -56,8 +58,23 @@ const data: OrganizationAnnotationsGroupAssociatedItemsResponseListResultsInner[
   },
 ]
 
+const clusterOnlyData: OrganizationAnnotationsGroupAssociatedItemsResponseListResultsInner[] = [
+  {
+    cluster_id: null,
+    cluster_name: null,
+    project_id: null,
+    project_name: null,
+    environment_id: null,
+    environment_name: null,
+    item_id: '3f50657b-1162-4dde-b706-4d5e937f3c09',
+    item_name: 'cluster-for-obs-team',
+    item_type: 'CLUSTER',
+  },
+]
+
 describe('LabelAnnotationItemsListModal', () => {
   beforeEach(() => {
+    props.type = 'annotation'
     useAnnotationsGroupAssociatedItemsSpy.mockReturnValue({
       data,
     })
@@ -100,8 +117,7 @@ describe('LabelAnnotationItemsListModal', () => {
   })
 
   it('should match snapshots with label', async () => {
-    props.type = 'label'
-    const { baseElement, userEvent } = renderWithProviders(<LabelAnnotationItemsListModal {...props} />)
+    const { baseElement, userEvent } = renderWithProviders(<LabelAnnotationItemsListModal {...props} type="label" />)
 
     const triggers = screen.getAllByRole('button')
     screen.getByText(/project 1/i)
@@ -111,5 +127,34 @@ describe('LabelAnnotationItemsListModal', () => {
     await userEvent.click(triggerEnvironment!)
 
     expect(baseElement).toMatchSnapshot()
+  })
+
+  it('should exclude CLUSTER rows when grouping services', () => {
+    const mixed = [...data, ...clusterOnlyData]
+    const result = groupByProjectEnvironmentsServices(getServiceAssociatedItems(mixed))
+
+    expect(result).toHaveLength(2)
+    expect(result[0].environments[0].services).toHaveLength(2)
+  })
+
+  it('should filter clusters by item_name for search', () => {
+    expect(filterClustersForAssociatedItemsModal(clusterOnlyData, 'obs')).toHaveLength(1)
+    expect(filterClustersForAssociatedItemsModal(clusterOnlyData, 'nomatch')).toHaveLength(0)
+  })
+
+  it('should render only clusters section and cluster name for CLUSTER-only payload', () => {
+    useAnnotationsGroupAssociatedItemsSpy.mockReturnValue({
+      data: clusterOnlyData,
+    })
+    useLabelsGroupAssociatedItemsSpy.mockReturnValue({
+      data: clusterOnlyData,
+    })
+
+    renderWithProviders(<LabelAnnotationItemsListModal {...props} type="annotation" associatedItemsCount={1} />)
+
+    expect(screen.getByRole('heading', { name: /associated items \(1\)/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^clusters$/i })).toBeInTheDocument()
+    expect(screen.getByText('cluster-for-obs-team')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^services$/i })).not.toBeInTheDocument()
   })
 })

--- a/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.tsx
@@ -2,8 +2,9 @@ import {
   type AnnotationsGroupAssociatedItemType,
   type OrganizationAnnotationsGroupAssociatedItemsResponseListResultsInner,
 } from 'qovery-typescript-axios'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { match } from 'ts-pattern'
+import { IconEnum } from '@qovery/shared/enums'
 import { Heading, Icon, InputSearch, Link, LoaderSpinner, Section, TreeView } from '@qovery/shared/ui'
 import { useAnnotationsGroupAssociatedItems } from '../hooks/use-annotations-group-associated-items/use-annotations-group-associated-items'
 import { useLabelsGroupAssociatedItems } from '../hooks/use-labels-group-associated-items/use-labels-group-associated-items'
@@ -77,6 +78,35 @@ export function groupByProjectEnvironmentsServices(
   return projects
 }
 
+function isClusterAssociatedItem(item: OrganizationAnnotationsGroupAssociatedItemsResponseListResultsInner): boolean {
+  return item.item_type === 'CLUSTER'
+}
+
+export function getServiceAssociatedItems(
+  data: OrganizationAnnotationsGroupAssociatedItemsResponseListResultsInner[]
+): OrganizationAnnotationsGroupAssociatedItemsResponseListResultsInner[] {
+  return data.filter((item) => !isClusterAssociatedItem(item))
+}
+
+export function filterClustersForAssociatedItemsModal(
+  data: OrganizationAnnotationsGroupAssociatedItemsResponseListResultsInner[],
+  searchValue?: string
+): OrganizationAnnotationsGroupAssociatedItemsResponseListResultsInner[] {
+  return data.filter((item) => {
+    if (!isClusterAssociatedItem(item)) {
+      return false
+    }
+    if (searchValue === undefined || searchValue === '') {
+      return true
+    }
+    const search = searchValue.toLowerCase()
+    return (
+      (item.item_name?.toLowerCase().includes(search) ?? false) ||
+      (item.cluster_name?.toLowerCase().includes(search) ?? false)
+    )
+  })
+}
+
 export interface LabelAnnotationItemsListModalProps {
   type: 'label' | 'annotation'
   organizationId: string
@@ -105,17 +135,45 @@ export function LabelAnnotationItemsListModal({
     })
 
   const [searchValue, setSearchValue] = useState<string | undefined>()
+  const normalizedSearch = searchValue?.trim() || undefined
 
-  const data = groupByProjectEnvironmentsServices(
-    type === 'label' ? labelsGroupAssociatedItems : annotationsGroupAssociatedItems,
-    searchValue
+  const rawItems = useMemo(
+    () => (type === 'label' ? labelsGroupAssociatedItems : annotationsGroupAssociatedItems),
+    [type, labelsGroupAssociatedItems, annotationsGroupAssociatedItems]
   )
 
-  const isLoading = type === 'label' ? labelsGroupIsLoading : annotationsGroupIsLoading
+  const serviceSourceItems = getServiceAssociatedItems(rawItems)
+  const clusterSourceItems = filterClustersForAssociatedItemsModal(rawItems)
+
+  const serviceTreeData = useMemo(
+    () => groupByProjectEnvironmentsServices(serviceSourceItems, normalizedSearch),
+    [serviceSourceItems, normalizedSearch]
+  )
+  const clusterRows = useMemo(
+    () => filterClustersForAssociatedItemsModal(rawItems, normalizedSearch),
+    [rawItems, normalizedSearch]
+  )
+
+  const hasServicesInSource = useMemo(() => serviceSourceItems.length > 0, [serviceSourceItems])
+  const hasClustersInSource = useMemo(() => clusterSourceItems.length > 0, [clusterSourceItems])
+  const hasAnySource = useMemo(
+    () => hasServicesInSource || hasClustersInSource,
+    [hasServicesInSource, hasClustersInSource]
+  )
+
+  const noSearchResults = useMemo(
+    () => Boolean(normalizedSearch) && hasAnySource && serviceTreeData.length === 0 && clusterRows.length === 0,
+    [normalizedSearch, hasAnySource, serviceTreeData.length, clusterRows.length]
+  )
+
+  const isLoading = useMemo(
+    () => (type === 'label' ? labelsGroupIsLoading : annotationsGroupIsLoading),
+    [type, labelsGroupIsLoading, annotationsGroupIsLoading]
+  )
 
   return (
     <Section className="p-6">
-      <Heading className="mb-6 text-2xl text-neutral">Associated services ({associatedItemsCount})</Heading>
+      <Heading className="mb-6 text-2xl text-neutral">Associated items ({associatedItemsCount})</Heading>
       {isLoading ? (
         <div className="flex h-40 items-start justify-center p-5">
           <LoaderSpinner className="w-5" />
@@ -124,77 +182,126 @@ export function LabelAnnotationItemsListModal({
         <>
           <InputSearch
             className="mb-3"
-            placeholder="Search by project, environment, service name"
+            placeholder="Search by project, environment, service, or cluster name"
             onChange={(value) => setSearchValue(value)}
           />
-          {data.length > 0 ? (
-            <TreeView.Root
-              type="single"
-              collapsible
-              className="rounded border border-neutral bg-surface-neutral-subtle px-4 py-2"
-            >
-              {data.map((project) => (
-                <TreeView.Item key={project.project_id} value={project.project_name}>
-                  <TreeView.Trigger>{project.project_name}</TreeView.Trigger>
-                  <TreeView.Content>
-                    {project.environments.map((environment) => (
-                      <TreeView.Root key={environment.environment_id} type="single" collapsible>
-                        <TreeView.Item value={environment.environment_name}>
-                          <TreeView.Trigger>
-                            <Link
-                              color="brand"
-                              onClick={() => onClose()}
-                              to="/organization/$organizationId/project/$projectId/environment/$environmentId"
-                              params={{
-                                organizationId,
-                                environmentId: environment.environment_id,
-                                projectId: project.project_id,
-                              }}
-                              className="text-sm"
-                            >
-                              {environment.environment_name}
-                            </Link>
-                          </TreeView.Trigger>
-                          <TreeView.Content>
-                            <ul>
-                              {environment.services.map((service) => (
-                                <li key={service.service_id} className=" border-l border-neutral">
-                                  <Link
-                                    color="brand"
-                                    onClick={() => onClose()}
-                                    to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId"
-                                    params={{
-                                      organizationId,
-                                      environmentId: environment.environment_id,
-                                      serviceId: service.service_id,
-                                      projectId: project.project_id,
-                                    }}
-                                    className="flex items-center py-1.5 pl-5 text-sm"
-                                  >
-                                    <Icon
-                                      name={match(service.service_type)
-                                        .with('CRON', 'LIFECYCLE', () => `${service.service_type}_JOB`)
-                                        .otherwise(() => service.service_type)}
-                                      width={20}
-                                      className="mr-2"
-                                    />
-                                    {service.service_name}
-                                  </Link>
-                                </li>
-                              ))}
-                            </ul>
-                          </TreeView.Content>
-                        </TreeView.Item>
-                      </TreeView.Root>
-                    ))}
-                  </TreeView.Content>
-                </TreeView.Item>
-              ))}
-            </TreeView.Root>
-          ) : (
+          {noSearchResults ? (
             <div className="px-5 py-4 text-center">
               <Icon iconName="wave-pulse" className="text-neutral-subtle" />
               <p className="mt-1 text-xs font-medium text-neutral-subtle">No value found</p>
+            </div>
+          ) : !hasAnySource ? (
+            <div className="px-5 py-4 text-center">
+              <Icon iconName="wave-pulse" className="text-neutral-subtle" />
+              <p className="mt-1 text-xs font-medium text-neutral-subtle">No value found</p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {hasClustersInSource ? (
+                <div>
+                  <Heading level={3} className="mb-2 text-neutral">
+                    Clusters
+                  </Heading>
+                  {clusterRows.length > 0 ? (
+                    <ul className="rounded border border-neutral bg-surface-neutral-subtle px-4 py-2">
+                      {clusterRows.map((cluster) => {
+                        const clusterId = cluster.cluster_id ?? cluster.item_id
+                        const displayName = cluster.cluster_name ?? cluster.item_name
+                        return (
+                          <li key={cluster.item_id} className="border-b border-neutral last:border-b-0">
+                            <Link
+                              color="brand"
+                              onClick={() => onClose()}
+                              to="/organization/$organizationId/cluster/$clusterId/overview"
+                              params={{ organizationId, clusterId }}
+                              className="flex items-center py-2 text-sm"
+                            >
+                              <Icon name={IconEnum.KUBERNETES} width={20} className="mr-2" />
+                              {displayName}
+                            </Link>
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  ) : (
+                    <p className="text-xs text-neutral-subtle">No matching clusters.</p>
+                  )}
+                </div>
+              ) : null}
+              {hasServicesInSource ? (
+                <div>
+                  <Heading level={3} className="mb-2 text-neutral">
+                    Services
+                  </Heading>
+                  {serviceTreeData.length > 0 ? (
+                    <TreeView.Root
+                      type="single"
+                      collapsible
+                      className="rounded border border-neutral bg-surface-neutral-subtle px-4 py-2"
+                    >
+                      {serviceTreeData.map((project) => (
+                        <TreeView.Item key={project.project_id} value={project.project_name}>
+                          <TreeView.Trigger>{project.project_name}</TreeView.Trigger>
+                          <TreeView.Content>
+                            {project.environments.map((environment) => (
+                              <TreeView.Root key={environment.environment_id} type="single" collapsible>
+                                <TreeView.Item value={environment.environment_name}>
+                                  <TreeView.Trigger>
+                                    <Link
+                                      color="brand"
+                                      onClick={() => onClose()}
+                                      to="/organization/$organizationId/project/$projectId/environment/$environmentId"
+                                      params={{
+                                        organizationId,
+                                        environmentId: environment.environment_id,
+                                        projectId: project.project_id,
+                                      }}
+                                      className="text-sm"
+                                    >
+                                      {environment.environment_name}
+                                    </Link>
+                                  </TreeView.Trigger>
+                                  <TreeView.Content>
+                                    <ul>
+                                      {environment.services.map((service) => (
+                                        <li key={service.service_id} className=" border-l border-neutral">
+                                          <Link
+                                            color="brand"
+                                            onClick={() => onClose()}
+                                            to="/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId"
+                                            params={{
+                                              organizationId,
+                                              environmentId: environment.environment_id,
+                                              serviceId: service.service_id,
+                                              projectId: project.project_id,
+                                            }}
+                                            className="flex items-center py-1.5 pl-5 text-sm"
+                                          >
+                                            <Icon
+                                              name={match(service.service_type)
+                                                .with('CRON', 'LIFECYCLE', () => `${service.service_type}_JOB`)
+                                                .otherwise(() => service.service_type)}
+                                              width={20}
+                                              className="mr-2"
+                                            />
+                                            {service.service_name}
+                                          </Link>
+                                        </li>
+                                      ))}
+                                    </ul>
+                                  </TreeView.Content>
+                                </TreeView.Item>
+                              </TreeView.Root>
+                            ))}
+                          </TreeView.Content>
+                        </TreeView.Item>
+                      ))}
+                    </TreeView.Root>
+                  ) : (
+                    <p className="text-xs text-neutral-subtle">No matching services.</p>
+                  )}
+                </div>
+              ) : null}
             </div>
           )}
         </>

--- a/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from 'react'
 import { match } from 'ts-pattern'
 import { IconEnum } from '@qovery/shared/enums'
 import { Heading, Icon, InputSearch, Link, LoaderSpinner, Section, TreeView } from '@qovery/shared/ui'
+import { pluralize } from '@qovery/shared/util-js'
 import { useAnnotationsGroupAssociatedItems } from '../hooks/use-annotations-group-associated-items/use-annotations-group-associated-items'
 import { useLabelsGroupAssociatedItems } from '../hooks/use-labels-group-associated-items/use-labels-group-associated-items'
 
@@ -163,7 +164,9 @@ export function LabelAnnotationItemsListModal({
 
   return (
     <Section className="p-6">
-      <Heading className="mb-6 text-2xl text-neutral">Associated items ({associatedItemsCount})</Heading>
+      <Heading className="mb-6 text-2xl text-neutral">
+        Associated {pluralize(associatedItemsCount, 'item')} ({associatedItemsCount})
+      </Heading>
       {isLoading ? (
         <div className="flex h-40 items-start justify-center p-5">
           <LoaderSpinner className="w-5" />

--- a/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.tsx
@@ -208,7 +208,7 @@ export function LabelAnnotationItemsListModal({
                         const clusterId = cluster.cluster_id ?? cluster.item_id
                         const displayName = cluster.cluster_name ?? cluster.item_name
                         return (
-                          <li key={cluster.item_id} className="border-b border-neutral last:border-b-0">
+                          <li key={cluster.item_id}>
                             <Link
                               color="brand"
                               onClick={() => onClose()}
@@ -224,7 +224,7 @@ export function LabelAnnotationItemsListModal({
                       })}
                     </ul>
                   ) : (
-                    <p className="text-xs text-neutral-subtle">No matching clusters.</p>
+                    <p className="mb-2 text-xs text-neutral-subtle">No matching clusters.</p>
                   )}
                 </div>
               ) : null}

--- a/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/label-annotation-items-list-modal/label-annotation-items-list-modal.tsx
@@ -142,8 +142,8 @@ export function LabelAnnotationItemsListModal({
     [type, labelsGroupAssociatedItems, annotationsGroupAssociatedItems]
   )
 
-  const serviceSourceItems = getServiceAssociatedItems(rawItems)
-  const clusterSourceItems = filterClustersForAssociatedItemsModal(rawItems)
+  const serviceSourceItems = useMemo(() => getServiceAssociatedItems(rawItems), [rawItems])
+  const clusterSourceItems = useMemo(() => filterClustersForAssociatedItemsModal(rawItems), [rawItems])
 
   const serviceTreeData = useMemo(
     () => groupByProjectEnvironmentsServices(serviceSourceItems, normalizedSearch),
@@ -154,22 +154,12 @@ export function LabelAnnotationItemsListModal({
     [rawItems, normalizedSearch]
   )
 
-  const hasServicesInSource = useMemo(() => serviceSourceItems.length > 0, [serviceSourceItems])
-  const hasClustersInSource = useMemo(() => clusterSourceItems.length > 0, [clusterSourceItems])
-  const hasAnySource = useMemo(
-    () => hasServicesInSource || hasClustersInSource,
-    [hasServicesInSource, hasClustersInSource]
-  )
-
-  const noSearchResults = useMemo(
-    () => Boolean(normalizedSearch) && hasAnySource && serviceTreeData.length === 0 && clusterRows.length === 0,
-    [normalizedSearch, hasAnySource, serviceTreeData.length, clusterRows.length]
-  )
-
-  const isLoading = useMemo(
-    () => (type === 'label' ? labelsGroupIsLoading : annotationsGroupIsLoading),
-    [type, labelsGroupIsLoading, annotationsGroupIsLoading]
-  )
+  const hasServicesInSource = serviceSourceItems.length > 0
+  const hasClustersInSource = clusterSourceItems.length > 0
+  const hasAnySource = hasServicesInSource || hasClustersInSource
+  const noSearchResults =
+    Boolean(normalizedSearch) && hasAnySource && serviceTreeData.length === 0 && clusterRows.length === 0
+  const isLoading = type === 'label' ? labelsGroupIsLoading : annotationsGroupIsLoading
 
   return (
     <Section className="p-6">


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1778571672511489)

Console was not reflecting the actual value of labels_groups. 
Also, the UI of the "associated items" modal was breaking when a cluster had an annotation. So we've reworked the modal.

## Screenshots / Recordings

📺  https://qovery.slack.com/archives/C0A4CDDJBRQ/p1778597169651059?thread_ts=1778571672.511489&cid=C0A4CDDJBRQ

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
