### PR TITLE
fix(password-show-hide): add truncate

### DIFF
--- a/libs/domains/variables/feature/src/lib/output-variables/__snapshots__/output-variables.spec.tsx.snap
+++ b/libs/domains/variables/feature/src/lib/output-variables/__snapshots__/output-variables.spec.tsx.snap
@@ -173,7 +173,7 @@ exports[`OutputVariables when serviceType is TERRAFORM should match snapshot 1`]
                   class="group flex h-5 w-full items-center gap-2 text-sm"
                 >
                   <span
-                    class="truncate text-neutral"
+                    class="text-neutral"
                     data-testid="visible_value"
                   >
                     admin2

--- a/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
+++ b/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
@@ -630,7 +630,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="group flex h-5 w-full items-center gap-2 text-sm"
                   >
                     <span
-                      class="truncate text-neutral"
+                      class="text-neutral"
                       data-testid="visible_value"
                     >
                       abc
@@ -1196,7 +1196,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="group flex h-5 w-full items-center gap-2 text-sm"
                   >
                     <span
-                      class="truncate text-neutral"
+                      class="text-neutral"
                       data-testid="visible_value"
                     >
                       fdgsdfg
@@ -1512,7 +1512,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="group flex h-5 w-full items-center gap-2 text-sm"
                   >
                     <span
-                      class="truncate text-neutral"
+                      class="text-neutral"
                       data-testid="visible_value"
                     >
                       admin2

--- a/libs/shared/ui/src/lib/components/password-show-hide/password-show-hide.tsx
+++ b/libs/shared/ui/src/lib/components/password-show-hide/password-show-hide.tsx
@@ -1,8 +1,9 @@
-import { type ChangeEventHandler, type ComponentPropsWithoutRef, useState } from 'react'
+import { type ChangeEventHandler, type ComponentPropsWithoutRef } from 'react'
 import { twMerge } from '@qovery/shared/util-js'
 import { CopyToClipboardButtonIcon } from '../copy-to-clipboard-button-icon/copy-to-clipboard-button-icon'
 import { Icon } from '../icon/icon'
 import { Tooltip } from '../tooltip/tooltip'
+import { Truncate } from '../truncate/truncate'
 
 export interface PasswordShowHideProps extends ComponentPropsWithoutRef<'input'> {
   value: string
@@ -44,8 +45,8 @@ export function PasswordShowHide({
           className="h-full w-full bg-transparent text-neutral outline-none"
         />
       ) : (
-        <span className="truncate text-neutral" data-testid="visible_value">
-          {value}
+        <span className="text-neutral" data-testid="visible_value">
+          <Truncate text={value ?? ''} truncateLimit={50} />
         </span>
       )}
       {canCopy && Boolean(value) && (


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Add truncate for the password-show-hide component
You can try [here](http://localhost:4200/organization/a7136e96-4e7a-405c-97ce-2b6ffea38a02/project/cd112add-c27a-4bd1-aa61-2f10115abb1c/variables)

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
