### PR TITLE
feat(clusters): add GCP static egress configuration for NAT gateway

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-card-feature/cluster-card-feature.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-card-feature/cluster-card-feature.spec.tsx
@@ -56,4 +56,58 @@ describe('ClusterCardFeature', () => {
     const toggle = screen.getByTestId('feature')
     expect(toggle).toBeInTheDocument()
   })
+
+  it('should show NAT_GATEWAY as false when gcp nested static_ips_enabled is false', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterCardFeature
+          cloudProvider={CloudProviderEnum.GCP}
+          feature={{
+            id: 'NAT_GATEWAY',
+            title: 'Static IP / Nat Gateways',
+            value_object: {
+              type: 'NAT_GATEWAY',
+              value: {
+                nat_gateway_type: {
+                  provider: 'gcp',
+                  static_ips_enabled: false,
+                  static_ips_count: 2,
+                },
+              },
+            },
+          }}
+          disabled
+        />
+      )
+    )
+
+    expect(screen.getByDisplayValue('false')).toBeInTheDocument()
+  })
+
+  it('should read NAT_GATEWAY nested nat_gateway_type static_ips_enabled', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterCardFeature
+          cloudProvider={CloudProviderEnum.GCP}
+          feature={{
+            id: 'NAT_GATEWAY',
+            title: 'Static IP / Nat Gateways',
+            value_object: {
+              type: 'NAT_GATEWAY',
+              value: {
+                nat_gateway_type: {
+                  provider: 'gcp',
+                  static_ips_enabled: true,
+                  static_ips_count: 2,
+                },
+              },
+            },
+          }}
+          disabled
+        />
+      )
+    )
+
+    expect(screen.getByDisplayValue('true')).toBeInTheDocument()
+  })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-card-feature/cluster-card-feature.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-card-feature/cluster-card-feature.tsx
@@ -2,6 +2,7 @@ import { type CloudVendorEnum, type ClusterFeatureResponse } from 'qovery-typesc
 import { type PropsWithChildren, type ReactNode, useEffect, useState } from 'react'
 import { type Control, Controller, type FieldValues, type UseFormSetValue, type UseFormWatch } from 'react-hook-form'
 import { ExternalLink, Icon, InputSelect, InputToggle, Tooltip } from '@qovery/shared/ui'
+import { getGcpNatGatewaySettings } from '../utils/get-gcp-nat-gateway-settings'
 
 export interface ClusterCardFeatureProps extends PropsWithChildren {
   feature: ClusterFeatureResponse
@@ -27,11 +28,21 @@ export function ClusterCardFeature({
 
   const name = watch && watch(`features.${feature.id}.value`)
 
-  const getValue = (value: boolean | string) => {
+  const getFeatureToggleValue = (feature: ClusterFeatureResponse) => {
+    const value = feature.value_object?.value
+
+    if (feature.id === 'NAT_GATEWAY' && cloudProvider === 'GCP') {
+      const gcpNatGatewaySettings = getGcpNatGatewaySettings(feature)
+      if (gcpNatGatewaySettings) {
+        return gcpNatGatewaySettings.static_ips_enabled
+      }
+    }
+
     if (typeof value === 'string') {
       return true
     }
-    return value
+
+    return Boolean(value)
   }
 
   useEffect(() => {
@@ -69,12 +80,7 @@ export function ClusterCardFeature({
         ) : (
           <Tooltip content={tooltip} disabled={!tooltip}>
             <span>
-              <InputToggle
-                disabled
-                small
-                className="relative top-[2px]"
-                value={getValue(Boolean(feature?.value_object?.value) || false)}
-              />
+              <InputToggle disabled small className="relative top-[2px]" value={getFeatureToggleValue(feature)} />
             </span>
           </Tooltip>
         )}

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.spec.tsx
@@ -108,7 +108,7 @@ describe('StepFeatures', () => {
     })
   })
 
-  it('should hide NAT_GATEWAY feature for GCP cluster creation', async () => {
+  it('should merge STATIC_IP and NAT_GATEWAY in GCP network configuration', async () => {
     useCloudProviderFeaturesMockSpy.mockReturnValue({
       data: [
         {
@@ -119,7 +119,12 @@ describe('StepFeatures', () => {
         {
           id: 'NAT_GATEWAY',
           title: 'NAT Gateway',
-          value_object: { value: false },
+          value_object: {
+            value: {
+              static_ips_enabled: false,
+              static_ips_count: 2,
+            },
+          },
         },
         {
           id: 'PRIVATE_CLUSTER',
@@ -145,9 +150,11 @@ describe('StepFeatures', () => {
     renderWithProviders(<StepFeatures {...defaultProps} />, { wrapper: getWrapper(gcpContextValue) })
 
     await waitFor(() => {
+      expect(screen.getAllByText('Static IP / Nat Gateways').length).toBeGreaterThan(0)
+      expect(screen.getByText('Enable static egress IPs')).toBeInTheDocument()
+      expect(screen.queryByText('Static IP count')).not.toBeInTheDocument()
       expect(screen.getByText('Private Cluster')).toBeInTheDocument()
-      expect(screen.getByText('Static IP')).toBeInTheDocument()
-      expect(screen.queryByText('NAT Gateway')).not.toBeInTheDocument()
+      expect(screen.queryByText(/^NAT Gateway$/)).not.toBeInTheDocument()
     })
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.tsx
@@ -25,13 +25,13 @@ import {
 } from '@qovery/shared/ui'
 import { twMerge } from '@qovery/shared/util-js'
 import { ClusterCardFeature } from '../../cluster-card-feature/cluster-card-feature'
+import { GcpStaticIp } from '../../gcp-static-ip/gcp-static-ip'
 import { ScalewayStaticIp } from '../../scaleway-static-ip/scaleway-static-ip'
 import { steps, useClusterContainerCreateContext } from '../cluster-creation-flow'
 import AWSVpcFeature from './aws-vpc-feature/aws-vpc-feature'
 import GCPVpcFeature from './gcp-vpc-feature/gcp-vpc-feature'
 
 const Qovery = '/assets/logos/logo-icon.svg'
-const GCP_HIDDEN_FEATURE_IDS = new Set(['NAT_GATEWAY'])
 const removeEmptySubnet = (objects?: Subnets[]) =>
   objects?.filter((field) => field.A !== '' || field.B !== '' || field.C !== '')
 
@@ -212,11 +212,32 @@ function StepFeaturesForm({
           {cloudProvider === 'GCP' && (
             <div>
               {match(watchVpcMode)
-                .with('DEFAULT', () =>
-                  features && features.length > 0 ? (
-                    features
-                      .filter((feature) => !GCP_HIDDEN_FEATURE_IDS.has(feature.id ?? ''))
-                      .map((feature) => (
+                .with('DEFAULT', () => {
+                  if (!features || features.length === 0) {
+                    return (
+                      <div className="mt-2 flex justify-center">
+                        <LoaderSpinner className="w-4" />
+                      </div>
+                    )
+                  }
+
+                  const staticIpFeature = features.find(({ id }) => id === 'STATIC_IP')
+                  const natGatewayFeature = features.find(({ id }) => id === 'NAT_GATEWAY')
+                  const hasMergedStaticIpNatGateway = Boolean(staticIpFeature && natGatewayFeature)
+                  const remainingFeatures = hasMergedStaticIpNatGateway
+                    ? features.filter(({ id }) => id !== 'STATIC_IP' && id !== 'NAT_GATEWAY')
+                    : features
+
+                  return (
+                    <>
+                      {hasMergedStaticIpNatGateway && (
+                        <GcpStaticIp
+                          staticIpFeature={staticIpFeature}
+                          natGatewayFeature={natGatewayFeature}
+                          production={isProduction || false}
+                        />
+                      )}
+                      {remainingFeatures.map((feature) => (
                         <ClusterCardFeature
                           key={feature.id}
                           feature={feature}
@@ -225,13 +246,10 @@ function StepFeaturesForm({
                           watch={clusterCardFeatureFormBindings.watch}
                           setValue={clusterCardFeatureFormBindings.setValue}
                         />
-                      ))
-                  ) : (
-                    <div className="mt-2 flex justify-center">
-                      <LoaderSpinner className="w-4" />
-                    </div>
+                      ))}
+                    </>
                   )
-                )
+                })
                 .with('EXISTING_VPC', () => <GCPVpcFeature />)
                 .otherwise(() => null)}
             </div>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
@@ -45,6 +45,20 @@ function SubnetsList({ title, index, subnets }: { title: string; index: string; 
   )
 }
 
+function formatFeatureValue(feature: ClusterFeaturesData['features'][string]) {
+  if (typeof feature.extendedValue === 'string') {
+    return feature.extendedValue
+  }
+
+  if (feature.extendedValue && typeof feature.extendedValue === 'object') {
+    const staticIpsEnabled = feature.extendedValue.static_ips_enabled
+    const staticIpsCount = feature.extendedValue.static_ips_count
+    return `static_ips_enabled=${staticIpsEnabled}, static_ips_count=${staticIpsCount}`
+  }
+
+  return feature.value.toString()
+}
+
 export function StepSummaryPresentation(props: StepSummaryPresentationProps) {
   const clusterBackup = props.resourcesData.infrastructure_charts_parameters?.eks_anywhere_parameters?.cluster_backup
   const showClusterBackup = Boolean(clusterBackup?.enabled)
@@ -598,7 +612,7 @@ export function StepSummaryPresentation(props: StepSummaryPresentationProps) {
                   return (
                     <li key={id}>
                       <strong className="font-medium">{currentFeature.title}: </strong>
-                      {currentFeature.extendedValue ? currentFeature.extendedValue : currentFeature.value.toString()}
+                      {formatFeatureValue(currentFeature)}
                     </li>
                   )
                 })}

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.spec.tsx
@@ -143,4 +143,163 @@ describe('StepSummary', () => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: '/organization/org-123/clusters' })
     })
   })
+
+  it('should send GCP NAT_GATEWAY using nat_gateway_type format on create', async () => {
+    mockContextValue.generalData = {
+      name: 'test-gcp-cluster',
+      description: 'description',
+      cloud_provider: CloudProviderEnum.GCP,
+      region: 'europe-west1',
+      installation_type: 'MANAGED',
+      production: false,
+      credentials: 'cred-id',
+      credentials_name: 'cred-name',
+    }
+    mockContextValue.featuresData = {
+      vpc_mode: 'DEFAULT',
+      features: {
+        STATIC_IP: {
+          id: 'STATIC_IP',
+          title: 'Static IP / Nat Gateways',
+          value: true,
+        },
+        NAT_GATEWAY: {
+          id: 'NAT_GATEWAY',
+          title: 'NAT Gateway',
+          value: true,
+          extendedValue: {
+            static_ips_enabled: false,
+            static_ips_count: 2,
+          },
+        },
+      },
+    }
+
+    mockCreateCluster.mockResolvedValue({ id: 'cluster-123' })
+    mockEditCloudProviderInfo.mockResolvedValue({})
+
+    const { userEvent } = renderWithProviders(<StepSummary {...defaultProps} />, { wrapper: Wrapper })
+
+    await userEvent.click(screen.getByTestId('button-create'))
+
+    await waitFor(() => {
+      expect(mockCreateCluster).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: 'org-123',
+          clusterRequest: expect.objectContaining({
+            cloud_provider: 'GCP',
+            features: expect.arrayContaining([
+              expect.objectContaining({
+                id: 'NAT_GATEWAY',
+                value: {
+                  nat_gateway_type: {
+                    provider: 'gcp',
+                    static_ips_enabled: false,
+                    static_ips_count: 2,
+                  },
+                },
+              }),
+            ]),
+          }),
+        })
+      )
+    })
+  })
+
+  it('should emit default NAT_GATEWAY for GCP when only STATIC_IP is in form data', async () => {
+    mockContextValue.generalData = {
+      name: 'test-gcp-cluster',
+      description: '',
+      cloud_provider: CloudProviderEnum.GCP,
+      region: 'europe-west1',
+      installation_type: 'MANAGED',
+      production: false,
+      credentials: 'cred-id',
+      credentials_name: 'cred-name',
+    }
+    mockContextValue.featuresData = {
+      vpc_mode: 'DEFAULT',
+      features: {
+        STATIC_IP: { id: 'STATIC_IP', title: 'Static IP / Nat Gateways', value: true },
+        // NAT_GATEWAY intentionally absent (race / quick navigation scenario)
+      },
+    }
+
+    mockCreateCluster.mockResolvedValue({ id: 'cluster-123' })
+    mockEditCloudProviderInfo.mockResolvedValue({})
+
+    const { userEvent } = renderWithProviders(<StepSummary {...defaultProps} />, { wrapper: Wrapper })
+
+    await userEvent.click(screen.getByTestId('button-create'))
+
+    await waitFor(() => {
+      expect(mockCreateCluster).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clusterRequest: expect.objectContaining({
+            features: expect.arrayContaining([
+              expect.objectContaining({
+                id: 'NAT_GATEWAY',
+                value: expect.objectContaining({
+                  nat_gateway_type: expect.objectContaining({ provider: 'gcp', static_ips_enabled: false }),
+                }),
+              }),
+            ]),
+          }),
+        })
+      )
+    })
+  })
+
+  it('should send SCW NAT_GATEWAY using nat_gateway_type format when extendedValue is string', async () => {
+    mockContextValue.generalData = {
+      name: 'test-scw-cluster',
+      description: '',
+      cloud_provider: CloudProviderEnum.SCW,
+      region: 'fr-par',
+      installation_type: 'MANAGED',
+      production: false,
+      credentials: 'cred-id',
+      credentials_name: 'cred-name',
+    }
+    mockContextValue.featuresData = {
+      vpc_mode: 'DEFAULT',
+      features: {
+        NAT_GATEWAY: {
+          id: 'NAT_GATEWAY',
+          title: 'NAT Gateway',
+          value: true,
+          extendedValue: 'sbn',
+        },
+        STATIC_IP: {
+          id: 'STATIC_IP',
+          title: 'Static IP',
+          value: true,
+        },
+      },
+    }
+
+    mockCreateCluster.mockResolvedValue({ id: 'cluster-123' })
+    mockEditCloudProviderInfo.mockResolvedValue({})
+
+    const { userEvent } = renderWithProviders(<StepSummary {...defaultProps} />, { wrapper: Wrapper })
+
+    await userEvent.click(screen.getByTestId('button-create'))
+
+    await waitFor(() => {
+      expect(mockCreateCluster).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clusterRequest: expect.objectContaining({
+            features: expect.arrayContaining([
+              expect.objectContaining({
+                id: 'NAT_GATEWAY',
+                value: expect.objectContaining({
+                  nat_gateway_type: expect.objectContaining({ provider: 'scaleway', type: 'sbn' }),
+                }),
+              }),
+            ]),
+          }),
+        })
+      )
+    })
+  })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.spec.tsx
@@ -268,7 +268,7 @@ describe('StepSummary', () => {
           id: 'NAT_GATEWAY',
           title: 'NAT Gateway',
           value: true,
-          extendedValue: 'sbn',
+          extendedValue: 'VPC-GW-S',
         },
         STATIC_IP: {
           id: 'STATIC_IP',
@@ -293,7 +293,7 @@ describe('StepSummary', () => {
               expect.objectContaining({
                 id: 'NAT_GATEWAY',
                 value: expect.objectContaining({
-                  nat_gateway_type: expect.objectContaining({ provider: 'scaleway', type: 'sbn' }),
+                  nat_gateway_type: expect.objectContaining({ provider: 'scaleway', type: 'VPC-GW-S' }),
                 }),
               }),
             ]),

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.tsx
@@ -1,6 +1,9 @@
 import { useNavigate } from '@tanstack/react-router'
 import {
   type ClusterCloudProviderInfoRequest,
+  type ClusterFeatureNatGatewayParameters,
+  type ClusterFeatureNatGatewayTypeGcp,
+  type ClusterFeatureNatGatewayTypeScalewayTypeEnum,
   type ClusterRequest,
   type ClusterRequestFeaturesInner,
   type KubernetesEnum,
@@ -180,13 +183,51 @@ export function StepSummary({ organizationId }: StepSummaryProps) {
     if (generalData.cloud_provider === 'AWS' || generalData.cloud_provider === 'GCP') {
       if (featuresData && featuresData.vpc_mode === 'DEFAULT') {
         formatFeatures = Object.keys(featuresData.features)
-          .map(
-            (id: string) =>
-              featuresData.features[id]?.value && {
-                id,
-                value: featuresData.features[id].extendedValue || featuresData.features[id].value,
+          .map((id: string) => {
+            const feature = featuresData.features[id]
+
+            if (!feature?.value) return null
+
+            if (generalData.cloud_provider === 'GCP' && id === 'STATIC_IP') {
+              // NAT_GATEWAY is the canonical GCP egress feature. If it is already present
+              // in the form it will be serialised by its own branch below; skip STATIC_IP.
+              // If it is absent (race / quick navigation), emit a safe default here so the
+              // payload is never silently empty.
+              if ('NAT_GATEWAY' in featuresData.features) return null
+              return {
+                id: 'NAT_GATEWAY',
+                value: {
+                  nat_gateway_type: {
+                    provider: 'gcp',
+                    static_ips_enabled: false,
+                    static_ips_count: 2,
+                  } as ClusterFeatureNatGatewayTypeGcp,
+                } as ClusterFeatureNatGatewayParameters,
               }
-          )
+            }
+
+            if (generalData.cloud_provider === 'GCP' && id === 'NAT_GATEWAY') {
+              const gcpNatGatewayType =
+                feature.extendedValue && typeof feature.extendedValue === 'object'
+                  ? feature.extendedValue
+                  : { static_ips_enabled: false, static_ips_count: 2 }
+
+              return {
+                id,
+                value: {
+                  nat_gateway_type: {
+                    provider: 'gcp',
+                    ...gcpNatGatewayType,
+                  } as ClusterFeatureNatGatewayTypeGcp,
+                } as ClusterFeatureNatGatewayParameters,
+              }
+            }
+
+            return {
+              id,
+              value: feature.extendedValue || feature.value,
+            }
+          })
           .filter(Boolean) as ClusterRequestFeaturesInner[]
       } else if (generalData.cloud_provider === 'AWS') {
         formatFeatures = [
@@ -274,15 +315,20 @@ export function StepSummary({ organizationId }: StepSummaryProps) {
           Object.keys(featuresData.features).forEach((featureId) => {
             if (featureId === SCW_CONTROL_PLANE_FEATURE_ID) return
             const featureData = featuresData.features[featureId]
-            if (featureId === 'NAT_GATEWAY' && featureData.extendedValue) {
+            if (featureId === 'NAT_GATEWAY' && typeof featureData.extendedValue === 'string') {
               scwFeatures.push({
                 id: featureId,
                 value: {
-                  nat_gateway_type: { provider: 'scaleway', type: featureData.extendedValue },
-                } as unknown as ClusterRequestFeaturesInner['value'],
+                  nat_gateway_type: {
+                    provider: 'scaleway',
+                    type: featureData.extendedValue as ClusterFeatureNatGatewayTypeScalewayTypeEnum,
+                  },
+                } as ClusterFeatureNatGatewayParameters,
               })
             } else if (featureData.value) {
-              scwFeatures.push({ id: featureId, value: featureData.extendedValue || featureData.value })
+              const scwFeatureValue =
+                typeof featureData.extendedValue === 'string' ? featureData.extendedValue : featureData.value
+              scwFeatures.push({ id: featureId, value: scwFeatureValue })
             }
           })
         }

--- a/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.spec.tsx
@@ -16,6 +16,7 @@ const mockUseCluster = useCluster as jest.MockedFunction<typeof useCluster>
 const mockUseClusterRoutingTable = useClusterRoutingTable as jest.MockedFunction<typeof useClusterRoutingTable>
 const mockUseEditCluster = useEditCluster as jest.MockedFunction<typeof useEditCluster>
 const mockUseEditRoutingTable = useEditRoutingTable as jest.MockedFunction<typeof useEditRoutingTable>
+const mockEditClusterMutate = jest.fn()
 
 const mockCluster: Cluster = {
   id: 'cluster-id',
@@ -46,9 +47,11 @@ const mockClusterScaleway: Cluster = {
     {
       id: 'NAT_GATEWAY',
       value_object: {
+        type: 'NAT_GATEWAY',
         value: {
           nat_gateway_type: {
-            type: 'sbn',
+            provider: 'scaleway',
+            type: 'VPC-GW-S',
           },
         },
       },
@@ -68,7 +71,7 @@ describe('ClusterNetworkSettings', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseEditCluster.mockReturnValue({
-      mutateAsync: jest.fn(),
+      mutateAsync: mockEditClusterMutate,
       isLoading: false,
     } as unknown as ReturnType<typeof useEditCluster>)
     mockUseEditRoutingTable.mockReturnValue({
@@ -132,6 +135,74 @@ describe('ClusterNetworkSettings', () => {
     expect(screen.getByTestId('submit-button')).toBeInTheDocument()
   })
 
+  it('should read SCW NAT_GATEWAY from legacy plain-string shape', () => {
+    const legacyStringCluster: Cluster = {
+      ...mockCluster,
+      cloud_provider: 'SCW',
+      region: 'fr-par',
+      features: [
+        {
+          id: 'NAT_GATEWAY',
+          value_object: {
+            value: 'VPC-GW-S',
+          },
+        },
+      ],
+    } as Cluster
+
+    mockUseCluster.mockReturnValue({
+      data: legacyStringCluster,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCluster>)
+    mockUseClusterRoutingTable.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useClusterRoutingTable>)
+
+    renderWithProviders(
+      wrapWithReactHookForm(<ClusterNetworkSettings organizationId="org-id" clusterId="cluster-id" />)
+    )
+
+    expect(screen.getByTestId('submit-button')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('VPC-GW-S')).toBeInTheDocument()
+  })
+
+  it('should read SCW NAT_GATEWAY from legacy nested-object shape without type discriminator', () => {
+    const legacyObjectCluster: Cluster = {
+      ...mockCluster,
+      cloud_provider: 'SCW',
+      region: 'fr-par',
+      features: [
+        {
+          id: 'NAT_GATEWAY',
+          value_object: {
+            value: {
+              nat_gateway_type: {
+                type: 'VPC-GW-M',
+              },
+            },
+          },
+        },
+      ],
+    } as Cluster
+
+    mockUseCluster.mockReturnValue({
+      data: legacyObjectCluster,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCluster>)
+    mockUseClusterRoutingTable.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useClusterRoutingTable>)
+
+    renderWithProviders(
+      wrapWithReactHookForm(<ClusterNetworkSettings organizationId="org-id" clusterId="cluster-id" />)
+    )
+
+    expect(screen.getByTestId('submit-button')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('VPC-GW-M')).toBeInTheDocument()
+  })
+
   it('should render configured network features for non-Scaleway cluster without existing VPC', () => {
     const clusterWithFeatures: Cluster = {
       ...mockCluster,
@@ -191,5 +262,181 @@ describe('ClusterNetworkSettings', () => {
     )
 
     expect(screen.queryByText('Routes')).not.toBeInTheDocument()
+  })
+
+  it('should show STATIC_IP as true for GCP when NAT_GATEWAY feature is missing', () => {
+    const gcpClusterWithoutNatGateway: Cluster = {
+      ...mockCluster,
+      cloud_provider: 'GCP',
+      features: [
+        {
+          id: 'STATIC_IP',
+          title: 'Static IP / Nat Gateways',
+          value_object: {
+            value: true,
+          },
+        },
+      ],
+    } as Cluster
+
+    mockUseCluster.mockReturnValue({
+      data: gcpClusterWithoutNatGateway,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCluster>)
+    mockUseClusterRoutingTable.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useClusterRoutingTable>)
+
+    renderWithProviders(
+      wrapWithReactHookForm(<ClusterNetworkSettings organizationId="org-id" clusterId="cluster-id" />)
+    )
+
+    // STATIC_IP is filtered from gcpDisplayFeatures so the "Configured network features" block is empty
+    expect(screen.queryByText('Configured network features')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('true')).toBeInTheDocument()
+    expect(screen.getByText('Enable static egress IPs')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('false')).toBeInTheDocument()
+    expect(screen.getByText(/may trigger a downtime of a few minutes/i)).toBeInTheDocument()
+    expect(screen.queryByText('Static IP count')).not.toBeInTheDocument()
+  })
+
+  it('should keep NAT_GATEWAY visible for GCP when STATIC_IP feature is missing', () => {
+    const gcpClusterWithoutStaticIp: Cluster = {
+      ...mockCluster,
+      cloud_provider: 'GCP',
+      features: [
+        {
+          id: 'NAT_GATEWAY',
+          title: 'Static IP / Nat Gateways',
+          value_object: {
+            type: 'NAT_GATEWAY',
+            value: {
+              nat_gateway_type: {
+                provider: 'gcp',
+                static_ips_enabled: true,
+                static_ips_count: 2,
+              },
+            },
+          },
+        },
+      ],
+    } as Cluster
+
+    mockUseCluster.mockReturnValue({
+      data: gcpClusterWithoutStaticIp,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCluster>)
+    mockUseClusterRoutingTable.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useClusterRoutingTable>)
+
+    renderWithProviders(
+      wrapWithReactHookForm(<ClusterNetworkSettings organizationId="org-id" clusterId="cluster-id" />)
+    )
+
+    expect(screen.getByText('Configured network features')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('true')).toBeInTheDocument()
+    expect(screen.queryByText('Enable static egress IPs')).not.toBeInTheDocument()
+  })
+
+  it('should include NAT_GATEWAY in submit payload when absent from cluster but configured by user', async () => {
+    const gcpClusterWithoutNatGateway: Cluster = {
+      ...mockCluster,
+      cloud_provider: 'GCP',
+      features: [
+        {
+          id: 'STATIC_IP',
+          title: 'Static IP / Nat Gateways',
+          value_object: { value: true },
+        },
+      ],
+    } as Cluster
+
+    mockUseCluster.mockReturnValue({
+      data: gcpClusterWithoutNatGateway,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCluster>)
+    mockUseClusterRoutingTable.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useClusterRoutingTable>)
+
+    const { userEvent } = renderWithProviders(
+      wrapWithReactHookForm(<ClusterNetworkSettings organizationId="org-id" clusterId="cluster-id" />)
+    )
+
+    // toggle[0] = STATIC_IP (disabled for GCP), toggle[1] = "Enable static egress IPs"
+    await userEvent.click(screen.getAllByTestId('input-toggle-button')[1])
+    await userEvent.click(screen.getByTestId('submit-button'))
+
+    expect(mockEditClusterMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clusterRequest: expect.objectContaining({
+          features: expect.arrayContaining([
+            expect.objectContaining({ id: 'STATIC_IP' }),
+            expect.objectContaining({
+              id: 'NAT_GATEWAY',
+              value: expect.objectContaining({
+                nat_gateway_type: expect.objectContaining({ provider: 'gcp', static_ips_enabled: true }),
+              }),
+            }),
+          ]),
+        }),
+      })
+    )
+  })
+
+  it('should allow editing GCP static egress settings and save', async () => {
+    const gcpCluster: Cluster = {
+      ...mockCluster,
+      cloud_provider: 'GCP',
+      features: [
+        {
+          id: 'STATIC_IP',
+          title: 'Static IP / Nat Gateways',
+          value_object: {
+            value: true,
+          },
+        },
+        {
+          id: 'NAT_GATEWAY',
+          title: 'NAT Gateway',
+          value_object: {
+            type: 'NAT_GATEWAY',
+            value: {
+              nat_gateway_type: {
+                provider: 'gcp',
+                static_ips_enabled: true,
+                static_ips_count: 3,
+              },
+            },
+          },
+        },
+      ],
+    } as Cluster
+
+    mockUseCluster.mockReturnValue({
+      data: gcpCluster,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCluster>)
+    mockUseClusterRoutingTable.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useClusterRoutingTable>)
+
+    const { userEvent } = renderWithProviders(
+      wrapWithReactHookForm(<ClusterNetworkSettings organizationId="org-id" clusterId="cluster-id" />)
+    )
+
+    expect(screen.getByText('Enable static egress IPs')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('3')).toBeInTheDocument()
+    expect(screen.getByTestId('submit-button')).toBeInTheDocument()
+    expect(screen.queryByText('Configured network features')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('submit-button'))
+
+    expect(mockEditClusterMutate).toHaveBeenCalled()
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
@@ -1,13 +1,17 @@
 import {
   type ClusterFeatureAwsExistingVpc,
   type ClusterFeatureGcpExistingVpc,
-  type ClusterRequestFeaturesInner,
+  type ClusterFeatureNatGatewayParameters,
+  type ClusterFeatureNatGatewayTypeGcp,
+  type ClusterFeatureNatGatewayTypeScalewayTypeEnum,
+  type ClusterFeatureResponse,
   type ClusterRoutingTableResultsInner,
 } from 'qovery-typescript-axios'
 import { useEffect } from 'react'
 import { Controller, type FieldValues, FormProvider, useForm, useFormContext } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import { IconEnum } from '@qovery/shared/enums'
+import { type ClusterFeatureExtendedValue, type ClusterFeaturesData } from '@qovery/shared/interfaces'
 import {
   BlockContent,
   Button,
@@ -23,16 +27,44 @@ import {
   useModalConfirmation,
 } from '@qovery/shared/ui'
 import { ClusterCardFeature } from '../cluster-card-feature/cluster-card-feature'
+import { GcpStaticIp } from '../gcp-static-ip/gcp-static-ip'
 import { useClusterRoutingTable } from '../hooks/use-cluster-routing-table/use-cluster-routing-table'
 import { useCluster } from '../hooks/use-cluster/use-cluster'
 import { useEditCluster } from '../hooks/use-edit-cluster/use-edit-cluster'
 import { useEditRoutingTable } from '../hooks/use-edit-routing-table/use-edit-routing-table'
 import ScalewayStaticIp from '../scaleway-static-ip/scaleway-static-ip'
+import { getGcpNatGatewaySettings } from '../utils/get-gcp-nat-gateway-settings'
 
 export interface ClusterNetworkSettingsProps {
   organizationId: string
   clusterId: string
 }
+
+// Fallback used when the cluster has STATIC_IP but no NAT_GATEWAY feature yet,
+// so GcpStaticIp can render sub-options in a default state.
+const GCP_NAT_GATEWAY_FEATURE_FALLBACK: ClusterFeatureResponse = {
+  id: 'NAT_GATEWAY',
+  value_object: {
+    type: 'NAT_GATEWAY',
+    value: {
+      nat_gateway_type: {
+        provider: 'gcp',
+        static_ips_enabled: false,
+        static_ips_count: 2,
+      } as ClusterFeatureNatGatewayTypeGcp,
+    },
+  },
+}
+
+const buildGcpNatGatewayValue = (settings: {
+  static_ips_enabled: boolean
+  static_ips_count: number
+}): ClusterFeatureNatGatewayParameters => ({
+  nat_gateway_type: {
+    provider: 'gcp',
+    ...settings,
+  } as ClusterFeatureNatGatewayTypeGcp,
+})
 
 const deleteRoutes = (routes: ClusterRoutingTableResultsInner[], destination?: string) => {
   return [...routes]?.filter((port) => port.destination !== destination)
@@ -337,24 +369,43 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
   const { openModalConfirmation } = useModalConfirmation()
 
   const isScalewayCluster = cluster?.cloud_provider === 'SCW'
+  const isGcpCluster = cluster?.cloud_provider === 'GCP'
 
-  const methods = useForm({
+  const methods = useForm<ClusterFeaturesData>({
     mode: 'onChange',
   })
 
   useEffect(() => {
-    if (cluster?.features && isScalewayCluster) {
-      const featuresData: Record<string, { value: boolean; extendedValue?: string }> = {}
+    if (cluster?.features && (isScalewayCluster || isGcpCluster)) {
+      const featuresData: Record<string, { value: boolean; extendedValue?: ClusterFeatureExtendedValue }> = {}
       cluster.features.forEach((feature) => {
         if (feature.id) {
-          if (feature.id === 'NAT_GATEWAY' && feature.value_object?.value) {
-            const natGatewayValue = feature.value_object.value as unknown as { nat_gateway_type: { type: string } }
-            const natGatewayType =
-              natGatewayValue?.nat_gateway_type?.type ||
-              (typeof natGatewayValue === 'string' ? natGatewayValue : undefined)
+          if (feature.id === 'NAT_GATEWAY' && isScalewayCluster) {
+            const valueObj = feature.value_object
+            let scwType: string | undefined
+            if (valueObj?.type === 'NAT_GATEWAY') {
+              // New discriminated shape
+              const natGatewayType = valueObj.value?.nat_gateway_type
+              scwType = natGatewayType && natGatewayType.provider === 'scaleway' ? natGatewayType.type : undefined
+            } else if (valueObj?.value) {
+              // Legacy shapes: plain string or object without type discriminator
+              const raw = valueObj.value as unknown
+              if (typeof raw === 'string') {
+                scwType = raw
+              } else if (raw && typeof raw === 'object' && 'nat_gateway_type' in raw) {
+                const legacy = raw as { nat_gateway_type?: { type?: string } }
+                scwType = legacy.nat_gateway_type?.type
+              }
+            }
             featuresData[feature.id] = {
-              value: Boolean(natGatewayType),
-              extendedValue: natGatewayType,
+              value: Boolean(scwType),
+              extendedValue: scwType,
+            }
+          } else if (feature.id === 'NAT_GATEWAY' && isGcpCluster) {
+            const gcpNatGatewaySettings = getGcpNatGatewaySettings(feature)
+            featuresData[feature.id] = {
+              value: Boolean(gcpNatGatewaySettings),
+              extendedValue: gcpNatGatewaySettings,
             }
           } else {
             featuresData[feature.id] = {
@@ -366,23 +417,23 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
       })
       methods.reset({ features: featuresData })
     }
-  }, [cluster, isScalewayCluster, methods])
+  }, [cluster, isScalewayCluster, isGcpCluster, methods])
 
   const onSubmit = methods.handleSubmit(async (data) => {
     if (!cluster) return
 
-    const staticIpFeature = data['features']?.['STATIC_IP']
+    const staticIpFeature = data.features?.STATIC_IP
     const staticIpEnabled = staticIpFeature?.value === true
 
     const features = cluster.features
       ?.filter((feature) => {
-        if (feature.id === 'NAT_GATEWAY' && isScalewayCluster && !staticIpEnabled) {
+        if (feature.id === 'NAT_GATEWAY' && (isScalewayCluster || isGcpCluster) && !staticIpEnabled) {
           return false
         }
         return true
       })
       .map((feature) => {
-        const formFeature = data['features']?.[feature.id || '']
+        const formFeature = data.features?.[feature.id || '']
 
         if (feature.id === 'STATIC_IP' && formFeature) {
           return {
@@ -395,16 +446,14 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
         }
 
         if (feature.id === 'NAT_GATEWAY' && formFeature && isScalewayCluster) {
-          if (formFeature.extendedValue) {
-            return {
-              ...feature,
-              value: {
-                nat_gateway_type: {
-                  provider: 'scaleway',
-                  type: formFeature.extendedValue,
-                },
-              } as unknown as ClusterRequestFeaturesInner['value'],
+          if (formFeature.extendedValue && typeof formFeature.extendedValue === 'string') {
+            const natGatewayValue: ClusterFeatureNatGatewayParameters = {
+              nat_gateway_type: {
+                provider: 'scaleway',
+                type: formFeature.extendedValue as ClusterFeatureNatGatewayTypeScalewayTypeEnum,
+              },
             }
+            return { ...feature, value: natGatewayValue }
           }
           return {
             ...feature,
@@ -412,8 +461,30 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
           }
         }
 
+        if (feature.id === 'NAT_GATEWAY' && isGcpCluster) {
+          if (formFeature?.value && formFeature.extendedValue && typeof formFeature.extendedValue === 'object') {
+            return { ...feature, value: buildGcpNatGatewayValue(formFeature.extendedValue) }
+          }
+          return { ...feature, value: null }
+        }
+
         return feature
       })
+
+    // GCP: NAT_GATEWAY may be absent from existing cluster features (clusters created before
+    // this feature was introduced). If the user has configured it in the form, append it to
+    // the payload so the changes are not silently dropped.
+    const gcpNatGatewayMissing =
+      isGcpCluster && staticIpEnabled && !cluster.features?.some((f) => f.id === 'NAT_GATEWAY')
+    if (gcpNatGatewayMissing && features) {
+      const natFormFeature = data.features?.NAT_GATEWAY
+      if (natFormFeature?.extendedValue && typeof natFormFeature.extendedValue === 'object') {
+        features.push({
+          id: 'NAT_GATEWAY',
+          value: buildGcpNatGatewayValue(natFormFeature.extendedValue),
+        })
+      }
+    }
 
     try {
       await editCluster({
@@ -430,10 +501,20 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
   })
 
   const featureExistingVpc = cluster?.features?.find(({ id }) => id === 'EXISTING_VPC')
+  const gcpStaticIpFeature = cluster?.features?.find(({ id }) => id === 'STATIC_IP')
+  const gcpNatGatewayFeature = cluster?.features?.find(({ id }) => id === 'NAT_GATEWAY')
   const featureExistingVpcValue = featureExistingVpc?.value_object
   const canEditRoutes =
     cluster?.cloud_provider === 'AWS' && cluster?.kubernetes === 'MANAGED' && !featureExistingVpcValue
-  const canEditFeatures = isScalewayCluster
+  const canEditFeatures = isScalewayCluster || isGcpCluster
+  const configuredFeatures = cluster?.features?.filter(({ id }) => id !== 'EXISTING_VPC' && id !== 'KARPENTER') ?? []
+  const hasGcpStaticIpFeature = isGcpCluster && Boolean(gcpStaticIpFeature)
+  const gcpDisplayFeatures = configuredFeatures.filter(({ id }) => {
+    if (id === 'STATIC_IP') return false
+    if (id === 'NAT_GATEWAY' && hasGcpStaticIpFeature) return false
+    return true
+  })
+  const displayConfiguredFeatures = isGcpCluster ? gcpDisplayFeatures : configuredFeatures
 
   const featureExistingVpcContent = match(featureExistingVpcValue)
     .with({ type: 'AWS_USER_PROVIDED_NETWORK' }, (f) => (
@@ -582,18 +663,37 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
                   )}
                 </>
               ) : (
-                <BlockContent title="Configured network features" classNameContent="p-0">
-                  {cluster?.features
-                    ?.filter(({ id }) => id !== 'EXISTING_VPC' && id !== 'KARPENTER')
-                    .map((feature) => (
-                      <ClusterCardFeature
-                        key={feature.id}
-                        feature={feature}
-                        cloudProvider={cluster?.cloud_provider}
-                        disabled
-                      />
-                    ))}
-                </BlockContent>
+                <>
+                  {hasGcpStaticIpFeature && (
+                    <GcpStaticIp
+                      staticIpFeature={gcpStaticIpFeature}
+                      natGatewayFeature={gcpNatGatewayFeature ?? GCP_NAT_GATEWAY_FEATURE_FALLBACK}
+                      production={cluster?.production || false}
+                      disabled={!canEditFeatures}
+                      staticIpToggleDisabled={isGcpCluster}
+                      showDowntimeWarning={canEditFeatures}
+                    />
+                  )}
+                  {displayConfiguredFeatures.length > 0 && (
+                    <BlockContent title="Configured network features" classNameContent="p-0">
+                      {displayConfiguredFeatures.map((feature) => (
+                        <ClusterCardFeature
+                          key={feature.id}
+                          feature={feature}
+                          cloudProvider={cluster?.cloud_provider}
+                          disabled
+                        />
+                      ))}
+                    </BlockContent>
+                  )}
+                  {canEditFeatures && hasGcpStaticIpFeature && (
+                    <div className="flex justify-end">
+                      <Button data-testid="submit-button" type="submit" size="lg" loading={isEditClusterLoading}>
+                        Save
+                      </Button>
+                    </div>
+                  )}
+                </>
               )}
             </>
           )}

--- a/libs/domains/clusters/feature/src/lib/gcp-static-ip/gcp-static-ip.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/gcp-static-ip/gcp-static-ip.spec.tsx
@@ -183,7 +183,7 @@ describe('GcpStaticIp', () => {
       )
     )
 
-    // ExternalLink as="button" renders an <a> (role=link); billing badge + docs link = 2 links total
+    // ExternalLink as="button" renders an <a> (role=link); billing badge + documentation link
     expect(screen.getAllByRole('link')).toHaveLength(2)
   })
 

--- a/libs/domains/clusters/feature/src/lib/gcp-static-ip/gcp-static-ip.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/gcp-static-ip/gcp-static-ip.spec.tsx
@@ -1,0 +1,215 @@
+import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
+import { type ClusterFeatureResponse } from 'qovery-typescript-axios'
+import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { GcpStaticIp } from './gcp-static-ip'
+
+const mockStaticIpFeature: ClusterFeatureResponse = {
+  id: 'STATIC_IP',
+  value: true,
+  value_object: {
+    value: true,
+  },
+}
+
+const mockNatGatewayFeature: ClusterFeatureResponse = {
+  id: 'NAT_GATEWAY',
+  value: true,
+  value_object: {
+    type: 'NAT_GATEWAY',
+    value: {
+      nat_gateway_type: {
+        provider: 'gcp',
+        static_ips_enabled: true,
+        static_ips_count: 2,
+      },
+    },
+  },
+}
+
+describe('GcpStaticIp', () => {
+  it('should hide GCP NAT details when static IP toggle is disabled', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <GcpStaticIp
+          staticIpFeature={mockStaticIpFeature}
+          natGatewayFeature={mockNatGatewayFeature}
+          production={false}
+        />,
+        {
+          defaultValues: {
+            features: {
+              STATIC_IP: { value: false },
+              NAT_GATEWAY: { value: false, extendedValue: undefined },
+            },
+          },
+        }
+      )
+    )
+
+    expect(screen.queryByText('Enable static egress IPs')).not.toBeInTheDocument()
+    expect(screen.queryByText('Static IP count')).not.toBeInTheDocument()
+  })
+
+  it('should show default static IP count when static IP toggle is enabled', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <GcpStaticIp
+          staticIpFeature={mockStaticIpFeature}
+          natGatewayFeature={mockNatGatewayFeature}
+          production={false}
+        />,
+        {
+          defaultValues: {
+            features: {
+              STATIC_IP: { value: true },
+              NAT_GATEWAY: {
+                value: true,
+                extendedValue: {
+                  static_ips_enabled: true,
+                  static_ips_count: 2,
+                },
+              },
+            },
+          },
+        }
+      )
+    )
+
+    expect(screen.getByText('Enable static egress IPs')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('2')).toBeInTheDocument()
+  })
+
+  it('should hide static IP count when static egress toggle is disabled', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <GcpStaticIp
+          staticIpFeature={mockStaticIpFeature}
+          natGatewayFeature={mockNatGatewayFeature}
+          production={false}
+        />,
+        {
+          defaultValues: {
+            features: {
+              STATIC_IP: { value: true },
+              NAT_GATEWAY: {
+                value: true,
+                extendedValue: {
+                  static_ips_enabled: false,
+                  static_ips_count: 2,
+                },
+              },
+            },
+          },
+        }
+      )
+    )
+
+    expect(screen.getByText('Enable static egress IPs')).toBeInTheDocument()
+    expect(screen.queryByText('Static IP count')).not.toBeInTheDocument()
+  })
+
+  it('should read nested nat_gateway_type settings for existing GCP clusters', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <GcpStaticIp
+          staticIpFeature={mockStaticIpFeature}
+          natGatewayFeature={mockNatGatewayFeature}
+          production={false}
+          disabled
+        />
+      )
+    )
+
+    expect(screen.getByText('Enable static egress IPs')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('2')).toBeInTheDocument()
+  })
+
+  it('should disable static ip toggle when staticIpToggleDisabled is true', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <GcpStaticIp
+          staticIpFeature={mockStaticIpFeature}
+          natGatewayFeature={mockNatGatewayFeature}
+          production={false}
+          staticIpToggleDisabled
+        />,
+        {
+          defaultValues: {
+            features: {
+              STATIC_IP: { value: true },
+              NAT_GATEWAY: {
+                value: true,
+                extendedValue: {
+                  static_ips_enabled: true,
+                  static_ips_count: 2,
+                },
+              },
+            },
+          },
+        }
+      )
+    )
+
+    expect(screen.getAllByTestId('input-toggle')[0]).toHaveClass('opacity-50')
+    expect(screen.getByText('Enable static egress IPs')).toBeInTheDocument()
+  })
+
+  it('should not show NAT sub-options when natGatewayFeature is undefined', () => {
+    renderWithProviders(
+      wrapWithReactHookForm(<GcpStaticIp staticIpFeature={mockStaticIpFeature} production={false} />, {
+        defaultValues: { features: { STATIC_IP: { value: true } } },
+      })
+    )
+
+    expect(screen.queryByText('Enable static egress IPs')).not.toBeInTheDocument()
+  })
+
+  it('should render billing badge button when is_cloud_provider_paying_feature is true', () => {
+    const paidFeature = {
+      ...mockStaticIpFeature,
+      is_cloud_provider_paying_feature: true,
+      cloud_provider_feature_documentation: 'https://cloud.google.com/nat',
+    }
+
+    // disabled mode: staticIpEnabled comes from feature.value_object.value, useEffect does not run
+    renderWithProviders(
+      wrapWithReactHookForm(
+        <GcpStaticIp
+          staticIpFeature={paidFeature}
+          natGatewayFeature={mockNatGatewayFeature}
+          production={false}
+          disabled
+        />
+      )
+    )
+
+    // ExternalLink as="button" renders an <a> (role=link); billing badge + docs link = 2 links total
+    expect(screen.getAllByRole('link')).toHaveLength(2)
+  })
+
+  it('should reset static IP count to default when input is cleared', async () => {
+    const { userEvent } = renderWithProviders(
+      wrapWithReactHookForm(
+        <GcpStaticIp
+          staticIpFeature={mockStaticIpFeature}
+          natGatewayFeature={mockNatGatewayFeature}
+          production={false}
+        />,
+        {
+          defaultValues: {
+            features: {
+              STATIC_IP: { value: true },
+              NAT_GATEWAY: { value: true, extendedValue: { static_ips_enabled: true, static_ips_count: 5 } },
+            },
+          },
+        }
+      )
+    )
+
+    const countInput = screen.getByDisplayValue('5')
+    await userEvent.clear(countInput)
+
+    // clearing triggers NaN path → resets to DEFAULT_STATIC_IPS_COUNT (2)
+    await waitFor(() => expect(screen.getByDisplayValue('2')).toBeInTheDocument())
+  })
+})

--- a/libs/domains/clusters/feature/src/lib/gcp-static-ip/gcp-static-ip.tsx
+++ b/libs/domains/clusters/feature/src/lib/gcp-static-ip/gcp-static-ip.tsx
@@ -6,6 +6,8 @@ import { BlockContent, Callout, ExternalLink, Icon, InputText, InputToggle, Tool
 import { type GcpNatGatewaySettings, getGcpNatGatewaySettings } from '../utils/get-gcp-nat-gateway-settings'
 
 const DEFAULT_STATIC_IPS_COUNT = 2
+const GCP_NETWORK_DOCUMENTATION_URL =
+  'https://www.qovery.com/docs/configuration/integrations/kubernetes/gke/managed#network'
 
 const isGcpNatGatewaySettings = (value: unknown): value is GcpNatGatewaySettings =>
   Boolean(
@@ -106,7 +108,7 @@ export function GcpStaticIp({
   }, [isEditable, natGatewayEnabled, natGatewayFeature?.id, natGatewaySettings, setValue, staticIpEnabled])
 
   return (
-    <BlockContent title="Static IP / Nat Gateways" classNameContent="p-4">
+    <BlockContent title="Static IP / Nat Gateways" classNameContent="w-full p-4">
       <div className="flex flex-col gap-4">
         <div className="flex items-start gap-3">
           <Controller
@@ -114,28 +116,30 @@ export function GcpStaticIp({
             control={control}
             defaultValue={staticIpValueFromFeature ?? production}
             render={({ field }) => (
-              <div className="flex gap-2">
-                <InputToggle
-                  value={field.value}
-                  onChange={(value) => {
-                    field.onChange(value)
-                    if (!natGatewayFeature?.id || !setValue) return
-                    if (!value) {
-                      setValue(`features.${natGatewayFeature.id}.value`, false)
-                      setValue(`features.${natGatewayFeature.id}.extendedValue`, undefined)
-                      return
-                    }
-                    setNatGatewaySettings({
-                      static_ips_enabled: natGatewaySettings?.static_ips_enabled ?? false,
-                      static_ips_count: natGatewaySettings?.static_ips_count ?? DEFAULT_STATIC_IPS_COUNT,
-                    })
-                  }}
-                  disabled={disabled || staticIpToggleDisabled}
-                  title="Static IP / Nat Gateways"
-                  description="Your cluster will use NAT Gateways for egress. You can configure static egress IPs below."
-                  align="top"
-                  small
-                />
+              <div className="flex w-full items-start justify-between gap-2">
+                <div className="flex-1">
+                  <InputToggle
+                    value={field.value}
+                    onChange={(value) => {
+                      field.onChange(value)
+                      if (!natGatewayFeature?.id || !setValue) return
+                      if (!value) {
+                        setValue(`features.${natGatewayFeature.id}.value`, false)
+                        setValue(`features.${natGatewayFeature.id}.extendedValue`, undefined)
+                        return
+                      }
+                      setNatGatewaySettings({
+                        static_ips_enabled: natGatewaySettings?.static_ips_enabled ?? false,
+                        static_ips_count: natGatewaySettings?.static_ips_count ?? DEFAULT_STATIC_IPS_COUNT,
+                      })
+                    }}
+                    disabled={disabled || staticIpToggleDisabled}
+                    title="Static IP / Nat Gateways"
+                    description="Your cluster will use NAT Gateways for egress. You can configure static egress IPs below."
+                    align="top"
+                    small
+                  />
+                </div>
                 {staticIpFeature?.is_cloud_provider_paying_feature && (
                   <Tooltip content="Billed by GCP">
                     <ExternalLink
@@ -158,7 +162,7 @@ export function GcpStaticIp({
         </div>
 
         {staticIpEnabled && natGatewayFeature && (
-          <div className="ml-8 flex flex-col gap-3">
+          <div className="flex flex-col gap-4">
             <InputToggle
               value={staticIpsEnabled}
               onChange={(value) =>
@@ -173,20 +177,6 @@ export function GcpStaticIp({
               align="top"
               small
             />
-            {showDowntimeWarning && (
-              <Callout.Root color="yellow">
-                <Callout.Icon>
-                  <Icon iconName="triangle-exclamation" iconStyle="regular" />
-                </Callout.Icon>
-                <Callout.Text>
-                  <Callout.TextHeading>Warning</Callout.TextHeading>
-                  <Callout.TextDescription>
-                    Enabling or disabling static egress IPs may trigger a downtime of a few minutes while the NAT
-                    gateway is reconfigured.
-                  </Callout.TextDescription>
-                </Callout.Text>
-              </Callout.Root>
-            )}
             {staticIpsEnabled && (
               <InputText
                 name="static_ips_count"
@@ -203,13 +193,26 @@ export function GcpStaticIp({
                       : sanitizeStaticIpsCount(parsedValue),
                   })
                 }}
-                hint="Default value is 2."
               />
+            )}
+            {showDowntimeWarning && (
+              <Callout.Root color="yellow">
+                <Callout.Icon>
+                  <Icon iconName="triangle-exclamation" iconStyle="regular" />
+                </Callout.Icon>
+                <Callout.Text>
+                  <Callout.TextHeading>Changing this setting may cause downtime</Callout.TextHeading>
+                  <Callout.TextDescription>
+                    Enabling or disabling static egress IPs may trigger a downtime of a few minutes while the NAT
+                    gateway is reconfigured.
+                  </Callout.TextDescription>
+                </Callout.Text>
+              </Callout.Root>
             )}
           </div>
         )}
 
-        <ExternalLink size="xs" href="https://www.qovery.com/docs/configuration/clusters">
+        <ExternalLink size="xs" href={GCP_NETWORK_DOCUMENTATION_URL}>
           Documentation link
         </ExternalLink>
       </div>

--- a/libs/domains/clusters/feature/src/lib/gcp-static-ip/gcp-static-ip.tsx
+++ b/libs/domains/clusters/feature/src/lib/gcp-static-ip/gcp-static-ip.tsx
@@ -1,0 +1,220 @@
+import { type ClusterFeatureResponse } from 'qovery-typescript-axios'
+import { useEffect } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import { type ClusterFeatureExtendedValue, type ClusterFeaturesData } from '@qovery/shared/interfaces'
+import { BlockContent, Callout, ExternalLink, Icon, InputText, InputToggle, Tooltip } from '@qovery/shared/ui'
+import { type GcpNatGatewaySettings, getGcpNatGatewaySettings } from '../utils/get-gcp-nat-gateway-settings'
+
+const DEFAULT_STATIC_IPS_COUNT = 2
+
+const isGcpNatGatewaySettings = (value: unknown): value is GcpNatGatewaySettings =>
+  Boolean(
+    value &&
+      typeof value === 'object' &&
+      'static_ips_enabled' in value &&
+      typeof value.static_ips_enabled === 'boolean' &&
+      'static_ips_count' in value &&
+      typeof value.static_ips_count === 'number'
+  )
+
+const sanitizeStaticIpsCount = (value: number) => Math.max(1, Math.trunc(value))
+
+const getStaticIpValueFromFeature = (feature?: ClusterFeatureResponse) =>
+  typeof feature?.value_object?.value === 'boolean' ? feature.value_object.value : undefined
+
+export interface GcpStaticIpProps {
+  staticIpFeature?: ClusterFeatureResponse
+  natGatewayFeature?: ClusterFeatureResponse
+  disabled?: boolean
+  staticIpToggleDisabled?: boolean
+  showDowntimeWarning?: boolean
+  production: boolean
+}
+
+export function GcpStaticIp({
+  staticIpFeature,
+  natGatewayFeature,
+  production,
+  disabled = false,
+  staticIpToggleDisabled = false,
+  showDowntimeWarning = false,
+}: GcpStaticIpProps) {
+  const { control, watch, setValue } = useFormContext<ClusterFeaturesData>()
+
+  const isEditable = !disabled
+  const staticIpValueFromFeature = getStaticIpValueFromFeature(staticIpFeature)
+  const staticIpEnabled = staticIpFeature?.id
+    ? watch(`features.${staticIpFeature.id}.value`) ?? staticIpValueFromFeature ?? false
+    : false
+  const natGatewayValueFromFeature = getGcpNatGatewaySettings(natGatewayFeature)
+  const natGatewayEnabled = natGatewayFeature?.id
+    ? watch(`features.${natGatewayFeature.id}.value`) ?? Boolean(natGatewayValueFromFeature)
+    : false
+  const natGatewayExtendedValue = natGatewayFeature?.id
+    ? (watch(`features.${natGatewayFeature.id}.extendedValue`) as ClusterFeatureExtendedValue | undefined)
+    : undefined
+
+  const natGatewaySettings = isGcpNatGatewaySettings(natGatewayExtendedValue)
+    ? natGatewayExtendedValue
+    : natGatewayValueFromFeature
+  const staticIpsEnabled = natGatewaySettings?.static_ips_enabled ?? false
+  const staticIpsCount = natGatewaySettings?.static_ips_count ?? DEFAULT_STATIC_IPS_COUNT
+
+  const setNatGatewaySettings = (settings: GcpNatGatewaySettings) => {
+    if (!natGatewayFeature?.id) return
+    setValue(`features.${natGatewayFeature.id}.value`, true, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    })
+    setValue(`features.${natGatewayFeature.id}.extendedValue`, settings, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    })
+  }
+
+  useEffect(() => {
+    if (!isEditable || !natGatewayFeature?.id || !setValue) return
+
+    if (!staticIpEnabled) {
+      if (natGatewayEnabled) {
+        setValue(`features.${natGatewayFeature.id}.value`, false)
+      }
+      if (natGatewaySettings) {
+        setValue(`features.${natGatewayFeature.id}.extendedValue`, undefined)
+      }
+      return
+    }
+
+    if (!natGatewayEnabled) {
+      setValue(`features.${natGatewayFeature.id}.value`, true)
+    }
+
+    if (!natGatewaySettings) {
+      setValue(`features.${natGatewayFeature.id}.value`, true, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      })
+      setValue(
+        `features.${natGatewayFeature.id}.extendedValue`,
+        { static_ips_enabled: false, static_ips_count: DEFAULT_STATIC_IPS_COUNT },
+        { shouldDirty: true, shouldTouch: true, shouldValidate: true }
+      )
+    }
+  }, [isEditable, natGatewayEnabled, natGatewayFeature?.id, natGatewaySettings, setValue, staticIpEnabled])
+
+  return (
+    <BlockContent title="Static IP / Nat Gateways" classNameContent="p-4">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-3">
+          <Controller
+            name={`features.${staticIpFeature?.id}.value`}
+            control={control}
+            defaultValue={staticIpValueFromFeature ?? production}
+            render={({ field }) => (
+              <div className="flex gap-2">
+                <InputToggle
+                  value={field.value}
+                  onChange={(value) => {
+                    field.onChange(value)
+                    if (!natGatewayFeature?.id || !setValue) return
+                    if (!value) {
+                      setValue(`features.${natGatewayFeature.id}.value`, false)
+                      setValue(`features.${natGatewayFeature.id}.extendedValue`, undefined)
+                      return
+                    }
+                    setNatGatewaySettings({
+                      static_ips_enabled: natGatewaySettings?.static_ips_enabled ?? false,
+                      static_ips_count: natGatewaySettings?.static_ips_count ?? DEFAULT_STATIC_IPS_COUNT,
+                    })
+                  }}
+                  disabled={disabled || staticIpToggleDisabled}
+                  title="Static IP / Nat Gateways"
+                  description="Your cluster will use NAT Gateways for egress. You can configure static egress IPs below."
+                  align="top"
+                  small
+                />
+                {staticIpFeature?.is_cloud_provider_paying_feature && (
+                  <Tooltip content="Billed by GCP">
+                    <ExternalLink
+                      as="button"
+                      href={staticIpFeature.cloud_provider_feature_documentation ?? undefined}
+                      className="relative -top-1 gap-1 px-1.5"
+                      color="neutral"
+                      variant="surface"
+                      size="xs"
+                      radius="full"
+                    >
+                      <Icon iconName="dollar-sign" iconStyle="solid" className="text-xs" />
+                      <Icon name="GCP" height="16" width="16" pathColor="#FFFFFF" />
+                    </ExternalLink>
+                  </Tooltip>
+                )}
+              </div>
+            )}
+          />
+        </div>
+
+        {staticIpEnabled && natGatewayFeature && (
+          <div className="ml-8 flex flex-col gap-3">
+            <InputToggle
+              value={staticIpsEnabled}
+              onChange={(value) =>
+                setNatGatewaySettings({
+                  static_ips_enabled: value,
+                  static_ips_count: sanitizeStaticIpsCount(staticIpsCount),
+                })
+              }
+              disabled={disabled}
+              title="Enable static egress IPs"
+              description="Allocate static egress IP addresses on the NAT Gateway."
+              align="top"
+              small
+            />
+            {showDowntimeWarning && (
+              <Callout.Root color="yellow">
+                <Callout.Icon>
+                  <Icon iconName="triangle-exclamation" iconStyle="regular" />
+                </Callout.Icon>
+                <Callout.Text>
+                  <Callout.TextHeading>Warning</Callout.TextHeading>
+                  <Callout.TextDescription>
+                    Enabling or disabling static egress IPs may trigger a downtime of a few minutes while the NAT
+                    gateway is reconfigured.
+                  </Callout.TextDescription>
+                </Callout.Text>
+              </Callout.Root>
+            )}
+            {staticIpsEnabled && (
+              <InputText
+                name="static_ips_count"
+                label="Static IP count"
+                type="number"
+                value={sanitizeStaticIpsCount(staticIpsCount)}
+                disabled={disabled}
+                onChange={(event) => {
+                  const parsedValue = Number.parseInt(event.currentTarget.value, 10)
+                  setNatGatewaySettings({
+                    static_ips_enabled: staticIpsEnabled,
+                    static_ips_count: Number.isNaN(parsedValue)
+                      ? DEFAULT_STATIC_IPS_COUNT
+                      : sanitizeStaticIpsCount(parsedValue),
+                  })
+                }}
+                hint="Default value is 2."
+              />
+            )}
+          </div>
+        )}
+
+        <ExternalLink size="xs" href="https://www.qovery.com/docs/configuration/clusters">
+          Documentation link
+        </ExternalLink>
+      </div>
+    </BlockContent>
+  )
+}
+
+export default GcpStaticIp

--- a/libs/domains/clusters/feature/src/lib/scaleway-static-ip/scaleway-static-ip.tsx
+++ b/libs/domains/clusters/feature/src/lib/scaleway-static-ip/scaleway-static-ip.tsx
@@ -41,7 +41,7 @@ export function ScalewayStaticIp({
   }, [staticIpEnabled, isEditable, natGatewayFeature?.id, setValue])
 
   return (
-    <BlockContent title="Static IP / Nat Gateways" classNameContent="p-4">
+    <BlockContent title="Static IP / Nat Gateways" classNameContent="w-full p-4">
       <div className="flex flex-col gap-4">
         <div className="flex items-start gap-3">
           <Controller
@@ -49,24 +49,26 @@ export function ScalewayStaticIp({
             control={control}
             defaultValue={production}
             render={({ field }) => (
-              <div className="flex gap-2">
-                <InputToggle
-                  value={field.value}
-                  onChange={(value) => {
-                    field.onChange(value)
-                    // When enabling Static IP, set default NAT Gateway type if not already set
-                    if (value && natGatewayFeature?.id && !natGatewayType && setValue) {
-                      const defaultType = SCALEWAY_NAT_GATEWAY_TYPES[0].value
-                      setValue(`features.${natGatewayFeature.id}.extendedValue`, defaultType)
-                      setValue(`features.${natGatewayFeature.id}.value`, true)
-                    }
-                  }}
-                  disabled={disabled}
-                  title="Static IP / Nat Gateways"
-                  description="Your cluster will only be visible from a fixed number of public IP. On Scaleway, Nat Gateways and Elastic IPs will be setup."
-                  align="top"
-                  small
-                />
+              <div className="flex w-full items-start justify-between gap-2">
+                <div className="flex-1">
+                  <InputToggle
+                    value={field.value}
+                    onChange={(value) => {
+                      field.onChange(value)
+                      // When enabling Static IP, set default NAT Gateway type if not already set
+                      if (value && natGatewayFeature?.id && !natGatewayType && setValue) {
+                        const defaultType = SCALEWAY_NAT_GATEWAY_TYPES[0].value
+                        setValue(`features.${natGatewayFeature.id}.extendedValue`, defaultType)
+                        setValue(`features.${natGatewayFeature.id}.value`, true)
+                      }
+                    }}
+                    disabled={disabled}
+                    title="Static IP / Nat Gateways"
+                    description="Your cluster will only be visible from a fixed number of public IP. On Scaleway, Nat Gateways and Elastic IPs will be setup."
+                    align="top"
+                    small
+                  />
+                </div>
                 {staticIpFeature?.is_cloud_provider_paying_feature && (
                   <Tooltip content="Billed by Scaleway">
                     <ExternalLink
@@ -89,7 +91,7 @@ export function ScalewayStaticIp({
         </div>
 
         {natGatewayFeature && (
-          <div className="ml-8">
+          <div>
             {isEditable ? (
               <Controller
                 name={`features.${natGatewayFeature.id}.extendedValue`}

--- a/libs/domains/clusters/feature/src/lib/scaleway-static-ip/scaleway-static-ip.tsx
+++ b/libs/domains/clusters/feature/src/lib/scaleway-static-ip/scaleway-static-ip.tsx
@@ -126,7 +126,7 @@ export function ScalewayStaticIp({
                         setValue(`features.${natGatewayFeature.id}.value`, true)
                       }
                     }}
-                    value={field.value}
+                    value={typeof field.value === 'string' ? field.value : undefined}
                     disabled={disabled || !staticIpEnabled}
                     portal
                   />

--- a/libs/domains/clusters/feature/src/lib/utils/get-gcp-nat-gateway-settings.spec.ts
+++ b/libs/domains/clusters/feature/src/lib/utils/get-gcp-nat-gateway-settings.spec.ts
@@ -1,0 +1,57 @@
+import { type ClusterFeatureResponse, ClusterFeatureResponseTypeEnum } from 'qovery-typescript-axios'
+import { getGcpNatGatewaySettings } from './get-gcp-nat-gateway-settings'
+
+const makeFeature = (value: object | null): ClusterFeatureResponse => ({
+  id: 'NAT_GATEWAY',
+  value_object: {
+    type: ClusterFeatureResponseTypeEnum.NAT_GATEWAY,
+    value,
+  },
+})
+
+describe('getGcpNatGatewaySettings', () => {
+  it('should return settings when value has GCP nat_gateway_type shape', () => {
+    expect(
+      getGcpNatGatewaySettings(
+        makeFeature({
+          nat_gateway_type: {
+            provider: 'gcp',
+            static_ips_enabled: true,
+            static_ips_count: 3,
+          },
+        })
+      )
+    ).toEqual({
+      static_ips_enabled: true,
+      static_ips_count: 3,
+    })
+  })
+
+  it('should return undefined for Scaleway nat_gateway_type shape', () => {
+    expect(
+      getGcpNatGatewaySettings(
+        makeFeature({
+          nat_gateway_type: {
+            provider: 'scaleway',
+            type: 'VPC-GW-S',
+          },
+        })
+      )
+    ).toBeUndefined()
+  })
+
+  it('should return undefined for null, undefined, or non-NAT_GATEWAY feature', () => {
+    expect(getGcpNatGatewaySettings(undefined)).toBeUndefined()
+    expect(
+      getGcpNatGatewaySettings({
+        id: 'STATIC_IP',
+        value_object: { type: ClusterFeatureResponseTypeEnum.BOOLEAN, value: true },
+      })
+    ).toBeUndefined()
+  })
+
+  it('should return undefined when nat_gateway_type is null or missing', () => {
+    expect(getGcpNatGatewaySettings(makeFeature(null))).toBeUndefined()
+    expect(getGcpNatGatewaySettings(makeFeature({ nat_gateway_type: null }))).toBeUndefined()
+  })
+})

--- a/libs/domains/clusters/feature/src/lib/utils/get-gcp-nat-gateway-settings.ts
+++ b/libs/domains/clusters/feature/src/lib/utils/get-gcp-nat-gateway-settings.ts
@@ -1,0 +1,17 @@
+import { type ClusterFeatureNatGatewayTypeGcp, type ClusterFeatureResponse } from 'qovery-typescript-axios'
+
+export type GcpNatGatewaySettings = {
+  static_ips_enabled: boolean
+  static_ips_count: number
+}
+
+export const getGcpNatGatewaySettings = (feature?: ClusterFeatureResponse): GcpNatGatewaySettings | undefined => {
+  const valueObj = feature?.value_object
+  if (valueObj?.type !== 'NAT_GATEWAY') return undefined
+  const natGatewayType = valueObj.value?.nat_gateway_type
+  if (natGatewayType && natGatewayType.provider === 'gcp') {
+    const { static_ips_enabled, static_ips_count } = natGatewayType as ClusterFeatureNatGatewayTypeGcp
+    return { static_ips_enabled, static_ips_count }
+  }
+  return undefined
+}

--- a/libs/shared/interfaces/src/lib/domain/cluster-creation-flow.interface.ts
+++ b/libs/shared/interfaces/src/lib/domain/cluster-creation-flow.interface.ts
@@ -65,6 +65,13 @@ export type Subnets = {
   C: string
 }
 
+export type ClusterFeatureExtendedValue =
+  | string
+  | {
+      static_ips_enabled: boolean
+      static_ips_count: number
+    }
+
 export type ClusterFeaturesData = {
   vpc_mode: 'DEFAULT' | 'EXISTING_VPC' | undefined
   aws_existing_vpc?: {
@@ -89,7 +96,7 @@ export type ClusterFeaturesData = {
       id: string
       title: string
       value: boolean
-      extendedValue?: string
+      extendedValue?: ClusterFeatureExtendedValue
     }
   }
 }


### PR DESCRIPTION


## Summary
https://qovery.atlassian.net/browse/QOV-1901

for GCP add new option to configure nat gateway
https://p80-z1d5ada7b-zbfc30c89-gtw.zc531a994.rustrocks.cloud/organization/21bd04fb-7b93-45c5-9957-4325d833a05a/cluster/47e795a1-ffc9-4db3-929c-70d8fabe12fa/settings/network

<img width="1061" height="847" alt="Screenshot 2026-05-19 at 11 37 53" src="https://github.com/user-attachments/assets/9c6ad9c8-2afb-4268-9942-c7b53a956f8a" />

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
