### PR TITLE
fix(audit logs): improve dropdown state management and animations

### DIFF
--- a/libs/shared/ui/src/lib/components/menu/menu.tsx
+++ b/libs/shared/ui/src/lib/components/menu/menu.tsx
@@ -92,7 +92,7 @@ export function Menu(props: MenuProps) {
   } = props
 
   const ref = useRef(null)
-  const [isOpen, setOpen] = useState<boolean | undefined>(undefined)
+  const [isOpen, setOpen] = useState<boolean | undefined>(open)
   // XXX: https://github.com/szhsin/react-menu/blob/d7c4df8a4324847403990174d9298038e11ac0c2/src/hooks/useClick.js
   const [skipOpen] = useState<{ v?: boolean }>({})
 
@@ -150,7 +150,9 @@ export function Menu(props: MenuProps) {
   }
 
   useEffect(() => {
-    setOpen((previousOpen) => (previousOpen === undefined && open === false ? undefined : open))
+    if (open !== undefined) {
+      setOpen(open)
+    }
     window.addEventListener('resize', closeMenu)
     window.addEventListener('scroll', closeMenu)
     return () => {

--- a/libs/shared/ui/src/lib/components/table/table-head-datepicker/table-head-datepicker.tsx
+++ b/libs/shared/ui/src/lib/components/table/table-head-datepicker/table-head-datepicker.tsx
@@ -7,6 +7,7 @@ import Icon from '../../icon/icon'
 import { type TableFilterProps } from '../table'
 
 const ALL = 'ALL'
+const REACT_DATEPICKER_IGNORE_ON_CLICK_OUTSIDE = 'react-datepicker-ignore-onclickoutside'
 
 export interface SelectedTimestamps {
   automaticallySelected: boolean
@@ -60,7 +61,7 @@ export function TableHeadDatePickerFilter({
 
   // Called when timestamp has been defined
   const onChangeTimestamp = (startDate: Date, endDate: Date) => {
-    setIsOpenTimestamp(!isOpenTimestamp)
+    setIsOpenTimestamp(false)
     setHasFilter(true)
     setFilter((prev) => [
       ...prev.filter(
@@ -80,6 +81,7 @@ export function TableHeadDatePickerFilter({
   // Called to clear the timestamp filter
   const cleanFilter = (event: MouseEvent) => {
     event.preventDefault()
+    event.stopPropagation()
     setFilter((prev) => [
       ...prev.filter(
         (currentValue) => currentValue.key !== fromTimestampProperty && currentValue.key !== toTimestampProperty
@@ -106,17 +108,17 @@ export function TableHeadDatePickerFilter({
         defaultDates={getDefaultDates(datePickerData.timestamps)}
         showDateTimeInputs
         useLocalTime
-        onClickOutside={() => setIsOpenTimestamp(!isOpenTimestamp)}
+        onClickOutside={() => setIsOpenTimestamp(false)}
         maxRangeInDays={datePickerData.maxRangeInDays}
       >
-        <div className="flex">
+        <div className={`${REACT_DATEPICKER_IGNORE_ON_CLICK_OUTSIDE} flex`}>
           {hasFilter ? (
             <Button
               type="button"
               color="neutral"
               size="sm"
               className="gap-1.5 whitespace-nowrap"
-              onClick={() => setIsOpenTimestamp(!isOpenTimestamp)}
+              onClick={() => setIsOpenTimestamp((isOpenTimestamp) => !isOpenTimestamp)}
             >
               {title}
               <span
@@ -134,7 +136,7 @@ export function TableHeadDatePickerFilter({
               size="sm"
               className="items-center gap-1.5 font-code"
               onClick={() => {
-                setIsOpenTimestamp(!isOpenTimestamp)
+                setIsOpenTimestamp((isOpenTimestamp) => !isOpenTimestamp)
               }}
             >
               {title}

--- a/libs/shared/ui/src/lib/styles/components/menu.scss
+++ b/libs/shared/ui/src/lib/styles/components/menu.scss
@@ -24,7 +24,7 @@
   transform: translateY(8px);
 
   &.menu__container--open {
-    animation-name: menuOpenBottom;
+    animation-name: menuOpenBottomFromTop;
   }
 }
 
@@ -128,6 +128,13 @@
   from {
     opacity: 0;
     transform: translateY(12px);
+  }
+}
+
+@keyframes menuOpenBottomFromTop {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary
- Fixed a bug in the Audit logs where we needed to click two times on each filters to open the dropdown
- Harmonized the dropdown opening animation with the one we have on the calendar dropdown in the same page for consistency 

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
