### PR TITLE
fix(clusters): temporarily hide NAT_GATEWAY feature for GCP cluster c…

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.spec.tsx
@@ -31,10 +31,12 @@ const mockContextValue: ClusterContainerCreateContextInterface = {
   creationFlowUrl: '/organization/org-123/cluster/create/aws',
 }
 
-function Wrapper({ children }: PropsWithChildren) {
-  return (
-    <ClusterContainerCreateContext.Provider value={mockContextValue}>{children}</ClusterContainerCreateContext.Provider>
-  )
+function getWrapper(contextValue: ClusterContainerCreateContextInterface = mockContextValue) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <ClusterContainerCreateContext.Provider value={contextValue}>{children}</ClusterContainerCreateContext.Provider>
+    )
+  }
 }
 
 jest.mock('./aws-vpc-feature/aws-vpc-feature', () => ({
@@ -90,7 +92,7 @@ describe('StepFeatures', () => {
   })
 
   it('should render features form', async () => {
-    renderWithProviders(<StepFeatures {...defaultProps} />, { wrapper: Wrapper })
+    renderWithProviders(<StepFeatures {...defaultProps} />, { wrapper: getWrapper() })
 
     await waitFor(() => {
       expect(screen.getByText('Network configuration')).toBeInTheDocument()
@@ -99,10 +101,53 @@ describe('StepFeatures', () => {
   })
 
   it('should set current step on mount', async () => {
-    renderWithProviders(<StepFeatures {...defaultProps} />, { wrapper: Wrapper })
+    renderWithProviders(<StepFeatures {...defaultProps} />, { wrapper: getWrapper() })
 
     await waitFor(() => {
       expect(mockSetCurrentStep).toHaveBeenCalled()
+    })
+  })
+
+  it('should hide NAT_GATEWAY feature for GCP cluster creation', async () => {
+    useCloudProviderFeaturesMockSpy.mockReturnValue({
+      data: [
+        {
+          id: 'STATIC_IP',
+          title: 'Static IP',
+          value_object: { value: false },
+        },
+        {
+          id: 'NAT_GATEWAY',
+          title: 'NAT Gateway',
+          value_object: { value: false },
+        },
+        {
+          id: 'PRIVATE_CLUSTER',
+          title: 'Private Cluster',
+          value_object: { value: false },
+        },
+      ],
+    })
+
+    const gcpContextValue: ClusterContainerCreateContextInterface = {
+      ...mockContextValue,
+      generalData: {
+        ...mockContextValue.generalData,
+        cloud_provider: CloudProviderEnum.GCP,
+      },
+      featuresData: {
+        vpc_mode: 'DEFAULT',
+        features: {},
+      },
+      creationFlowUrl: '/organization/org-123/cluster/create/gcp',
+    }
+
+    renderWithProviders(<StepFeatures {...defaultProps} />, { wrapper: getWrapper(gcpContextValue) })
+
+    await waitFor(() => {
+      expect(screen.getByText('Private Cluster')).toBeInTheDocument()
+      expect(screen.getByText('Static IP')).toBeInTheDocument()
+      expect(screen.queryByText('NAT Gateway')).not.toBeInTheDocument()
     })
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.tsx
@@ -31,6 +31,7 @@ import AWSVpcFeature from './aws-vpc-feature/aws-vpc-feature'
 import GCPVpcFeature from './gcp-vpc-feature/gcp-vpc-feature'
 
 const Qovery = '/assets/logos/logo-icon.svg'
+const GCP_HIDDEN_FEATURE_IDS = new Set(['NAT_GATEWAY'])
 const removeEmptySubnet = (objects?: Subnets[]) =>
   objects?.filter((field) => field.A !== '' || field.B !== '' || field.C !== '')
 
@@ -213,16 +214,18 @@ function StepFeaturesForm({
               {match(watchVpcMode)
                 .with('DEFAULT', () =>
                   features && features.length > 0 ? (
-                    features.map((feature) => (
-                      <ClusterCardFeature
-                        key={feature.id}
-                        feature={feature}
-                        cloudProvider={cloudProvider}
-                        control={clusterCardFeatureFormBindings.control}
-                        watch={clusterCardFeatureFormBindings.watch}
-                        setValue={clusterCardFeatureFormBindings.setValue}
-                      />
-                    ))
+                    features
+                      .filter((feature) => !GCP_HIDDEN_FEATURE_IDS.has(feature.id ?? ''))
+                      .map((feature) => (
+                        <ClusterCardFeature
+                          key={feature.id}
+                          feature={feature}
+                          cloudProvider={cloudProvider}
+                          control={clusterCardFeatureFormBindings.control}
+                          watch={clusterCardFeatureFormBindings.watch}
+                          setValue={clusterCardFeatureFormBindings.setValue}
+                        />
+                      ))
                   ) : (
                     <div className="mt-2 flex justify-center">
                       <LoaderSpinner className="w-4" />


### PR DESCRIPTION
temporary commit. once the backend will be ready, I will remove it and apply the same logic done for SCW

<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: <!-- QOV-1234 -->

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
