### PR TITLE
fix(application-container-storage-modal): update validation message wording to include directory name requirement

### DIFF
--- a/libs/domains/service-settings/feature/src/lib/application-container-storage-settings/application-container-storage-modal/application-container-storage-modal.tsx
+++ b/libs/domains/service-settings/feature/src/lib/application-container-storage-settings/application-container-storage-modal/application-container-storage-modal.tsx
@@ -118,7 +118,7 @@ export function ApplicationContainerStorageModal({
           rules={{
             required: 'Please enter a value.',
             pattern: {
-              message: 'Use /data format; / alone is not allowed',
+              message: 'Use a path like /data; / alone is not allowed',
               value: /^\/.?\w+.*/,
             },
           }}

--- a/libs/domains/service-settings/feature/src/lib/application-container-storage-settings/application-container-storage-modal/application-container-storage-modal.tsx
+++ b/libs/domains/service-settings/feature/src/lib/application-container-storage-settings/application-container-storage-modal/application-container-storage-modal.tsx
@@ -118,7 +118,7 @@ export function ApplicationContainerStorageModal({
           rules={{
             required: 'Please enter a value.',
             pattern: {
-              message: 'The mount point must start with a slash followed by a directory name, for example /data',
+              message: 'Use /data format; / alone is not allowed',
               value: /^\/.?\w+.*/,
             },
           }}

--- a/libs/domains/service-settings/feature/src/lib/application-container-storage-settings/application-container-storage-modal/application-container-storage-modal.tsx
+++ b/libs/domains/service-settings/feature/src/lib/application-container-storage-settings/application-container-storage-modal/application-container-storage-modal.tsx
@@ -118,7 +118,7 @@ export function ApplicationContainerStorageModal({
           rules={{
             required: 'Please enter a value.',
             pattern: {
-              message: 'The mount point must start with a slash',
+              message: 'The mount point must start with a slash followed by a directory name, for example /data',
               value: /^\/.?\w+.*/,
             },
           }}


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

https://qovery.slack.com/archives/C0A4CDDJBRQ/p1779433343944679?thread_ts=1779429549.122119&cid=C0A4CDDJBRQ

## Screenshots / Recordings

<img width="1452" height="872" alt="Screenshot 2026-05-22 at 09 10 01" src="https://github.com/user-attachments/assets/50abb460-a741-4e40-acc6-93f992e0896c" />

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
