### PR TITLE
fix(cluster-metrics): disable EKS Anywhere upgrade drift alert in clu…

### DIFF
--- a/libs/domains/cluster-metrics/feature/src/lib/cluster-card-setup/cluster-card-setup.spec.tsx
+++ b/libs/domains/cluster-metrics/feature/src/lib/cluster-card-setup/cluster-card-setup.spec.tsx
@@ -15,6 +15,7 @@ describe('ClusterCardSetup', () => {
   const mockCluster = {
     created_at: '2024-05-01T12:00:00Z',
     cloud_provider: 'AWS',
+    kubernetes: 'MANAGED',
   }
 
   const mockDeploymentStatus = {
@@ -70,6 +71,34 @@ describe('ClusterCardSetup', () => {
 
     expect(screen.getByText('Upgrade Kubernetes')).toBeInTheDocument()
     expect(screen.getByText('v1.26.0 → v1.28.1')).toBeInTheDocument()
+  })
+
+  it('should render plain Kubernetes version for EKS Anywhere drift status', () => {
+    const mockRunningStatus = {
+      computed_status: {
+        kube_version_status: {
+          type: 'DRIFT',
+          kube_version: 'v1.34',
+          expected_kube_version: 'v1.33',
+        },
+      },
+    }
+    ;(useCluster as jest.Mock).mockReturnValue({
+      data: {
+        ...mockCluster,
+        kubernetes: 'PARTIALLY_MANAGED',
+      },
+    })
+    ;(useClusterRunningStatus as jest.Mock).mockReturnValue({
+      data: mockRunningStatus,
+    })
+
+    renderWithProviders(<ClusterCardSetup organizationId={mockOrganizationId} clusterId={mockClusterId} />)
+
+    expect(screen.getByText('Kubernetes version')).toBeInTheDocument()
+    expect(screen.getByText('v1.34')).toBeInTheDocument()
+    expect(screen.queryByText('Upgrade Kubernetes')).not.toBeInTheDocument()
+    expect(screen.queryByText('v1.34 → v1.33')).not.toBeInTheDocument()
   })
 
   it('should render unsupported Kubernetes version status', () => {

--- a/libs/domains/cluster-metrics/feature/src/lib/cluster-card-setup/cluster-card-setup.tsx
+++ b/libs/domains/cluster-metrics/feature/src/lib/cluster-card-setup/cluster-card-setup.tsx
@@ -21,6 +21,7 @@ export function ClusterCardSetup({ organizationId, clusterId }: ClusterCardSetup
   })
 
   const kubeVersion = runningStatus?.computed_status?.kube_version_status
+  const isEksAnywhereCluster = cluster?.kubernetes === 'PARTIALLY_MANAGED'
 
   const isLoading =
     !deploymentStatus?.is_deployed || !deploymentStatus?.last_deployment_date || !cluster?.created_at || !kubeVersion
@@ -49,11 +50,25 @@ export function ClusterCardSetup({ organizationId, clusterId }: ClusterCardSetup
                   ))
                   .with({ type: 'DRIFT' }, (status) => (
                     <>
-                      <StatusChip status="WARNING" />
-                      Upgrade Kubernetes
-                      <Badge color="yellow" size="sm" variant="surface">
-                        {status.kube_version} → {status.expected_kube_version}
-                      </Badge>
+                      {isEksAnywhereCluster ? (
+                        <>
+                          <StatusChip status="RUNNING" />
+                          Kubernetes version
+                          <Badge variant="surface" size="sm">
+                            {status.kube_version}
+                          </Badge>
+                        </>
+                      ) : (
+                        <>
+                          <StatusChip status="WARNING" />
+                          Upgrade Kubernetes
+                          <Badge color="yellow" size="sm" variant="surface">
+                            {!status.expected_kube_version
+                              ? status.kube_version
+                              : `${status.kube_version} → ${status.expected_kube_version}`}
+                          </Badge>
+                        </>
+                      )}
                     </>
                   ))
                   .with({ type: 'UNKNOWN' }, () => (


### PR DESCRIPTION

## Summary

This PR updates the Cluster setup card behavior for EKS Anywhere clusters.

Removes the upgrade/drift messaging (Upgrade Kubernetes) for EKS Anywhere.
Removes the current_version → expected_version display (for example, 1.34 → 1.33).
Shows only the current Kubernetes version (for example, v1.34) with a neutral/non-warning status.
Non-EKS Anywhere clusters keep the existing behavior.



before: https://console.qovery.com/organization/148bff50-453d-4111-8353-915bd6ec08b3/cluster/eb77465e-a1b2-4c62-aa1c-89db4cac8bc3/overview
after: 
<img width="1272" height="497" alt="Screenshot 2026-05-20 at 14 38 19" src="https://github.com/user-attachments/assets/412f7048-5e95-4912-9d58-e34db85f0f33" />


**Issue**: <!-- QOV-1234 -->

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
