### PR TITLE
fix(clusters): use regular cloud-shell debug flavor for GCP clusters

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/cloud-shell.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/cloud-shell.tsx
@@ -23,7 +23,11 @@ function RouteComponent() {
   return (
     <div className="flex h-page-container min-h-0 flex-col overflow-hidden bg-background">
       <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-        <ClusterTerminal organizationId={cluster.organization.id} clusterId={cluster.id} />
+        <ClusterTerminal
+          organizationId={cluster.organization.id}
+          clusterId={cluster.id}
+          cloudProvider={cluster.cloud_provider}
+        />
       </div>
     </div>
   )

--- a/libs/domains/clusters/feature/src/lib/cluster-terminal/cluster-terminal.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-terminal/cluster-terminal.spec.tsx
@@ -1,4 +1,6 @@
+import { DebugFlavor } from 'qovery-ws-typescript-axios'
 import { renderWithProviders } from '@qovery/shared/util-tests'
+import { useReactQueryWsSubscription } from '@qovery/state/util-queries'
 import { ClusterTerminal, type ClusterTerminalProps } from './cluster-terminal'
 
 jest.mock('color', () => ({
@@ -22,9 +24,39 @@ const props: ClusterTerminalProps = {
   clusterId: '0',
 }
 
+const useReactQueryWsSubscriptionMock = jest.mocked(useReactQueryWsSubscription)
+
 describe('ClusterTerminal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('should match snapshot', () => {
     const { baseElement } = renderWithProviders(<ClusterTerminal {...props} />)
     expect(baseElement).toMatchSnapshot()
+  })
+
+  it('should use regular privilege for GCP clusters', () => {
+    renderWithProviders(<ClusterTerminal {...props} cloudProvider="GCP" />)
+
+    expect(useReactQueryWsSubscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        urlSearchParams: expect.objectContaining({
+          flavor: DebugFlavor.REGULAR_PRIVILEGE,
+        }),
+      })
+    )
+  })
+
+  it('should keep full privilege for non-GCP clusters', () => {
+    renderWithProviders(<ClusterTerminal {...props} cloudProvider="AWS" />)
+
+    expect(useReactQueryWsSubscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        urlSearchParams: expect.objectContaining({
+          flavor: DebugFlavor.FULL_PRIVILEGE,
+        }),
+      })
+    )
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-terminal/cluster-terminal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-terminal/cluster-terminal.tsx
@@ -3,9 +3,11 @@ import { AttachAddon } from '@xterm/addon-attach'
 import { FitAddon } from '@xterm/addon-fit'
 import { type ITerminalAddon } from '@xterm/xterm'
 import Color from 'color'
+import { type CloudVendorEnum } from 'qovery-typescript-axios'
 import { DebugFlavor } from 'qovery-ws-typescript-axios'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { XTerm } from 'react-xtermjs'
+import { match } from 'ts-pattern'
 import { LoaderSpinner, toast } from '@qovery/shared/ui'
 import { useTerminalReadiness } from '@qovery/shared/util-hooks'
 import { QOVERY_WS } from '@qovery/shared/util-node-env'
@@ -16,14 +18,18 @@ const MemoizedXTerm = memo(XTerm)
 export interface ClusterTerminalProps {
   organizationId: string
   clusterId: string
+  cloudProvider?: CloudVendorEnum
 }
 
-export function ClusterTerminal({ organizationId, clusterId }: ClusterTerminalProps) {
+export function ClusterTerminal({ organizationId, clusterId, cloudProvider }: ClusterTerminalProps) {
   const [addons, setAddons] = useState<Array<ITerminalAddon>>([])
   const isTerminalLoading = addons.length < 2
   const { attachWebSocket, detachWebSocket, isTerminalReady } = useTerminalReadiness()
   const showDelayedLoader = !isTerminalReady
   const fitAddon = addons[0] as FitAddon | undefined
+  const debugFlavor = match(cloudProvider)
+    .with('GCP', () => DebugFlavor.REGULAR_PRIVILEGE)
+    .otherwise(() => DebugFlavor.FULL_PRIVILEGE)
 
   const getCssVariableHex = (variableName: string): string => {
     const styles = getComputedStyle(document.documentElement)
@@ -82,7 +88,7 @@ export function ClusterTerminal({ organizationId, clusterId }: ClusterTerminalPr
     urlSearchParams: {
       organization: organizationId,
       cluster: clusterId,
-      flavor: DebugFlavor.FULL_PRIVILEGE,
+      flavor: debugFlavor,
       tty_height: rows.toString(),
       tty_width: cols.toString(),
     },


### PR DESCRIPTION


## Summary
fix "cloud shell" for GCP cluster
<img width="1473" height="642" alt="Screenshot 2026-05-20 at 10 39 01" src="https://github.com/user-attachments/assets/0a6ddaa9-940c-49fa-8468-c710a7f58249" />


## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
