### PR TITLE
fix: incorrect URL on "Create a Cluster" button

### DIFF
--- a/apps/console/src/app/components/not-found-page/not-found-page.tsx
+++ b/apps/console/src/app/components/not-found-page/not-found-page.tsx
@@ -1,9 +1,7 @@
 import { type NotFoundRouteProps } from '@tanstack/react-router'
 import { type ReactNode } from 'react'
-import { useOrganizations } from '@qovery/domains/organizations/feature'
 import { Heading, Link, LogoIcon, Section } from '@qovery/shared/ui'
 import { type SerializedError } from '@qovery/shared/utils'
-import { useAuth0Context } from '../../../auth/auth0'
 
 type NotFoundPageProps = Partial<NotFoundRouteProps> & {
   action?: ReactNode
@@ -21,12 +19,6 @@ function isNotFoundPageData(data: unknown): data is NotFoundPageData {
 
 export function NotFoundPage({ action, data, error }: NotFoundPageProps) {
   const errorTyped = error as SerializedError | undefined
-  const { isAuthenticated } = useAuth0Context()
-  const { data: organizations = [] } = useOrganizations({ enabled: isAuthenticated })
-
-  const currentOrganizationId = localStorage.getItem('currentOrganizationId') ?? ''
-  const selectedOrganization =
-    organizations.find((organization) => organization.id === currentOrganizationId) ?? organizations[0]
 
   const pageData = isNotFoundPageData(data) ? data : undefined
   const title = pageData?.title ?? errorTyped?.name ?? errorTyped?.code ?? 'Page not found'
@@ -34,23 +26,9 @@ export function NotFoundPage({ action, data, error }: NotFoundPageProps) {
     pageData?.message ??
     errorTyped?.message ??
     "The page you're looking for doesn't exist anymore, or the URL is incorrect."
-  const defaultAction = selectedOrganization ? (
-    <Link
-      as="button"
-      to="/organization/$organizationId/overview"
-      params={{ organizationId: selectedOrganization.id }}
-      size="md"
-      className="mt-6 gap-2"
-    >
-      Go to organization
-    </Link>
-  ) : isAuthenticated ? (
+  const defaultAction = (
     <Link as="button" to="/" size="md" className="mt-6 gap-2">
-      Go to home
-    </Link>
-  ) : (
-    <Link as="button" to="/login" search={{ redirect: '/' }} size="md" className="mt-6 gap-2">
-      Go to login
+      Go to organization
     </Link>
   )
 

--- a/apps/console/src/app/components/not-found-page/not-found-page.tsx
+++ b/apps/console/src/app/components/not-found-page/not-found-page.tsx
@@ -2,6 +2,7 @@ import { type NotFoundRouteProps } from '@tanstack/react-router'
 import { type ReactNode } from 'react'
 import { Heading, Link, LogoIcon, Section } from '@qovery/shared/ui'
 import { type SerializedError } from '@qovery/shared/utils'
+import { useAuth0Context } from '../../../auth/auth0'
 
 type NotFoundPageProps = Partial<NotFoundRouteProps> & {
   action?: ReactNode
@@ -19,6 +20,7 @@ function isNotFoundPageData(data: unknown): data is NotFoundPageData {
 
 export function NotFoundPage({ action, data, error }: NotFoundPageProps) {
   const errorTyped = error as SerializedError | undefined
+  const { isAuthenticated } = useAuth0Context()
 
   const pageData = isNotFoundPageData(data) ? data : undefined
   const title = pageData?.title ?? errorTyped?.name ?? errorTyped?.code ?? 'Page not found'
@@ -26,9 +28,13 @@ export function NotFoundPage({ action, data, error }: NotFoundPageProps) {
     pageData?.message ??
     errorTyped?.message ??
     "The page you're looking for doesn't exist anymore, or the URL is incorrect."
-  const defaultAction = (
+  const defaultAction = isAuthenticated ? (
     <Link as="button" to="/" size="md" className="mt-6 gap-2">
       Go to organization
+    </Link>
+  ) : (
+    <Link as="button" to="/login" search={{ redirect: '/' }} size="md" className="mt-6 gap-2">
+      Go to login
     </Link>
   )
 

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { Outlet, createFileRoute, useMatches } from '@tanstack/react-router'
 import { ClusterStateEnum as ClusterState, type ClusterStateEnum } from 'qovery-typescript-axios'
-import { Suspense, useMemo } from 'react'
+import { Suspense, useEffect, useMemo } from 'react'
 import { memo } from 'react'
 import { ClusterDeploymentProgressCard, useClusterStatuses, useClusters } from '@qovery/domains/clusters/feature'
 import { useEnvironment } from '@qovery/domains/environments/feature'
@@ -112,6 +112,12 @@ function RouteComponent() {
       ),
     [matches]
   )
+
+  useEffect(() => {
+    if (organizationId) {
+      localStorage.setItem('currentOrganizationId', organizationId)
+    }
+  }, [organizationId])
 
   return (
     <>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
@@ -6,6 +6,7 @@ import { memo } from 'react'
 import { ClusterDeploymentProgressCard, useClusterStatuses, useClusters } from '@qovery/domains/clusters/feature'
 import { useEnvironment } from '@qovery/domains/environments/feature'
 import { LoaderSpinner } from '@qovery/shared/ui'
+import { useLocalStorage } from '@qovery/shared/util-hooks'
 import { StatusWebSocketListener } from '@qovery/shared/util-web-sockets'
 import { queries } from '@qovery/state/util-queries'
 import { type FileRouteTypes } from '../../../../routeTree.gen'
@@ -67,6 +68,7 @@ function RouteComponent() {
   const projectId = mergedParams.projectId ?? ''
   const environmentId = mergedParams.environmentId ?? ''
   const versionId = mergedParams.versionId ?? ''
+  const [, setCurrentOrganizationId] = useLocalStorage<string>('currentOrganizationId', '')
 
   const { data: clusters } = useClusters({ organizationId })
   const { data: clusterStatuses } = useClusterStatuses({ organizationId, enabled: !!organizationId })
@@ -115,9 +117,9 @@ function RouteComponent() {
 
   useEffect(() => {
     if (organizationId) {
-      localStorage.setItem('currentOrganizationId', organizationId)
+      setCurrentOrganizationId(organizationId)
     }
-  }, [organizationId])
+  }, [organizationId, setCurrentOrganizationId])
 
   return (
     <>

--- a/libs/domains/projects/feature/src/lib/deployment-rules/deployement-rules.tsx
+++ b/libs/domains/projects/feature/src/lib/deployment-rules/deployement-rules.tsx
@@ -201,7 +201,9 @@ function DeploymentRulesContent({ organizationId, projectId, linkNewRule }: Depl
         size="md"
         variant="outline"
         onClick={() =>
-          hasClusters ? navigate({ to: linkNewRule }) : navigate({ to: `/organization/${organizationId}/clusters/new` })
+          hasClusters
+            ? navigate({ to: linkNewRule })
+            : navigate({ to: '/organization/$organizationId/cluster/new', params: { organizationId } })
         }
       >
         {hasClusters ? 'Add rule' : 'Create a Cluster'}

--- a/libs/domains/projects/feature/tsconfig.lib.json
+++ b/libs/domains/projects/feature/tsconfig.lib.json
@@ -4,6 +4,7 @@
     "outDir": "../../../../dist/out-tsc",
     "types": ["node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts"]
   },
+  "files": ["../../../../apps/console/src/router-types.d.ts"],
   "exclude": [
     "jest.config.ts",
     "src/**/*.spec.ts",


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1779289693163229)

📺 [Screen recoding of the issues](https://www.loom.com/share/817c61c1e6fe4d41b015e66684a36bb0)

This PR fixes both of these bugs.

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
