### PR TITLE
feat(monitoring): add k8s event

### DIFF
--- a/libs/domains/observability/data-access/src/lib/domains-observability-data-access.ts
+++ b/libs/domains/observability/data-access/src/lib/domains-observability-data-access.ts
@@ -9,6 +9,7 @@ import {
   type AlertRuleEditRequest,
   AlertRulesApi,
   ClustersApi,
+  type GetClusterKubernetesEvents200ResponseResultsInner,
 } from 'qovery-typescript-axios'
 
 const clusterApi = new ClustersApi()
@@ -305,6 +306,34 @@ export const observability = createQueryKeys('observability', {
         endTimestamp
       )
       return typeof response.data.response === 'string' ? JSON.parse(response.data.response) : response.data.response
+    },
+  }),
+  kubernetesEvents: ({
+    clusterId,
+    fromDateTime,
+    toDateTime,
+    nodeName,
+    podName,
+    reportingComponent,
+  }: {
+    clusterId: string
+    fromDateTime: string
+    toDateTime: string
+    nodeName?: string
+    podName?: string
+    reportingComponent?: string
+  }) => ({
+    queryKey: [clusterId, fromDateTime, toDateTime, nodeName, podName, reportingComponent],
+    async queryFn(): Promise<GetClusterKubernetesEvents200ResponseResultsInner[]> {
+      const response = await clusterApi.getClusterKubernetesEvents(
+        clusterId,
+        fromDateTime,
+        toDateTime,
+        nodeName,
+        podName,
+        reportingComponent
+      )
+      return response.data.results ?? []
     },
   }),
   alertRules: ({ organizationId }: { organizationId: string }) => ({

--- a/libs/domains/observability/feature/src/lib/hooks/use-kubernetes-event-details/use-kubernetes-event-details.ts
+++ b/libs/domains/observability/feature/src/lib/hooks/use-kubernetes-event-details/use-kubernetes-event-details.ts
@@ -1,0 +1,102 @@
+import { useQuery } from '@tanstack/react-query'
+import type { GetClusterKubernetesEvents200ResponseResultsInner } from 'qovery-typescript-axios'
+import { useMemo } from 'react'
+import { observability } from '@qovery/domains/observability/data-access'
+import type { ReferenceLineEvent } from '../../local-chart/local-chart'
+
+const WINDOW_MS = 2 * 60 * 60 * 1000
+
+interface KubernetesEventApiResponse extends GetClusterKubernetesEvents200ResponseResultsInner {
+  createdAt?: string
+  firstOccurrence?: string
+  lastOccurrence?: string
+  reportingComponent?: string
+}
+
+export interface KubernetesEventDetail extends KubernetesEventApiResponse {
+  distance: number
+  timestamp: number
+}
+
+export interface UseKubernetesEventDetailsProps {
+  clusterId: string
+  serviceId: string
+  event: ReferenceLineEvent
+}
+
+function parseIsoTimestamp(timestamp?: string): number | undefined {
+  if (!timestamp) return undefined
+  const parsed = new Date(timestamp).getTime()
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function getShortServiceId(serviceId: string): string {
+  return serviceId.split('-')[0]
+}
+
+function getEventTimestamp(event: KubernetesEventApiResponse): number | undefined {
+  return (
+    parseIsoTimestamp(event.lastOccurrence ?? event.last_occurrence) ??
+    parseIsoTimestamp(event.firstOccurrence ?? event.first_occurrence) ??
+    parseIsoTimestamp(event.createdAt ?? event.created_at)
+  )
+}
+
+function hasServiceHint(event: KubernetesEventApiResponse, serviceId: string): boolean {
+  const shortServiceId = getShortServiceId(serviceId)
+  const name = event.name ?? ''
+  return Boolean(shortServiceId && (name.includes(shortServiceId) || name.includes(`z${shortServiceId}`)))
+}
+
+function findNearestKubernetesEvent(
+  events: KubernetesEventApiResponse[] | undefined,
+  event: ReferenceLineEvent,
+  serviceId: string
+): KubernetesEventDetail | undefined {
+  if (!events?.length) return undefined
+
+  const candidates = events.filter((kubernetesEvent) => {
+    const hasMatchingReason = kubernetesEvent.reason === event.reason
+    const isPodEvent = !kubernetesEvent.kind || kubernetesEvent.kind === 'Pod'
+    return hasMatchingReason && isPodEvent && getEventTimestamp(kubernetesEvent)
+  })
+
+  const serviceCandidates = candidates.filter((kubernetesEvent) => hasServiceHint(kubernetesEvent, serviceId))
+  const pool = serviceCandidates.length > 0 ? serviceCandidates : candidates
+
+  return pool
+    .map((kubernetesEvent) => {
+      const timestamp = getEventTimestamp(kubernetesEvent) ?? event.timestamp
+      return {
+        ...kubernetesEvent,
+        distance: Math.abs(timestamp - event.timestamp),
+        timestamp,
+      }
+    })
+    .sort((a, b) => a.distance - b.distance)[0]
+}
+
+export function useKubernetesEventDetails({ clusterId, serviceId, event }: UseKubernetesEventDetailsProps) {
+  const fromDateTime = new Date(event.timestamp - WINDOW_MS).toISOString()
+  const toDateTime = new Date(event.timestamp + WINDOW_MS).toISOString()
+  const podName = getShortServiceId(serviceId)
+
+  const { data } = useQuery({
+    ...observability.kubernetesEvents({
+      clusterId,
+      fromDateTime,
+      toDateTime,
+      podName,
+    }),
+    staleTime: 60_000,
+    suspense: true,
+  })
+
+  const detail = useMemo(() => findNearestKubernetesEvent(data, event, serviceId), [data, event, serviceId])
+
+  return {
+    detail,
+    firstOccurrence: detail?.firstOccurrence ?? detail?.first_occurrence,
+    reportingComponent: detail?.reportingComponent ?? detail?.reporting_component,
+  }
+}

--- a/libs/domains/observability/feature/src/lib/hooks/use-kubernetes-event-details/use-kubernetes-event-details.ts
+++ b/libs/domains/observability/feature/src/lib/hooks/use-kubernetes-event-details/use-kubernetes-event-details.ts
@@ -48,6 +48,10 @@ function hasServiceHint(event: KubernetesEventApiResponse, serviceId: string): b
   return Boolean(shortServiceId && (name.includes(shortServiceId) || name.includes(`z${shortServiceId}`)))
 }
 
+function matchesPod(event: KubernetesEventApiResponse, podName?: string): boolean {
+  return Boolean(podName && event.name === podName)
+}
+
 function findNearestKubernetesEvent(
   events: KubernetesEventApiResponse[] | undefined,
   event: ReferenceLineEvent,
@@ -60,6 +64,20 @@ function findNearestKubernetesEvent(
     const isPodEvent = !kubernetesEvent.kind || kubernetesEvent.kind === 'Pod'
     return hasMatchingReason && isPodEvent && getEventTimestamp(kubernetesEvent)
   })
+
+  const podCandidates = candidates.filter((kubernetesEvent) => matchesPod(kubernetesEvent, event.pod))
+  if (podCandidates.length > 0) {
+    return podCandidates
+      .map((kubernetesEvent) => {
+        const timestamp = getEventTimestamp(kubernetesEvent) ?? event.timestamp
+        return {
+          ...kubernetesEvent,
+          distance: Math.abs(timestamp - event.timestamp),
+          timestamp,
+        }
+      })
+      .sort((a, b) => a.distance - b.distance)[0]
+  }
 
   const serviceCandidates = candidates.filter((kubernetesEvent) => hasServiceHint(kubernetesEvent, serviceId))
   const pool = serviceCandidates.length > 0 ? serviceCandidates : candidates
@@ -79,7 +97,7 @@ function findNearestKubernetesEvent(
 export function useKubernetesEventDetails({ clusterId, serviceId, event }: UseKubernetesEventDetailsProps) {
   const fromDateTime = new Date(event.timestamp - WINDOW_MS).toISOString()
   const toDateTime = new Date(event.timestamp + WINDOW_MS).toISOString()
-  const podName = getShortServiceId(serviceId)
+  const podName = event.pod ?? getShortServiceId(serviceId)
 
   const { data } = useQuery({
     ...observability.kubernetesEvents({

--- a/libs/domains/observability/feature/src/lib/local-chart/event-sidebar.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/local-chart/event-sidebar.spec.tsx
@@ -52,17 +52,17 @@ describe('EventSidebar', () => {
   ]
 
   it('should render successfully', () => {
-    const { baseElement } = renderWithProviders(<EventSidebar events={[]} />)
+    const { baseElement } = renderWithProviders(<EventSidebar serviceId="service-1" events={[]} />)
     expect(baseElement).toBeTruthy()
   })
 
   it('should render with no events', () => {
-    renderWithProviders(<EventSidebar events={[]} />)
+    renderWithProviders(<EventSidebar serviceId="service-1" events={[]} />)
     expect(screen.getByText('No events associated')).toBeInTheDocument()
   })
 
   it('should render events list when events are provided', () => {
-    renderWithProviders(<EventSidebar events={mockEvents} />)
+    renderWithProviders(<EventSidebar serviceId="service-1" events={mockEvents} />)
 
     expect(screen.getByText('Events associated')).toBeInTheDocument()
     expect(screen.getByText('Deployed')).toBeInTheDocument()
@@ -71,12 +71,12 @@ describe('EventSidebar', () => {
   })
 
   it('should display singular Event when only one event', () => {
-    renderWithProviders(<EventSidebar events={[mockEvents[0]]} />)
+    renderWithProviders(<EventSidebar serviceId="service-1" events={[mockEvents[0]]} />)
     expect(screen.getByText('Event associated')).toBeInTheDocument()
   })
 
   it('should display plural Events when multiple events', () => {
-    renderWithProviders(<EventSidebar events={mockEvents} />)
+    renderWithProviders(<EventSidebar serviceId="service-1" events={mockEvents} />)
     expect(screen.getByText('Events associated')).toBeInTheDocument()
   })
 })

--- a/libs/domains/observability/feature/src/lib/local-chart/event-sidebar.tsx
+++ b/libs/domains/observability/feature/src/lib/local-chart/event-sidebar.tsx
@@ -1,19 +1,196 @@
+import { useQuery } from '@tanstack/react-query'
+import type { GetClusterKubernetesEvents200ResponseResultsInner } from 'qovery-typescript-axios'
+import { useState } from 'react'
+import { observability } from '@qovery/domains/observability/data-access'
 import type { AnyService } from '@qovery/domains/services/data-access'
-import { Badge, Icon, Skeleton, Tooltip } from '@qovery/shared/ui'
+import { Badge, DescriptionList, Icon, Skeleton, Tooltip } from '@qovery/shared/ui'
 import { getColorByPod } from '@qovery/shared/util-hooks'
-import { pluralize } from '@qovery/shared/util-js'
+import { pluralize, twMerge } from '@qovery/shared/util-js'
 import { formatTimestamp } from '../util-chart/format-timestamp'
 import { useDashboardContext } from '../util-filter/dashboard-context'
 import type { ReferenceLineEvent } from './local-chart'
 
 export interface EventSidebarProps {
   events: ReferenceLineEvent[]
+  clusterId?: string
+  serviceId: string
   service?: AnyService
   isLoading?: boolean
 }
 
-export function EventSidebar({ events, service, isLoading = false }: EventSidebarProps) {
+interface KubernetesEventApiResponse extends GetClusterKubernetesEvents200ResponseResultsInner {
+  createdAt?: string
+  firstOccurrence?: string
+  lastOccurrence?: string
+  reportingComponent?: string
+}
+
+interface KubernetesEventDetail extends KubernetesEventApiResponse {
+  distance: number
+  timestamp: number
+}
+
+function parseIsoTimestamp(timestamp?: string): number | undefined {
+  if (!timestamp) return undefined
+  const parsed = new Date(timestamp).getTime()
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function getShortServiceId(serviceId: string): string {
+  return serviceId.split('-')[0]
+}
+
+function getEventTimestamp(event: KubernetesEventApiResponse): number | undefined {
+  return (
+    parseIsoTimestamp(event.lastOccurrence ?? event.last_occurrence) ??
+    parseIsoTimestamp(event.firstOccurrence ?? event.first_occurrence) ??
+    parseIsoTimestamp(event.createdAt ?? event.created_at)
+  )
+}
+
+function hasServiceHint(event: KubernetesEventApiResponse, serviceId: string): boolean {
+  const shortServiceId = getShortServiceId(serviceId)
+  const name = event.name ?? ''
+  return Boolean(shortServiceId && (name.includes(shortServiceId) || name.includes(`z${shortServiceId}`)))
+}
+
+function findNearestKubernetesEvent(
+  events: KubernetesEventApiResponse[] | undefined,
+  event: ReferenceLineEvent,
+  serviceId: string
+): KubernetesEventDetail | undefined {
+  if (!events?.length) return undefined
+
+  const candidates = events.filter((kubernetesEvent) => {
+    const hasMatchingReason = kubernetesEvent.reason === event.reason
+    const isPodEvent = !kubernetesEvent.kind || kubernetesEvent.kind === 'Pod'
+    return hasMatchingReason && isPodEvent && getEventTimestamp(kubernetesEvent)
+  })
+
+  const serviceCandidates = candidates.filter((kubernetesEvent) => hasServiceHint(kubernetesEvent, serviceId))
+  const pool = serviceCandidates.length > 0 ? serviceCandidates : candidates
+
+  return pool
+    .map((kubernetesEvent) => {
+      const timestamp = getEventTimestamp(kubernetesEvent) ?? event.timestamp
+      return {
+        ...kubernetesEvent,
+        distance: Math.abs(timestamp - event.timestamp),
+        timestamp,
+      }
+    })
+    .sort((a, b) => a.distance - b.distance)[0]
+}
+
+function KubernetesEventDetails({
+  clusterId,
+  serviceId,
+  event,
+}: {
+  clusterId?: string
+  serviceId: string
+  event: ReferenceLineEvent
+}) {
+  const WINDOW_MS = 2 * 60 * 60 * 1000
   const { useLocalTime } = useDashboardContext()
+  const fromDateTime = new Date(event.timestamp - WINDOW_MS).toISOString()
+  const toDateTime = new Date(event.timestamp + WINDOW_MS).toISOString()
+  const podName = getShortServiceId(serviceId)
+
+  const { data, isLoading } = useQuery({
+    ...observability.kubernetesEvents({
+      clusterId: clusterId ?? '',
+      fromDateTime,
+      toDateTime,
+      podName,
+    }),
+    enabled: Boolean(clusterId && serviceId && event.type === 'k8s-event'),
+    staleTime: 60_000,
+  })
+
+  const detail = findNearestKubernetesEvent(data as KubernetesEventApiResponse[] | undefined, event, serviceId)
+  const firstOccurrence = detail?.firstOccurrence ?? detail?.first_occurrence
+  const reportingComponent = detail?.reportingComponent ?? detail?.reporting_component
+
+  if (!clusterId) {
+    return (
+      <div className="mt-2 border-l border-neutral pl-3">
+        <span className="text-neutral-subtle">Kubernetes event details are not available.</span>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="mt-2 flex flex-col gap-1 border-l border-neutral pl-3">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+    )
+  }
+
+  if (!detail) {
+    return (
+      <div className="mt-2 border-l border-neutral pl-3">
+        <span className="text-neutral-subtle">No matching Kubernetes event found.</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-2 flex flex-col gap-2 border-l border-neutral pl-3">
+      {detail.message && <p className="font-medium leading-5 text-neutral">{detail.message}</p>}
+      <DescriptionList.Root className="grid-cols-[max-content_minmax(0,_1fr)] gap-x-3 gap-y-1 text-xs">
+        {firstOccurrence && (
+          <>
+            <DescriptionList.Term className="whitespace-nowrap">Kubernetes time</DescriptionList.Term>
+            <DescriptionList.Details className="min-w-0 break-words">
+              {formatTimestamp(new Date(firstOccurrence).getTime(), useLocalTime).fullTimeString}
+            </DescriptionList.Details>
+          </>
+        )}
+        <DescriptionList.Term className="whitespace-nowrap">Monitoring marker</DescriptionList.Term>
+        <DescriptionList.Details className="min-w-0 break-words">
+          {formatTimestamp(event.timestamp, useLocalTime).fullTimeString}
+        </DescriptionList.Details>
+        <DescriptionList.Term className="whitespace-nowrap">Matched event time</DescriptionList.Term>
+        <DescriptionList.Details className="min-w-0 break-words">
+          {formatTimestamp(detail.timestamp, useLocalTime).fullTimeString}
+        </DescriptionList.Details>
+        {detail.name && (
+          <>
+            <DescriptionList.Term className="whitespace-nowrap">Pod</DescriptionList.Term>
+            <DescriptionList.Details className="min-w-0 break-words font-code">{detail.name}</DescriptionList.Details>
+          </>
+        )}
+        {detail.namespace && (
+          <>
+            <DescriptionList.Term className="whitespace-nowrap">Namespace</DescriptionList.Term>
+            <DescriptionList.Details className="min-w-0 break-words font-code">
+              {detail.namespace}
+            </DescriptionList.Details>
+          </>
+        )}
+        {reportingComponent && (
+          <>
+            <DescriptionList.Term className="whitespace-nowrap">Component</DescriptionList.Term>
+            <DescriptionList.Details className="min-w-0 break-words">{reportingComponent}</DescriptionList.Details>
+          </>
+        )}
+        {detail.count !== undefined && (
+          <>
+            <DescriptionList.Term className="whitespace-nowrap">Count</DescriptionList.Term>
+            <DescriptionList.Details>{detail.count}</DescriptionList.Details>
+          </>
+        )}
+      </DescriptionList.Root>
+    </div>
+  )
+}
+
+export function EventSidebar({ events, clusterId, serviceId, service, isLoading = false }: EventSidebarProps) {
+  const { useLocalTime } = useDashboardContext()
+  const [expandedEventKey, setExpandedEventKey] = useState<string>()
 
   return (
     <div className="flex h-[87vh] w-full min-w-[420px] max-w-[420px] flex-col border-l border-neutral">
@@ -40,11 +217,21 @@ export function EventSidebar({ events, service, isLoading = false }: EventSideba
             {events.map((event) => {
               const timestamp = formatTimestamp(event.timestamp, useLocalTime)
               const key = event.key
+              const isExpandable = event.type === 'k8s-event'
+              const isExpanded = expandedEventKey === key
               return (
                 <div
                   key={key}
-                  className="flex gap-2 border-b border-neutral px-4 py-2 text-sm text-neutral-subtle hover:bg-surface-neutral-componentHover"
+                  className={twMerge(
+                    'flex gap-2 border-b border-neutral px-4 py-2 text-sm text-neutral-subtle hover:bg-surface-neutral-componentHover',
+                    isExpandable && 'cursor-pointer',
+                    isExpanded && 'bg-surface-neutral-subtle'
+                  )}
                   data-event-key={key}
+                  onClick={() => {
+                    if (!isExpandable) return
+                    setExpandedEventKey((current) => (current === key ? undefined : key))
+                  }}
                   onMouseEnter={() => {
                     const referenceLine = document.querySelectorAll(`.recharts-reference-line-line[name="${key}"]`)
                     referenceLine.forEach((line) => {
@@ -71,7 +258,27 @@ export function EventSidebar({ events, service, isLoading = false }: EventSideba
                   <div className="flex w-full flex-col gap-1 text-xs">
                     <div className="flex w-full items-center justify-between gap-2">
                       <span className="font-medium">{event.reason}</span>
-                      <span className="text-neutral-subtle">{timestamp.fullTimeString}</span>
+                      <div className="flex items-center gap-1">
+                        <span className="text-neutral-subtle">{timestamp.fullTimeString}</span>
+                        {isExpandable && (
+                          <button
+                            type="button"
+                            className="focus:ring-brand-500 flex h-5 w-5 items-center justify-center rounded text-neutral-subtle hover:bg-surface-neutral-subtle hover:text-neutral focus:outline-none focus:ring-2"
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              setExpandedEventKey((current) => (current === key ? undefined : key))
+                            }}
+                            aria-expanded={isExpanded}
+                            aria-label={isExpanded ? 'Hide Kubernetes event details' : 'Show Kubernetes event details'}
+                          >
+                            <Icon
+                              iconName={isExpanded ? 'chevron-down' : 'chevron-right'}
+                              iconStyle="regular"
+                              className="text-xs"
+                            />
+                          </button>
+                        )}
+                      </div>
                     </div>
                     {event.type === 'event' && (
                       <>
@@ -103,6 +310,7 @@ export function EventSidebar({ events, service, isLoading = false }: EventSideba
                         </Tooltip>
                       </div>
                     )}
+                    {isExpanded && <KubernetesEventDetails clusterId={clusterId} serviceId={serviceId} event={event} />}
                   </div>
                 </div>
               )

--- a/libs/domains/observability/feature/src/lib/local-chart/event-sidebar.tsx
+++ b/libs/domains/observability/feature/src/lib/local-chart/event-sidebar.tsx
@@ -1,11 +1,9 @@
-import { useQuery } from '@tanstack/react-query'
-import type { GetClusterKubernetesEvents200ResponseResultsInner } from 'qovery-typescript-axios'
-import { useState } from 'react'
-import { observability } from '@qovery/domains/observability/data-access'
+import { Suspense, useState } from 'react'
 import type { AnyService } from '@qovery/domains/services/data-access'
-import { Badge, DescriptionList, Icon, Skeleton, Tooltip } from '@qovery/shared/ui'
+import { Badge, Button, DescriptionList, Icon, Skeleton, Tooltip } from '@qovery/shared/ui'
 import { getColorByPod } from '@qovery/shared/util-hooks'
 import { pluralize, twMerge } from '@qovery/shared/util-js'
+import { useKubernetesEventDetails } from '../hooks/use-kubernetes-event-details/use-kubernetes-event-details'
 import { formatTimestamp } from '../util-chart/format-timestamp'
 import { useDashboardContext } from '../util-filter/dashboard-context'
 import type { ReferenceLineEvent } from './local-chart'
@@ -18,68 +16,42 @@ export interface EventSidebarProps {
   isLoading?: boolean
 }
 
-interface KubernetesEventApiResponse extends GetClusterKubernetesEvents200ResponseResultsInner {
-  createdAt?: string
-  firstOccurrence?: string
-  lastOccurrence?: string
-  reportingComponent?: string
-}
-
-interface KubernetesEventDetail extends KubernetesEventApiResponse {
-  distance: number
-  timestamp: number
-}
-
-function parseIsoTimestamp(timestamp?: string): number | undefined {
-  if (!timestamp) return undefined
-  const parsed = new Date(timestamp).getTime()
-  return Number.isFinite(parsed) ? parsed : undefined
-}
-
-function getShortServiceId(serviceId: string): string {
-  return serviceId.split('-')[0]
-}
-
-function getEventTimestamp(event: KubernetesEventApiResponse): number | undefined {
+function KubernetesEventDetailsUnavailable() {
   return (
-    parseIsoTimestamp(event.lastOccurrence ?? event.last_occurrence) ??
-    parseIsoTimestamp(event.firstOccurrence ?? event.first_occurrence) ??
-    parseIsoTimestamp(event.createdAt ?? event.created_at)
+    <div className="mt-2 border-l border-neutral pl-3">
+      <span className="text-neutral-subtle">Kubernetes event details are not available.</span>
+    </div>
   )
 }
 
-function hasServiceHint(event: KubernetesEventApiResponse, serviceId: string): boolean {
-  const shortServiceId = getShortServiceId(serviceId)
-  const name = event.name ?? ''
-  return Boolean(shortServiceId && (name.includes(shortServiceId) || name.includes(`z${shortServiceId}`)))
-}
-
-function findNearestKubernetesEvent(
-  events: KubernetesEventApiResponse[] | undefined,
-  event: ReferenceLineEvent,
-  serviceId: string
-): KubernetesEventDetail | undefined {
-  if (!events?.length) return undefined
-
-  const candidates = events.filter((kubernetesEvent) => {
-    const hasMatchingReason = kubernetesEvent.reason === event.reason
-    const isPodEvent = !kubernetesEvent.kind || kubernetesEvent.kind === 'Pod'
-    return hasMatchingReason && isPodEvent && getEventTimestamp(kubernetesEvent)
-  })
-
-  const serviceCandidates = candidates.filter((kubernetesEvent) => hasServiceHint(kubernetesEvent, serviceId))
-  const pool = serviceCandidates.length > 0 ? serviceCandidates : candidates
-
-  return pool
-    .map((kubernetesEvent) => {
-      const timestamp = getEventTimestamp(kubernetesEvent) ?? event.timestamp
-      return {
-        ...kubernetesEvent,
-        distance: Math.abs(timestamp - event.timestamp),
-        timestamp,
-      }
-    })
-    .sort((a, b) => a.distance - b.distance)[0]
+function KubernetesEventDetailsButton({
+  isExpanded,
+  isLoading = false,
+  onClick,
+}: {
+  isExpanded: boolean
+  isLoading?: boolean
+  onClick: () => void
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      color="neutral"
+      size="xs"
+      className={twMerge('mt-1 w-fit shrink-0 gap-1.5', isLoading && 'pointer-events-auto')}
+      onClick={(event) => {
+        event.stopPropagation()
+        if (isLoading) return
+        onClick()
+      }}
+      aria-expanded={isExpanded}
+      aria-label={isExpanded ? 'Hide Kubernetes event details' : 'Show Kubernetes event details'}
+      loading={isLoading}
+    >
+      {isExpanded ? 'Hide details' : 'See details'}
+    </Button>
+  )
 }
 
 function KubernetesEventDetails({
@@ -87,47 +59,12 @@ function KubernetesEventDetails({
   serviceId,
   event,
 }: {
-  clusterId?: string
+  clusterId: string
   serviceId: string
   event: ReferenceLineEvent
 }) {
-  const WINDOW_MS = 2 * 60 * 60 * 1000
   const { useLocalTime } = useDashboardContext()
-  const fromDateTime = new Date(event.timestamp - WINDOW_MS).toISOString()
-  const toDateTime = new Date(event.timestamp + WINDOW_MS).toISOString()
-  const podName = getShortServiceId(serviceId)
-
-  const { data, isLoading } = useQuery({
-    ...observability.kubernetesEvents({
-      clusterId: clusterId ?? '',
-      fromDateTime,
-      toDateTime,
-      podName,
-    }),
-    enabled: Boolean(clusterId && serviceId && event.type === 'k8s-event'),
-    staleTime: 60_000,
-  })
-
-  const detail = findNearestKubernetesEvent(data as KubernetesEventApiResponse[] | undefined, event, serviceId)
-  const firstOccurrence = detail?.firstOccurrence ?? detail?.first_occurrence
-  const reportingComponent = detail?.reportingComponent ?? detail?.reporting_component
-
-  if (!clusterId) {
-    return (
-      <div className="mt-2 border-l border-neutral pl-3">
-        <span className="text-neutral-subtle">Kubernetes event details are not available.</span>
-      </div>
-    )
-  }
-
-  if (isLoading) {
-    return (
-      <div className="mt-2 flex flex-col gap-1 border-l border-neutral pl-3">
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-2/3" />
-      </div>
-    )
-  }
+  const { detail, firstOccurrence, reportingComponent } = useKubernetesEventDetails({ clusterId, serviceId, event })
 
   if (!detail) {
     return (
@@ -144,29 +81,31 @@ function KubernetesEventDetails({
         {firstOccurrence && (
           <>
             <DescriptionList.Term className="whitespace-nowrap">Kubernetes time</DescriptionList.Term>
-            <DescriptionList.Details className="min-w-0 break-words">
+            <DescriptionList.Details className="min-w-0 break-words font-code font-normal text-neutral">
               {formatTimestamp(new Date(firstOccurrence).getTime(), useLocalTime).fullTimeString}
             </DescriptionList.Details>
           </>
         )}
         <DescriptionList.Term className="whitespace-nowrap">Monitoring marker</DescriptionList.Term>
-        <DescriptionList.Details className="min-w-0 break-words">
+        <DescriptionList.Details className="min-w-0 break-words font-code font-normal text-neutral">
           {formatTimestamp(event.timestamp, useLocalTime).fullTimeString}
         </DescriptionList.Details>
         <DescriptionList.Term className="whitespace-nowrap">Matched event time</DescriptionList.Term>
-        <DescriptionList.Details className="min-w-0 break-words">
+        <DescriptionList.Details className="min-w-0 break-words font-code font-normal text-neutral">
           {formatTimestamp(detail.timestamp, useLocalTime).fullTimeString}
         </DescriptionList.Details>
         {detail.name && (
           <>
             <DescriptionList.Term className="whitespace-nowrap">Pod</DescriptionList.Term>
-            <DescriptionList.Details className="min-w-0 break-words font-code">{detail.name}</DescriptionList.Details>
+            <DescriptionList.Details className="min-w-0 break-words font-code font-normal text-neutral">
+              {detail.name}
+            </DescriptionList.Details>
           </>
         )}
         {detail.namespace && (
           <>
             <DescriptionList.Term className="whitespace-nowrap">Namespace</DescriptionList.Term>
-            <DescriptionList.Details className="min-w-0 break-words font-code">
+            <DescriptionList.Details className="min-w-0 break-words font-code font-normal text-neutral">
               {detail.namespace}
             </DescriptionList.Details>
           </>
@@ -174,17 +113,40 @@ function KubernetesEventDetails({
         {reportingComponent && (
           <>
             <DescriptionList.Term className="whitespace-nowrap">Component</DescriptionList.Term>
-            <DescriptionList.Details className="min-w-0 break-words">{reportingComponent}</DescriptionList.Details>
+            <DescriptionList.Details className="min-w-0 break-words font-code font-normal text-neutral">
+              {reportingComponent}
+            </DescriptionList.Details>
           </>
         )}
         {detail.count !== undefined && (
           <>
             <DescriptionList.Term className="whitespace-nowrap">Count</DescriptionList.Term>
-            <DescriptionList.Details>{detail.count}</DescriptionList.Details>
+            <DescriptionList.Details className="font-code font-normal text-neutral">
+              {detail.count}
+            </DescriptionList.Details>
           </>
         )}
       </DescriptionList.Root>
     </div>
+  )
+}
+
+function KubernetesEventDetailsExpanded({
+  clusterId,
+  serviceId,
+  event,
+  onToggle,
+}: {
+  clusterId: string
+  serviceId: string
+  event: ReferenceLineEvent
+  onToggle: () => void
+}) {
+  return (
+    <>
+      <KubernetesEventDetailsButton isExpanded onClick={onToggle} />
+      <KubernetesEventDetails clusterId={clusterId} serviceId={serviceId} event={event} />
+    </>
   )
 }
 
@@ -219,19 +181,15 @@ export function EventSidebar({ events, clusterId, serviceId, service, isLoading 
               const key = event.key
               const isExpandable = event.type === 'k8s-event'
               const isExpanded = expandedEventKey === key
+              const toggleEventDetails = () => {
+                setExpandedEventKey((current) => (current === key ? undefined : key))
+              }
+
               return (
                 <div
                   key={key}
-                  className={twMerge(
-                    'flex gap-2 border-b border-neutral px-4 py-2 text-sm text-neutral-subtle hover:bg-surface-neutral-componentHover',
-                    isExpandable && 'cursor-pointer',
-                    isExpanded && 'bg-surface-neutral-subtle'
-                  )}
+                  className="flex gap-2 border-b border-neutral px-4 py-2 text-sm text-neutral-subtle hover:bg-surface-neutral-componentHover"
                   data-event-key={key}
-                  onClick={() => {
-                    if (!isExpandable) return
-                    setExpandedEventKey((current) => (current === key ? undefined : key))
-                  }}
                   onMouseEnter={() => {
                     const referenceLine = document.querySelectorAll(`.recharts-reference-line-line[name="${key}"]`)
                     referenceLine.forEach((line) => {
@@ -258,27 +216,7 @@ export function EventSidebar({ events, clusterId, serviceId, service, isLoading 
                   <div className="flex w-full flex-col gap-1 text-xs">
                     <div className="flex w-full items-center justify-between gap-2">
                       <span className="font-medium">{event.reason}</span>
-                      <div className="flex items-center gap-1">
-                        <span className="text-neutral-subtle">{timestamp.fullTimeString}</span>
-                        {isExpandable && (
-                          <button
-                            type="button"
-                            className="focus:ring-brand-500 flex h-5 w-5 items-center justify-center rounded text-neutral-subtle hover:bg-surface-neutral-subtle hover:text-neutral focus:outline-none focus:ring-2"
-                            onClick={(event) => {
-                              event.stopPropagation()
-                              setExpandedEventKey((current) => (current === key ? undefined : key))
-                            }}
-                            aria-expanded={isExpanded}
-                            aria-label={isExpanded ? 'Hide Kubernetes event details' : 'Show Kubernetes event details'}
-                          >
-                            <Icon
-                              iconName={isExpanded ? 'chevron-down' : 'chevron-right'}
-                              iconStyle="regular"
-                              className="text-xs"
-                            />
-                          </button>
-                        )}
-                      </div>
+                      <span className="text-neutral-subtle">{timestamp.fullTimeString}</span>
                     </div>
                     {event.type === 'event' && (
                       <>
@@ -310,7 +248,27 @@ export function EventSidebar({ events, clusterId, serviceId, service, isLoading 
                         </Tooltip>
                       </div>
                     )}
-                    {isExpanded && <KubernetesEventDetails clusterId={clusterId} serviceId={serviceId} event={event} />}
+                    {isExpandable && (
+                      <>
+                        {isExpanded && clusterId ? (
+                          <Suspense
+                            fallback={
+                              <KubernetesEventDetailsButton isExpanded isLoading onClick={toggleEventDetails} />
+                            }
+                          >
+                            <KubernetesEventDetailsExpanded
+                              clusterId={clusterId}
+                              serviceId={serviceId}
+                              event={event}
+                              onToggle={toggleEventDetails}
+                            />
+                          </Suspense>
+                        ) : (
+                          <KubernetesEventDetailsButton isExpanded={isExpanded} onClick={toggleEventDetails} />
+                        )}
+                        {isExpanded && !clusterId && <KubernetesEventDetailsUnavailable />}
+                      </>
+                    )}
                   </div>
                 </div>
               )

--- a/libs/domains/observability/feature/src/lib/local-chart/local-chart.tsx
+++ b/libs/domains/observability/feature/src/lib/local-chart/local-chart.tsx
@@ -223,6 +223,7 @@ export interface LocalChartProps extends PropsWithChildren {
   isEmpty: boolean
   isLoading: boolean
   serviceId: string
+  clusterId?: string
   label?: string
   description?: ReactNode
   descriptionRight?: ReactNode
@@ -248,6 +249,7 @@ export const LocalChart = forwardRef<ElementRef<'section'>, LocalChartProps>(fun
     className,
     children,
     serviceId,
+    clusterId,
     yDomain,
     xDomain,
     referenceLineData,
@@ -327,7 +329,13 @@ export const LocalChart = forwardRef<ElementRef<'section'>, LocalChartProps>(fun
             {children}
           </ChartContent>
           {isFullscreen && events && !hideEvents && (
-            <EventSidebar events={events} service={service} isLoading={isLoading || eventsLoading} />
+            <EventSidebar
+              events={events}
+              clusterId={clusterId}
+              serviceId={serviceId}
+              service={service}
+              isLoading={isLoading || eventsLoading}
+            />
           )}
         </div>
       </Section>
@@ -349,7 +357,13 @@ export const LocalChart = forwardRef<ElementRef<'section'>, LocalChartProps>(fun
               {children}
             </ChartContent>
             {events && !hideEvents && (
-              <EventSidebar events={events} service={service} isLoading={isLoading || eventsLoading} />
+              <EventSidebar
+                events={events}
+                clusterId={clusterId}
+                serviceId={serviceId}
+                service={service}
+                isLoading={isLoading || eventsLoading}
+              />
             )}
           </div>
         </ModalChart>

--- a/libs/domains/observability/feature/src/lib/service/service-dashboard/card-instance-status/card-instance-status.spec.tsx
+++ b/libs/domains/observability/feature/src/lib/service/service-dashboard/card-instance-status/card-instance-status.spec.tsx
@@ -75,17 +75,40 @@ describe('CardInstanceStatus', () => {
   })
 
   it('should render with instance issues (RED status) and show modal link', () => {
-    useInstantMetrics.mockReturnValue(
-      createMockUseInstantMetricsReturn({
-        data: {
-          result: [
-            {
-              value: [1234567890, '2'],
-            },
-          ],
-        },
-      })
-    )
+    useInstantMetrics
+      .mockReturnValueOnce(
+        createMockUseInstantMetricsReturn({
+          data: {
+            result: [
+              {
+                value: [1234567890, '2'],
+              },
+            ],
+          },
+        })
+      )
+      .mockReturnValueOnce(
+        createMockUseInstantMetricsReturn({
+          data: {
+            result: [
+              {
+                value: [1234567890, '0'],
+              },
+            ],
+          },
+        })
+      )
+      .mockReturnValueOnce(
+        createMockUseInstantMetricsReturn({
+          data: {
+            result: [
+              {
+                value: [1234567890, '0'],
+              },
+            ],
+          },
+        })
+      )
 
     renderWithProviders(
       <DashboardProvider>
@@ -175,7 +198,7 @@ describe('CardInstanceStatus', () => {
       </DashboardProvider>
     )
 
-    expect(useInstantMetrics).toHaveBeenCalledTimes(2)
+    expect(useInstantMetrics).toHaveBeenCalledTimes(3)
     expect(useInstantMetrics).toHaveBeenCalledWith({
       clusterId: 'test-cluster-id',
       query: expect.stringContaining('kube_pod_container_status_restarts_total'),
@@ -183,6 +206,14 @@ describe('CardInstanceStatus', () => {
       endTimestamp: expect.any(String),
       boardShortName: 'service_overview',
       metricShortName: 'card_instance_status_error_count',
+    })
+    expect(useInstantMetrics).toHaveBeenCalledWith({
+      clusterId: 'test-cluster-id',
+      query: expect.stringContaining('k8s_event_logger_q_k8s_events_total'),
+      startTimestamp: expect.any(String),
+      endTimestamp: expect.any(String),
+      boardShortName: 'service_overview',
+      metricShortName: 'card_instance_status_k8s_event_count',
     })
 
     const call = useInstantMetrics.mock.calls[0][0].query

--- a/libs/domains/observability/feature/src/lib/service/service-dashboard/card-instance-status/card-instance-status.tsx
+++ b/libs/domains/observability/feature/src/lib/service/service-dashboard/card-instance-status/card-instance-status.tsx
@@ -25,6 +25,18 @@ const query = (timeRange: string, selector: string) => `
   )
 `
 
+const queryK8sEvents = (serviceId: string, timeRange: string) => `
+  sum(
+    increase(
+      k8s_event_logger_q_k8s_events_total{
+        qovery_com_service_id="${serviceId}",
+        reason=~"Failed|OOMKilled|BackOff|Evicted|FailedScheduling|FailedMount|FailedAttachVolume|Preempted|NodeNotReady",
+        type="Warning"
+      }[${timeRange}]
+    )
+  ) or vector(0)
+`
+
 // TODO PG think to use recorder rule
 const queryAutoscalingReached = (timeRange: string, subQueryTimeRange: string, containerName: string) => `
   100 *
@@ -81,6 +93,14 @@ export function CardInstanceStatus({
     boardShortName: 'service_overview',
     metricShortName: 'card_instance_status_error_count',
   })
+  const { data: metricsK8sEvents, isLoading: isLoadingMetricsK8sEvents } = useInstantMetrics({
+    clusterId,
+    query: queryK8sEvents(serviceId, queryTimeRange),
+    startTimestamp,
+    endTimestamp,
+    boardShortName: 'service_overview',
+    metricShortName: 'card_instance_status_k8s_event_count',
+  })
   const { data: metricsAutoscalingReached, isLoading: isLoadingMetricsAutoscalingReached } = useInstantMetrics({
     clusterId,
     query: queryAutoscalingReached(queryTimeRange, subQueryTimeRange, containerName),
@@ -90,14 +110,16 @@ export function CardInstanceStatus({
     metricShortName: 'card_instance_hpa_limit_count',
   })
 
-  const instanceErrors = Math.round(Number(metricsInstanceErrors?.data?.result[0]?.value[1])) || 0
+  const instanceErrorsValue = Math.round(Number(metricsInstanceErrors?.data?.result[0]?.value[1])) || 0
+  const k8sEventsValue = Math.round(Number(metricsK8sEvents?.data?.result[0]?.value[1])) || 0
+  const instanceErrors = instanceErrorsValue + k8sEventsValue
   const autoscalingReachedRaw = metricsAutoscalingReached?.data?.result[0]?.value[1] || '0'
   const autoscalingReachedNum = parseFloat(autoscalingReachedRaw)
   const autoscalingReached = Number(autoscalingReachedNum.toFixed(1))
 
   const title = 'Instance number'
   const description = 'Number of healthy and unhealthy instances over time.'
-  const isLoading = isLoadingMetricsInstanceErrors || isLoadingMetricsAutoscalingReached
+  const isLoading = isLoadingMetricsInstanceErrors || isLoadingMetricsK8sEvents || isLoadingMetricsAutoscalingReached
 
   const isAutoscalingEnabled = match(service)
     .with({ serviceType: 'APPLICATION' }, (s) => s.max_running_instances !== s.min_running_instances)

--- a/libs/domains/observability/feature/src/lib/service/service-dashboard/instance-status-chart/instance-status-chart.tsx
+++ b/libs/domains/observability/feature/src/lib/service/service-dashboard/instance-status-chart/instance-status-chart.tsx
@@ -32,7 +32,7 @@ const queryRestartWithReason = (selector: string, timeRange: string) => `
  `
 
 const queryK8sEvent = (serviceId: string, dynamicRange: string) => `
-  sum by (pod,reason)(
+  sum by (pod,reason,message,uid)(
   (
     k8s_event_logger_q_k8s_events_total{
       qovery_com_service_id="${serviceId}",
@@ -48,6 +48,11 @@ const queryK8sEvent = (serviceId: string, dynamicRange: string) => `
   ) > 0
 )
 `
+
+const normalizeK8sEventMessage = (message?: string): string | undefined => {
+  const normalized = message?.trim()
+  return normalized ? normalized : undefined
+}
 
 const queryMinReplicas = (containerName: string) => `
   max by(label_qovery_com_service_id)(kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="${containerName}"})
@@ -121,76 +126,6 @@ const getDescriptionFromK8sEvent = (reason: string): string => {
       return 'The node hosting the pod became NotReady.'
     default:
       return 'Unknown'
-  }
-}
-
-// TODO: keep it for now, but we should improve it
-const getExitCodeInfo = (exitCode: string): { name: string; description: string } => {
-  const code = parseInt(exitCode, 10)
-
-  switch (code) {
-    case 0:
-      return {
-        name: exitCode + ': Purposely stopped',
-        description: 'Used by developers to indicate that the container was automatically stopped.',
-      }
-    case 1:
-      return {
-        name: exitCode + ': Application error',
-        description:
-          'Container was stopped due to application error or incorrect reference in the image specification.',
-      }
-    case 125:
-      return {
-        name: exitCode + ': Container failed to run error',
-        description: 'The docker run command did not execute successfully.',
-      }
-    case 126:
-      return {
-        name: exitCode + ': Command invoke error',
-        description: 'A command specified in the image specification could not be invoked.',
-      }
-    case 127:
-      return {
-        name: exitCode + ': File or directory not found',
-        description: 'File or directory specified in the image specification was not found.',
-      }
-    case 128:
-      return {
-        name: exitCode + ': Invalid argument used on exit',
-        description: 'Exit was triggered with an invalid exit code (valid codes are integers between 0-255).',
-      }
-    case 134:
-      return {
-        name: exitCode + ': Abnormal termination (SIGABRT)',
-        description: 'The container aborted itself using the abort() function.',
-      }
-    case 137:
-      return {
-        name: exitCode + ': Immediate termination (SIGKILL)',
-        description: 'Container was immediately terminated by the operating system via SIGKILL signal.',
-      }
-    case 139:
-      return {
-        name: exitCode + ': Segmentation fault (SIGSEGV)',
-        description: 'Container attempted to access memory that was not assigned to it and was terminated.',
-      }
-    case 143:
-      return {
-        name: exitCode + ': Graceful termination (SIGTERM)',
-        description: 'Container received warning that it was about to be terminated, then terminated.',
-      }
-    case 255:
-      return {
-        name: exitCode + ': Exit Status Out Of Range',
-        description:
-          'Container exited, returning an exit code outside the acceptable range, meaning the cause of the error is not known.',
-      }
-    default:
-      return {
-        name: `Exit Code ${exitCode}`,
-        description: 'Unknown exit code.',
-      }
   }
 }
 
@@ -404,16 +339,20 @@ export function InstanceStatusChart({
     // Add k8s event as reference lines
     if (metricsK8sEvent?.data?.result) {
       metricsK8sEvent.data.result.forEach(
-        (series: { metric: { reason: string; pod: string }; values: [number, string][] }) => {
+        (series: {
+          metric: { reason: string; pod: string; uid?: string; message?: string }
+          values: [number, string][]
+        }) => {
           series.values.forEach(([timestamp, value]: [number, string]) => {
             const numValue = parseFloat(value)
             if (numValue > 0) {
-              const key = `${series.metric.reason}-${timestamp}`
+              const key = `${series.metric.reason}-${series.metric.pod}-${series.metric.uid ?? 'unknown'}-${timestamp}`
+              const k8sEventMessage = normalizeK8sEventMessage(series.metric.message)
               referenceLines.push({
                 type: 'k8s-event',
                 timestamp: timestamp * 1000,
                 reason: series.metric.reason,
-                description: getDescriptionFromK8sEvent(series.metric.reason),
+                description: k8sEventMessage ?? getDescriptionFromK8sEvent(series.metric.reason),
                 icon: 'xmark',
                 color: 'var(--negative-11)',
                 pod: series.metric.pod,
@@ -454,7 +393,7 @@ export function InstanceStatusChart({
     referenceLines.sort((a, b) => b.timestamp - a.timestamp)
 
     return referenceLines
-  }, [metricsK8sEvent, metricsHpaMaxLimitReached, metricsRestartsWithReason])
+  }, [metricsK8sEvent, metricsHpaMaxLimitReached, metricsRestartsWithReason, metricsRestartsWithReasonStepInSec])
 
   const isLoading = useMemo(
     () =>
@@ -482,6 +421,7 @@ export function InstanceStatusChart({
       tooltipLabel="Instance issues"
       unit="instance"
       serviceId={serviceId}
+      clusterId={clusterId}
       yDomain={[0, 'dataMax + 1']}
       referenceLineData={referenceLineData}
       isFullscreen={isFullscreen}

--- a/libs/domains/observability/feature/src/lib/service/service-dashboard/instance-status-chart/instance-status-chart.tsx
+++ b/libs/domains/observability/feature/src/lib/service/service-dashboard/instance-status-chart/instance-status-chart.tsx
@@ -32,7 +32,7 @@ const queryRestartWithReason = (selector: string, timeRange: string) => `
  `
 
 const queryK8sEvent = (serviceId: string, dynamicRange: string) => `
-  sum by (pod,reason,message,uid)(
+  sum by (pod,reason,uid)(
   (
     k8s_event_logger_q_k8s_events_total{
       qovery_com_service_id="${serviceId}",
@@ -48,11 +48,6 @@ const queryK8sEvent = (serviceId: string, dynamicRange: string) => `
   ) > 0
 )
 `
-
-const normalizeK8sEventMessage = (message?: string): string | undefined => {
-  const normalized = message?.trim()
-  return normalized ? normalized : undefined
-}
 
 const queryMinReplicas = (containerName: string) => `
   max by(label_qovery_com_service_id)(kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="${containerName}"})
@@ -339,20 +334,16 @@ export function InstanceStatusChart({
     // Add k8s event as reference lines
     if (metricsK8sEvent?.data?.result) {
       metricsK8sEvent.data.result.forEach(
-        (series: {
-          metric: { reason: string; pod: string; uid?: string; message?: string }
-          values: [number, string][]
-        }) => {
+        (series: { metric: { reason: string; pod: string; uid?: string }; values: [number, string][] }) => {
           series.values.forEach(([timestamp, value]: [number, string]) => {
             const numValue = parseFloat(value)
             if (numValue > 0) {
               const key = `${series.metric.reason}-${series.metric.pod}-${series.metric.uid ?? 'unknown'}-${timestamp}`
-              const k8sEventMessage = normalizeK8sEventMessage(series.metric.message)
               referenceLines.push({
                 type: 'k8s-event',
                 timestamp: timestamp * 1000,
                 reason: series.metric.reason,
-                description: k8sEventMessage ?? getDescriptionFromK8sEvent(series.metric.reason),
+                description: getDescriptionFromK8sEvent(series.metric.reason),
                 icon: 'xmark',
                 color: 'var(--negative-11)',
                 pod: series.metric.pod,


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

https://qovery.slack.com/archives/C038JMN9GUE/p1779050041836459

- Adds a See details action on Kubernetes events in the monitoring event sidebar.
- Fetches the full Kubernetes event payload on demand from API/Loki.
- Displays the raw event message, timestamps, pod, namespace, component, and count.
- Keeps the chart markers lightweight and loads detailed event data only when needed.

## Screenshots / Recordings

<img width="2902" height="1556" alt="image" src="https://github.com/user-attachments/assets/bcbbf4f8-fcd7-4fc7-b9fd-cc9e06eec1de" />

<img width="2890" height="1548" alt="image" src="https://github.com/user-attachments/assets/51a556ee-cb08-41fe-b19b-bca9496e956e" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
