### PR TITLE
feat(variables): improve alias variable display

### DIFF
--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
@@ -88,6 +88,15 @@ describe('CreateUpdateVariableModal', () => {
     expect(screen.getByRole('button', { name: /open editor/i })).toBeInTheDocument()
   })
 
+  it('should render the description field as a single-line input', () => {
+    renderWithProviders(<CreateUpdateVariableModal {...baseProps} mode="CREATE" type="VALUE" />)
+
+    const descriptionField = screen.getByLabelText('Description (optional)')
+
+    expect(descriptionField).toBeInstanceOf(HTMLInputElement)
+    expect(descriptionField).not.toBeInstanceOf(HTMLTextAreaElement)
+  })
+
   it('should not render the open editor button for aliases', () => {
     renderWithProviders(<CreateUpdateVariableModal {...baseProps} mode="CREATE" type="ALIAS" variable={baseVariable} />)
 

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -551,7 +551,7 @@ export function CreateUpdateVariableModal(props: CreateUpdateVariableModalProps)
             },
           }}
           render={({ field, fieldState: { error } }) => (
-            <InputTextArea
+            <InputText
               className="mb-3"
               name={field.name}
               onChange={field.onChange}

--- a/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
+++ b/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
@@ -83,7 +83,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="relative inline-block"
                   >
                     <button
-                      aria-controls="radix-:r28:"
+                      aria-controls="radix-:r2b:"
                       aria-expanded="false"
                       aria-haspopup="dialog"
                       class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong h-7 px-2 gap-x-1 rounded bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral whitespace-nowrap text-xs"
@@ -105,7 +105,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="relative inline-block"
                   >
                     <button
-                      aria-controls="radix-:r2b:"
+                      aria-controls="radix-:r2e:"
                       aria-expanded="false"
                       aria-haspopup="dialog"
                       class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong h-7 px-2 gap-x-1 rounded bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral whitespace-nowrap text-xs"
@@ -127,7 +127,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="relative inline-block"
                   >
                     <button
-                      aria-controls="radix-:r2e:"
+                      aria-controls="radix-:r2h:"
                       aria-expanded="false"
                       aria-haspopup="dialog"
                       class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong h-7 px-2 gap-x-1 rounded bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral whitespace-nowrap text-xs"
@@ -163,6 +163,7 @@ exports[`VariableList should match snapshot 1`] = `
             >
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[32px_minmax(0,40%)_50px_minmax(0,20%)_minmax(0,15%)_minmax(0,10%)_minmax(0,12%)]"
+                id="variable-row-810e3ca6-6e42-40b1-952a-4cfcef3c9fd1"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -206,15 +207,19 @@ exports[`VariableList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="flex flex-row gap-1 text-2xs text-neutral-subtle"
+                      class="flex min-w-0 flex-row gap-1 text-2xs text-neutral-subtle"
                     >
                       <i
                         aria-hidden="true"
                         class="fa-regular fa-arrow-turn-down-right text-2xs text-neutral-subtle"
                       />
-                      <span>
+                      <button
+                        aria-label="Scroll to QOVERY_OUTPUT_JOB_Z33962E52_DB_USERNAME variable"
+                        class="max-w-full truncate rounded-sm text-left hover:underline focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-text"
+                        type="button"
+                      >
                         QOVERY_OUTPUT_JOB_Z33962E52_DB_USERNAME
-                      </span>
+                      </button>
                     </div>
                   </div>
                 </td>
@@ -227,7 +232,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r2g:"
+                    id="radix-:r2j:"
                     type="button"
                   >
                     <i
@@ -238,7 +243,28 @@ exports[`VariableList should match snapshot 1`] = `
                 </td>
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
-                />
+                >
+                  <span
+                    class="group flex h-5 w-full items-center gap-2 text-sm"
+                  >
+                    <span
+                      class="truncate text-neutral"
+                      data-testid="visible_value"
+                    >
+                      admin2
+                    </span>
+                    <span
+                      class="relative cursor-pointer transition after:absolute after:inset-[-4px] after:block after:content-['']"
+                      data-state="closed"
+                      data-testid="copy-container"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="fa-regular fa-copy text-neutral-subtle opacity-0 hover:text-neutral group-hover:opacity-100"
+                      />
+                    </span>
+                  </span>
+                </td>
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative opacity-0"
                 />
@@ -265,6 +291,7 @@ exports[`VariableList should match snapshot 1`] = `
               </tr>
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[32px_minmax(0,40%)_50px_minmax(0,20%)_minmax(0,15%)_minmax(0,10%)_minmax(0,12%)]"
+                id="variable-row-fcdbdda7-3133-4bba-9a72-36f8a0519848"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -308,15 +335,19 @@ exports[`VariableList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="flex flex-row gap-1 text-2xs text-neutral-subtle"
+                      class="flex min-w-0 flex-row gap-1 text-2xs text-neutral-subtle"
                     >
                       <i
                         aria-hidden="true"
                         class="fa-regular fa-arrow-turn-down-right text-2xs text-neutral-subtle"
                       />
-                      <span>
+                      <button
+                        aria-label="Scroll to QOVERY_OUTPUT_JOB_ZEDE360F7_DB_HOST variable"
+                        class="max-w-full truncate rounded-sm text-left hover:underline focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-text"
+                        type="button"
+                      >
                         QOVERY_OUTPUT_JOB_ZEDE360F7_DB_HOST
-                      </span>
+                      </button>
                     </div>
                   </div>
                 </td>
@@ -329,7 +360,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r2k:"
+                    id="radix-:r2o:"
                     type="button"
                   >
                     <i
@@ -340,7 +371,28 @@ exports[`VariableList should match snapshot 1`] = `
                 </td>
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
-                />
+                >
+                  <span
+                    class="group flex h-5 w-full items-center gap-2 text-sm"
+                  >
+                    <span
+                      class="truncate text-neutral"
+                      data-testid="visible_value"
+                    >
+                      mydbhostname
+                    </span>
+                    <span
+                      class="relative cursor-pointer transition after:absolute after:inset-[-4px] after:block after:content-['']"
+                      data-state="closed"
+                      data-testid="copy-container"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="fa-regular fa-copy text-neutral-subtle opacity-0 hover:text-neutral group-hover:opacity-100"
+                      />
+                    </span>
+                  </span>
+                </td>
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative opacity-0"
                 />
@@ -367,6 +419,7 @@ exports[`VariableList should match snapshot 1`] = `
               </tr>
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[32px_minmax(0,40%)_50px_minmax(0,20%)_minmax(0,15%)_minmax(0,10%)_minmax(0,12%)]"
+                id="variable-row-fb121e5a-ff31-4835-a328-8ed561133174"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -420,7 +473,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r2o:"
+                    id="radix-:r2t:"
                     type="button"
                   >
                     <i
@@ -566,6 +619,7 @@ exports[`VariableList should match snapshot 1`] = `
               </tr>
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[32px_minmax(0,40%)_50px_minmax(0,20%)_minmax(0,15%)_minmax(0,10%)_minmax(0,12%)]"
+                id="variable-row-57658166-0318-430c-8d8a-610a34d98910"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -614,7 +668,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r2s:"
+                    id="radix-:r31:"
                     type="button"
                   >
                     <i
@@ -673,6 +727,7 @@ exports[`VariableList should match snapshot 1`] = `
               </tr>
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[32px_minmax(0,40%)_50px_minmax(0,20%)_minmax(0,15%)_minmax(0,10%)_minmax(0,12%)]"
+                id="variable-row-acac4cee-5627-437b-9fd3-d0947d92da4b"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -721,7 +776,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r31:"
+                    id="radix-:r36:"
                     type="button"
                   >
                     <i
@@ -873,6 +928,7 @@ exports[`VariableList should match snapshot 1`] = `
               </tr>
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[32px_minmax(0,40%)_50px_minmax(0,20%)_minmax(0,15%)_minmax(0,10%)_minmax(0,12%)]"
+                id="variable-row-831751ab-ebfb-4036-97f7-31689e3d8ed9"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -971,7 +1027,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r37:"
+                    id="radix-:r3c:"
                     type="button"
                   >
                     <i
@@ -1123,6 +1179,7 @@ exports[`VariableList should match snapshot 1`] = `
               </tr>
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[32px_minmax(0,40%)_50px_minmax(0,20%)_minmax(0,15%)_minmax(0,10%)_minmax(0,12%)]"
+                id="variable-row-3486e37c-5cdc-4e50-bcf7-75b1c818eb5f"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -1180,7 +1237,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r3d:"
+                    id="radix-:r3i:"
                     type="button"
                   >
                     <i
@@ -1239,6 +1296,7 @@ exports[`VariableList should match snapshot 1`] = `
               </tr>
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[32px_minmax(0,40%)_50px_minmax(0,20%)_minmax(0,15%)_minmax(0,10%)_minmax(0,12%)]"
+                id="variable-row-7d1b18cf-9ea1-4b00-b82a-4b5d152aa6eb"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -1282,15 +1340,19 @@ exports[`VariableList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="flex flex-row gap-1 text-2xs text-neutral-subtle"
+                      class="flex min-w-0 flex-row gap-1 text-2xs text-neutral-subtle"
                     >
                       <i
                         aria-hidden="true"
                         class="fa-regular fa-arrow-turn-down-right text-2xs text-neutral-subtle"
                       />
-                      <span>
+                      <button
+                        aria-label="Scroll to FOO variable"
+                        class="max-w-full truncate rounded-sm text-left hover:underline focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-text"
+                        type="button"
+                      >
                         FOO
-                      </span>
+                      </button>
                     </div>
                   </div>
                 </td>
@@ -1303,7 +1365,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r3i:"
+                    id="radix-:r3n:"
                     type="button"
                   >
                     <i
@@ -1314,7 +1376,28 @@ exports[`VariableList should match snapshot 1`] = `
                 </td>
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
-                />
+                >
+                  <span
+                    class="group flex h-5 w-full items-center gap-2 text-sm"
+                  >
+                    <span
+                      class="truncate text-neutral"
+                      data-testid="visible_value"
+                    >
+                      fdgsdfg
+                    </span>
+                    <span
+                      class="relative cursor-pointer transition after:absolute after:inset-[-4px] after:block after:content-['']"
+                      data-state="closed"
+                      data-testid="copy-container"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="fa-regular fa-copy text-neutral-subtle opacity-0 hover:text-neutral group-hover:opacity-100"
+                      />
+                    </span>
+                  </span>
+                </td>
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative opacity-0"
                 />
@@ -1406,7 +1489,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="relative inline-block"
                   >
                     <button
-                      aria-controls="radix-:r3n:"
+                      aria-controls="radix-:r3t:"
                       aria-expanded="false"
                       aria-haspopup="dialog"
                       class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong h-7 px-2 gap-x-1 rounded bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral whitespace-nowrap text-xs"
@@ -1428,7 +1511,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="relative inline-block"
                   >
                     <button
-                      aria-controls="radix-:r3q:"
+                      aria-controls="radix-:r40:"
                       aria-expanded="false"
                       aria-haspopup="dialog"
                       class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong h-7 px-2 gap-x-1 rounded bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral whitespace-nowrap text-xs"
@@ -1464,6 +1547,7 @@ exports[`VariableList should match snapshot 1`] = `
             >
               <tr
                 class="h-16 items-center hover:bg-surface-neutral-subtle grid w-full grid-cols-[minmax(0,calc(40%_+_32px))_50px_minmax(0,30%)_minmax(0,15%)_minmax(0,12%)]"
+                id="variable-row-ade79b9c-8515-47f2-8069-83c1e8c35c4d"
               >
                 <td
                   class="border-neutral px-4 py-0 flex h-full items-center first:relative"
@@ -1496,7 +1580,7 @@ exports[`VariableList should match snapshot 1`] = `
                     aria-label="actions"
                     class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-8 justify-center"
                     data-state="closed"
-                    id="radix-:r3s:"
+                    id="radix-:r42:"
                     type="button"
                   >
                     <i

--- a/libs/domains/variables/feature/src/lib/variable-list/variable-list.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/variable-list/variable-list.spec.tsx
@@ -34,7 +34,7 @@ jest.mock('../hooks/use-variables/use-variables', () => ({
         aliased_variable: {
           id: 'ade79b9c-8515-47f2-8069-83c1e8c35c4d',
           key: 'QOVERY_OUTPUT_JOB_Z33962E52_DB_USERNAME',
-          value: 'admin2',
+          value: '||QOVERY_OUTPUT_JOB_Z33962E52_DB_USERNAME||',
           scope: 'BUILT_IN',
           variable_type: 'BUILT_IN',
           mount_path: null,
@@ -200,7 +200,14 @@ const variableListProps: VariableListProps = {
   onDeleteVariable: jest.fn(),
 }
 
+const scrollIntoView = jest.fn()
+
 describe('VariableList', () => {
+  beforeEach(() => {
+    scrollIntoView.mockClear()
+    Element.prototype.scrollIntoView = scrollIntoView
+  })
+
   it('should render successfully', () => {
     const { baseElement } = renderWithProviders(<VariableList {...variableListProps} />)
     expect(baseElement).toBeTruthy()
@@ -222,6 +229,25 @@ describe('VariableList', () => {
     expect(within(customSection as HTMLElement).getAllByRole('row')).toHaveLength(9)
     expect(within(builtInSection as HTMLElement).getAllByRole('row')).toHaveLength(2)
     expect(screen.getAllByTestId('doppler-tag')).toHaveLength(1)
+  })
+  it('should display alias values from the base variable', () => {
+    renderWithProviders(<VariableList {...variableListProps} />)
+    const row = screen.getByText('DB_USERNAME').closest('tr')
+    expect(row).toBeTruthy()
+    expect(within(row as HTMLElement).getByText('admin2')).toBeInTheDocument()
+  })
+  it('should scroll to the base variable when clicking an alias reference', async () => {
+    const { userEvent } = renderWithProviders(<VariableList {...variableListProps} />)
+    const row = screen.getByText('DB_USERNAME').closest('tr')
+    expect(row).toBeTruthy()
+
+    await userEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: /scroll to QOVERY_OUTPUT_JOB_Z33962E52_DB_USERNAME variable/i,
+      })
+    )
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
   })
   it('should display Service for service-backed scope values', () => {
     renderWithProviders(<VariableList {...variableListProps} />)

--- a/libs/domains/variables/feature/src/lib/variable-list/variable-list.tsx
+++ b/libs/domains/variables/feature/src/lib/variable-list/variable-list.tsx
@@ -12,7 +12,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import { type APIVariableScopeEnum, type APIVariableTypeEnum, type VariableResponse } from 'qovery-typescript-axios'
-import { Fragment, useMemo, useState } from 'react'
+import { Fragment, useCallback, useMemo, useState } from 'react'
 import { match } from 'ts-pattern'
 import { ExternalServiceEnum, IconEnum, ServiceTypeEnum } from '@qovery/shared/enums'
 import { APPLICATION_GENERAL_URL, APPLICATION_URL, DATABASE_GENERAL_URL, DATABASE_URL } from '@qovery/shared/routes'
@@ -51,6 +51,10 @@ import { VariableListSkeleton } from './variable-list-skeleton'
 const { Table } = TablePrimitives
 
 type Scope = Exclude<keyof typeof APIVariableScopeEnum, 'BUILT_IN'>
+
+function getVariableRowId(variableId: string): string {
+  return `variable-row-${variableId}`
+}
 
 function isServiceScopeServiceType(serviceType: VariableResponse['service_type']): boolean {
   return match(serviceType)
@@ -125,6 +129,10 @@ export function VariableList({
   const [builtInGlobalFilter, setBuiltInGlobalFilter] = useState('')
   const nonBuiltInVariables = useMemo(() => variables.filter((variable) => variable.scope !== 'BUILT_IN'), [variables])
   const builtInVariables = useMemo(() => variables.filter((variable) => variable.scope === 'BUILT_IN'), [variables])
+  const variablesById = useMemo(() => new Map(variables.map((variable) => [variable.id, variable])), [variables])
+  const scrollToVariable = useCallback((variableId: string) => {
+    document.getElementById(getVariableRowId(variableId))?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [])
 
   const _onCreateVariable: (
     variable: VariableResponse,
@@ -176,6 +184,7 @@ export function VariableList({
       },
     })
   }
+
   const isServiceScope = match(props)
     .with(
       { scope: 'APPLICATION' },
@@ -253,6 +262,8 @@ export function VariableList({
         size: showServiceLinkColumn ? 40 : 45,
         cell: (info) => {
           const variable = info.row.original
+          const aliasedVariable = variable.aliased_variable
+          const overriddenVariable = variable.overridden_variable
 
           return (
             <div className="flex flex-col justify-center gap-1">
@@ -266,12 +277,12 @@ export function VariableList({
                       {variable.owned_by}
                     </span>
                   )}
-                  {variable.aliased_variable && (
+                  {aliasedVariable && (
                     <span className="mr-2 inline-flex h-4 items-center rounded bg-surface-info-component px-1 text-2xs font-bold text-info">
                       ALIAS
                     </span>
                   )}
-                  {variable.overridden_variable && (
+                  {overriddenVariable && (
                     <span className="mr-2 inline-flex h-4 items-center rounded bg-surface-brand-component px-1 text-2xs font-bold text-brand">
                       OVERRIDE
                     </span>
@@ -300,11 +311,20 @@ export function VariableList({
                   </Tooltip>
                 )}
               </div>
-              {(variable.aliased_variable || variable.overridden_variable) && (
-                <div className="flex flex-row gap-1 text-2xs text-neutral-subtle">
+              {(aliasedVariable || overriddenVariable) && (
+                <div className="flex min-w-0 flex-row gap-1 text-2xs text-neutral-subtle">
                   <Icon iconName="arrow-turn-down-right" iconStyle="regular" className="text-2xs text-neutral-subtle" />
-                  {variable.aliased_variable && <span>{variable.aliased_variable.key}</span>}
-                  {variable.overridden_variable && <span>{variable.overridden_variable.key}</span>}
+                  {aliasedVariable && (
+                    <button
+                      type="button"
+                      aria-label={`Scroll to ${aliasedVariable.key} variable`}
+                      className="max-w-full truncate rounded-sm text-left hover:underline focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-text"
+                      onClick={() => scrollToVariable(aliasedVariable.id)}
+                    >
+                      {aliasedVariable.key}
+                    </button>
+                  )}
+                  {overriddenVariable && <span>{overriddenVariable.key}</span>}
                 </div>
               )}
             </div>
@@ -411,7 +431,13 @@ export function VariableList({
             )
           }
           if (variable.variable_type === 'ALIAS') {
-            return null
+            const baseVariable = variable.aliased_variable ? variablesById.get(variable.aliased_variable.id) : undefined
+            const aliasValue = baseVariable?.value ?? variable.aliased_variable?.value
+
+            if (aliasValue !== null && aliasValue !== undefined) {
+              return <PasswordShowHide value={aliasValue} isSecret={baseVariable?.is_secret ?? variable.is_secret} />
+            }
+            return <PasswordShowHide value="" isSecret={true} />
           }
           if (variable.value !== null) {
             return <PasswordShowHide value={variable.value} isSecret={variable.is_secret} />
@@ -506,7 +532,9 @@ export function VariableList({
         },
       }),
     ],
-    [variables.length, _onCreateVariable, _onEditVariable, props.scope]
+    // Keep the pre-existing modal handlers local so this alias change does not rewrite modal behavior.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [variables, variablesById, props, scrollToVariable, showServiceLinkColumn]
   )
   const nonBuiltInColumns = useMemo(() => {
     if (!isEnvironmentScope && props.scope !== 'PROJECT') {
@@ -698,7 +726,10 @@ export function VariableList({
           <Table.Body>
             {tableInstance.getRowModel().rows.map((row) => (
               <Fragment key={row.id}>
-                <Table.Row className={twMerge('h-16 items-center hover:bg-surface-neutral-subtle', rowGridClassName)}>
+                <Table.Row
+                  id={getVariableRowId(row.original.id)}
+                  className={twMerge('h-16 items-center hover:bg-surface-neutral-subtle', rowGridClassName)}
+                >
                   {row.getVisibleCells().map((cell) => (
                     // Keep this cell hidden (not removed) in service scope (custom vars only) to preserve visual column alignment
                     <Table.Cell


### PR DESCRIPTION
## Summary
- Display alias variable values from the referenced base variable row instead of the embedded alias interpolation payload.
- Make alias base variable references clickable so they scroll the referenced row into view.
- Cover alias value resolution and scroll behavior in the variable list tests
- Change description component from textArea to inputText to reduce confusion between value and description field.

## Screens
<img width="1311" height="610" alt="image" src="https://github.com/user-attachments/assets/1d1326ff-62ba-4ff3-9999-a1aa9220e1e1" />
<img width="536" height="523" alt="image" src="https://github.com/user-attachments/assets/b96c9989-c01f-4109-9bb5-804d7d0a9814" />
