### PR TITLE
fix(local-storage): handle legacy raw string values to prevent JSON.parse crash

### DIFF
--- a/apps/console/src/routes/index.tsx
+++ b/apps/console/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { Navigate, createFileRoute } from '@tanstack/react-router'
 import { useOrganizations } from '@qovery/domains/organizations/feature'
 import { useUserSignUp } from '@qovery/domains/users-sign-up/feature'
 import { getOnboardingEntryUrl } from '@qovery/shared/routes'
+import { useLocalStorage } from '@qovery/shared/util-hooks'
 import { queries } from '@qovery/state/util-queries'
 
 export const Route = createFileRoute('/')({
@@ -23,7 +24,7 @@ function Index() {
   const { data: userSignUp } = useUserSignUp({ enabled: isAuthenticated })
 
   // Redirect to latest selected organization
-  const currentOrganizationId = localStorage.getItem('currentOrganizationId') || ''
+  const [currentOrganizationId = ''] = useLocalStorage<string>('currentOrganizationId', '')
   const latestSelectedOrganization =
     organizations.find((organization) => organization.id === currentOrganizationId) || organizations[0]
   if (latestSelectedOrganization) {

--- a/libs/domains/onboarding/feature/src/lib/step-plans/step-plans.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-plans/step-plans.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx'
 import { type FormEvent, type MutableRefObject, useMemo } from 'react'
 import { ENVIRONMENTS_URL } from '@qovery/shared/routes'
 import { Button, ExternalLink, Heading, Icon, LoaderSpinner, Section } from '@qovery/shared/ui'
+import { useLocalStorage } from '@qovery/shared/util-hooks'
 import { twMerge } from '@qovery/shared/util-js'
 import { fieldCardStyles } from '@qovery/shared/util-payment'
 import { Background } from './background'
@@ -43,8 +44,8 @@ export default function StepPlans(props: StepPlansProps) {
     isSubmitting,
   } = props
   const navigate = useNavigate()
-  const currentOrganizationId = localStorage.getItem('currentOrganizationId') || ''
-  const currentProjectId = localStorage.getItem('currentProjectId') || ''
+  const [currentOrganizationId = ''] = useLocalStorage<string>('currentOrganizationId', '')
+  const [currentProjectId = ''] = useLocalStorage<string>('currentProjectId', '')
 
   const dateFormatter = useMemo(
     () =>

--- a/libs/domains/services/feature/src/lib/hooks/use-favorite-services/use-favorite-services.spec.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-favorite-services/use-favorite-services.spec.ts
@@ -3,7 +3,8 @@ import { useLocalStorage } from '@qovery/shared/util-hooks'
 import { act, renderHook } from '@qovery/shared/util-tests'
 import useFavoriteServices from './use-favorite-services'
 
-jest.mock('@uidotdev/usehooks', () => ({
+jest.mock('@qovery/shared/util-hooks', () => ({
+  ...jest.requireActual('@qovery/shared/util-hooks'),
   useLocalStorage: jest.fn(),
 }))
 

--- a/libs/domains/services/feature/src/lib/hooks/use-recent-services/use-recent-services.spec.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-recent-services/use-recent-services.spec.ts
@@ -3,7 +3,8 @@ import { useLocalStorage } from '@qovery/shared/util-hooks'
 import { act, renderHook } from '@qovery/shared/util-tests'
 import useRecentServices from './use-recent-services'
 
-jest.mock('@uidotdev/usehooks', () => ({
+jest.mock('@qovery/shared/util-hooks', () => ({
+  ...jest.requireActual('@qovery/shared/util-hooks'),
   useLocalStorage: jest.fn(),
 }))
 

--- a/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
+++ b/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
@@ -248,7 +248,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="group flex h-5 w-full items-center gap-2 text-sm"
                   >
                     <span
-                      class="truncate text-neutral"
+                      class="text-neutral"
                       data-testid="visible_value"
                     >
                       admin2
@@ -376,7 +376,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="group flex h-5 w-full items-center gap-2 text-sm"
                   >
                     <span
-                      class="truncate text-neutral"
+                      class="text-neutral"
                       data-testid="visible_value"
                     >
                       mydbhostname
@@ -1381,7 +1381,7 @@ exports[`VariableList should match snapshot 1`] = `
                     class="group flex h-5 w-full items-center gap-2 text-sm"
                   >
                     <span
-                      class="truncate text-neutral"
+                      class="text-neutral"
                       data-testid="visible_value"
                     >
                       fdgsdfg

--- a/libs/shared/util-hooks/src/index.ts
+++ b/libs/shared/util-hooks/src/index.ts
@@ -1,17 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import {
-  useClickAway,
-  useCopyToClipboard,
-  useDebounce,
-  useDocumentTitle,
-  useLocalStorage,
-  useNetworkState,
-} from '@uidotdev/usehooks'
+import { useClickAway, useCopyToClipboard, useDebounce, useDocumentTitle, useNetworkState } from '@uidotdev/usehooks'
 
 // NOTE: if you export from `@uidotdev/usehooks`, you need to mock it on the `mocks.ts` file for tests
-export { useDocumentTitle, useClickAway, useCopyToClipboard, useDebounce, useLocalStorage, useNetworkState }
+export { useDocumentTitle, useClickAway, useCopyToClipboard, useDebounce, useNetworkState }
 
 export * from './lib/use-format-hotkeys/use-format-hotkeys'
+export * from './lib/use-local-storage/use-local-storage'
 export * from './lib/use-support-chat/use-support-chat'
 export * from './lib/use-pod-color/use-pod-color'
 export * from './lib/use-terminal-readiness/use-terminal-readiness'

--- a/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.spec.ts
+++ b/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.spec.ts
@@ -1,0 +1,93 @@
+import { act, renderHook } from '@testing-library/react'
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { useLocalStorage as useLocalStorageBase } from '@uidotdev/usehooks'
+import type { SetStateAction } from 'react'
+import { useLocalStorage } from './use-local-storage'
+
+jest.mock('@uidotdev/usehooks', () => ({
+  useLocalStorage: jest.fn(),
+}))
+
+const useLocalStorageBaseMock = useLocalStorageBase as jest.Mock
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useLocalStorageBaseMock.mockImplementation((key: string, initialValue: unknown) => {
+      const setValue = jest.fn((value: unknown) => {
+        const currentValue = localStorage.getItem(key)
+        const previousValue = currentValue ? JSON.parse(currentValue) : initialValue
+        const nextValue = typeof value === 'function' ? value(previousValue) : value
+
+        if (nextValue === undefined || nextValue === null) {
+          localStorage.removeItem(key)
+          return
+        }
+
+        localStorage.setItem(key, JSON.stringify(nextValue))
+      })
+      const currentValue = localStorage.getItem(key)
+
+      return [currentValue ? JSON.parse(currentValue) : initialValue, setValue]
+    })
+  })
+
+  it('should read JSON values from localStorage', () => {
+    localStorage.setItem('key', JSON.stringify('github'))
+
+    const { result } = renderHook(() => useLocalStorage('key', undefined))
+
+    expect(result.current[0]).toBe('github')
+  })
+
+  it('should keep legacy raw string values from localStorage', () => {
+    localStorage.setItem('currentOrganizationId', '12345678-1234-1234-1234-123456789abc')
+
+    const { result } = renderHook(() => useLocalStorage('currentOrganizationId', ''))
+
+    expect(result.current[0]).toBe('12345678-1234-1234-1234-123456789abc')
+    expect(localStorage.getItem('currentOrganizationId')).toBe(JSON.stringify('12345678-1234-1234-1234-123456789abc'))
+  })
+
+  it('should store updated string values as JSON', () => {
+    localStorage.setItem('lastUsedLogin', 'github')
+
+    const { result } = renderHook(() => useLocalStorage('lastUsedLogin', undefined))
+
+    act(() => {
+      result.current[1]('saml_sso' as unknown as SetStateAction<undefined>)
+    })
+
+    expect(localStorage.getItem('lastUsedLogin')).toBe(JSON.stringify('saml_sso'))
+  })
+
+  it('should support functional updates with legacy raw string values', () => {
+    localStorage.setItem('lastUsedLogin', 'github')
+
+    const { result } = renderHook(() => useLocalStorage<string | undefined>('lastUsedLogin', undefined))
+
+    act(() => {
+      result.current[1]((previousValue) => `${previousValue}_sso`)
+    })
+
+    expect(localStorage.getItem('lastUsedLogin')).toBe(JSON.stringify('github_sso'))
+  })
+
+  it('should store updated object values as JSON', () => {
+    const { result } = renderHook(() => useLocalStorage('qovery-recent-services', {}))
+
+    act(() => {
+      result.current[1]({ organization: ['service-id'] })
+    })
+
+    expect(localStorage.getItem('qovery-recent-services')).toBe(JSON.stringify({ organization: ['service-id'] }))
+  })
+
+  it('should fallback to the initial value for corrupted object values', () => {
+    localStorage.setItem('qovery-recent-services', 'invalid json')
+
+    const { result } = renderHook(() => useLocalStorage('qovery-recent-services', {}))
+
+    expect(result.current[0]).toEqual({})
+  })
+})

--- a/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.spec.ts
+++ b/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.spec.ts
@@ -9,7 +9,7 @@ describe('useLocalStorage', () => {
   it('should read JSON values from localStorage', () => {
     localStorage.setItem('key', JSON.stringify('github'))
 
-    const { result } = renderHook(() => useLocalStorage('key', undefined))
+    const { result } = renderHook(() => useLocalStorage<string | undefined>('key', undefined))
 
     expect(result.current[0]).toBe('github')
   })

--- a/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.spec.ts
+++ b/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.spec.ts
@@ -1,35 +1,9 @@
 import { act, renderHook } from '@testing-library/react'
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { useLocalStorage as useLocalStorageBase } from '@uidotdev/usehooks'
-import type { SetStateAction } from 'react'
 import { useLocalStorage } from './use-local-storage'
-
-jest.mock('@uidotdev/usehooks', () => ({
-  useLocalStorage: jest.fn(),
-}))
-
-const useLocalStorageBaseMock = useLocalStorageBase as jest.Mock
 
 describe('useLocalStorage', () => {
   beforeEach(() => {
     localStorage.clear()
-    useLocalStorageBaseMock.mockImplementation((key: string, initialValue: unknown) => {
-      const setValue = jest.fn((value: unknown) => {
-        const currentValue = localStorage.getItem(key)
-        const previousValue = currentValue ? JSON.parse(currentValue) : initialValue
-        const nextValue = typeof value === 'function' ? value(previousValue) : value
-
-        if (nextValue === undefined || nextValue === null) {
-          localStorage.removeItem(key)
-          return
-        }
-
-        localStorage.setItem(key, JSON.stringify(nextValue))
-      })
-      const currentValue = localStorage.getItem(key)
-
-      return [currentValue ? JSON.parse(currentValue) : initialValue, setValue]
-    })
   })
 
   it('should read JSON values from localStorage', () => {
@@ -40,37 +14,32 @@ describe('useLocalStorage', () => {
     expect(result.current[0]).toBe('github')
   })
 
-  it('should keep legacy raw string values from localStorage', () => {
+  it('should read legacy raw string values without mutating localStorage', () => {
+    localStorage.setItem('lastUsedLogin', 'github')
+
+    const { result } = renderHook(() => useLocalStorage<string | undefined>('lastUsedLogin', undefined))
+
+    expect(result.current[0]).toBe('github')
+    expect(localStorage.getItem('lastUsedLogin')).toBe('github')
+  })
+
+  it('should read legacy current organization id values without mutating localStorage', () => {
     localStorage.setItem('currentOrganizationId', '12345678-1234-1234-1234-123456789abc')
 
     const { result } = renderHook(() => useLocalStorage('currentOrganizationId', ''))
 
     expect(result.current[0]).toBe('12345678-1234-1234-1234-123456789abc')
-    expect(localStorage.getItem('currentOrganizationId')).toBe(JSON.stringify('12345678-1234-1234-1234-123456789abc'))
+    expect(localStorage.getItem('currentOrganizationId')).toBe('12345678-1234-1234-1234-123456789abc')
   })
 
-  it('should store updated string values as JSON', () => {
-    localStorage.setItem('lastUsedLogin', 'github')
-
-    const { result } = renderHook(() => useLocalStorage('lastUsedLogin', undefined))
-
-    act(() => {
-      result.current[1]('saml_sso' as unknown as SetStateAction<undefined>)
-    })
-
-    expect(localStorage.getItem('lastUsedLogin')).toBe(JSON.stringify('saml_sso'))
-  })
-
-  it('should support functional updates with legacy raw string values', () => {
-    localStorage.setItem('lastUsedLogin', 'github')
-
+  it('should store updated string values as raw strings', () => {
     const { result } = renderHook(() => useLocalStorage<string | undefined>('lastUsedLogin', undefined))
 
     act(() => {
-      result.current[1]((previousValue) => `${previousValue}_sso`)
+      result.current[1]('saml_sso')
     })
 
-    expect(localStorage.getItem('lastUsedLogin')).toBe(JSON.stringify('github_sso'))
+    expect(localStorage.getItem('lastUsedLogin')).toBe('saml_sso')
   })
 
   it('should store updated object values as JSON', () => {
@@ -83,11 +52,12 @@ describe('useLocalStorage', () => {
     expect(localStorage.getItem('qovery-recent-services')).toBe(JSON.stringify({ organization: ['service-id'] }))
   })
 
-  it('should fallback to the initial value for corrupted object values', () => {
+  it('should fallback to the initial value for corrupted object values without mutating localStorage', () => {
     localStorage.setItem('qovery-recent-services', 'invalid json')
 
     const { result } = renderHook(() => useLocalStorage('qovery-recent-services', {}))
 
     expect(result.current[0]).toEqual({})
+    expect(localStorage.getItem('qovery-recent-services')).toBe('invalid json')
   })
 })

--- a/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.ts
+++ b/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.ts
@@ -1,36 +1,76 @@
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { useLocalStorage as useLocalStorageBase } from '@uidotdev/usehooks'
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useSyncExternalStore } from 'react'
 
-function safelyParseLocalStorageValue(value: string) {
+function dispatchStorageEvent(key: string, newValue: string | null) {
+  window.dispatchEvent(new StorageEvent('storage', { key, newValue }))
+}
+
+function setLocalStorageItem<T>(key: string, value: T) {
+  const localStorageValue = typeof value === 'string' ? value : JSON.stringify(value)
+  window.localStorage.setItem(key, localStorageValue)
+  dispatchStorageEvent(key, localStorageValue)
+}
+
+function removeLocalStorageItem(key: string) {
+  window.localStorage.removeItem(key)
+  dispatchStorageEvent(key, null)
+}
+
+function getLocalStorageItem(key: string) {
+  return window.localStorage.getItem(key)
+}
+
+function subscribeToLocalStorage(callback: () => void) {
+  window.addEventListener('storage', callback)
+  return () => window.removeEventListener('storage', callback)
+}
+
+function getLocalStorageServerSnapshot(): never {
+  throw Error('useLocalStorage is a client-only hook')
+}
+
+function parseLocalStorageValue<T>(storedValue: string | null, initialValue: T) {
+  if (storedValue === null) {
+    return initialValue
+  }
+
   try {
-    JSON.parse(value)
-    return true
+    return JSON.parse(storedValue) as T
   } catch {
-    return false
+    if (typeof initialValue === 'string' || initialValue === undefined || initialValue === null) {
+      return storedValue as T
+    }
+
+    return initialValue
   }
 }
 
-// This function ensures that the value in localStorage is a JSON object.
-// If the value is not a JSON object, it will be converted to a JSON object.
-// If the value is a string, it will be stored as a string.
-// If the value is undefined or null, it will be removed from localStorage.
-function ensureJsonLocalStorageValue<T>(key: string, initialValue?: T) {
-  const value = window.localStorage.getItem(key)
+export function useLocalStorage<T>(key: string, initialValue?: T): [T, Dispatch<SetStateAction<T>>] {
+  const getSnapshot = () => getLocalStorageItem(key)
+  const store = useSyncExternalStore(subscribeToLocalStorage, getSnapshot, getLocalStorageServerSnapshot)
 
-  if (value === null || safelyParseLocalStorageValue(value)) {
-    return
-  }
+  const setState = useCallback(
+    (value: SetStateAction<T>) => {
+      try {
+        const currentValue = parseLocalStorageValue(store, initialValue as T)
+        const nextState = typeof value === 'function' ? (value as (previousValue: T) => T)(currentValue) : value
 
-  if (typeof initialValue === 'string' || initialValue === undefined || initialValue === null) {
-    window.localStorage.setItem(key, JSON.stringify(value))
-    return
-  }
+        if (nextState === undefined || nextState === null) {
+          removeLocalStorageItem(key)
+        } else {
+          setLocalStorageItem(key, nextState)
+        }
+      } catch (error) {
+        console.warn(error)
+      }
+    },
+    [initialValue, key, store]
+  )
 
-  window.localStorage.setItem(key, JSON.stringify(initialValue))
-}
+  useEffect(() => {
+    if (getLocalStorageItem(key) === null && typeof initialValue !== 'undefined') {
+      setLocalStorageItem(key, initialValue)
+    }
+  }, [initialValue, key])
 
-export function useLocalStorage<T>(key: string, initialValue?: T) {
-  ensureJsonLocalStorageValue(key, initialValue)
-
-  return useLocalStorageBase<T>(key, initialValue)
+  return [parseLocalStorageValue(store, initialValue as T), setState]
 }

--- a/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.ts
+++ b/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.ts
@@ -1,0 +1,36 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { useLocalStorage as useLocalStorageBase } from '@uidotdev/usehooks'
+
+function safelyParseLocalStorageValue(value: string) {
+  try {
+    JSON.parse(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// This function ensures that the value in localStorage is a JSON object.
+// If the value is not a JSON object, it will be converted to a JSON object.
+// If the value is a string, it will be stored as a string.
+// If the value is undefined or null, it will be removed from localStorage.
+function ensureJsonLocalStorageValue<T>(key: string, initialValue?: T) {
+  const value = window.localStorage.getItem(key)
+
+  if (value === null || safelyParseLocalStorageValue(value)) {
+    return
+  }
+
+  if (typeof initialValue === 'string' || initialValue === undefined || initialValue === null) {
+    window.localStorage.setItem(key, JSON.stringify(value))
+    return
+  }
+
+  window.localStorage.setItem(key, JSON.stringify(initialValue))
+}
+
+export function useLocalStorage<T>(key: string, initialValue?: T) {
+  ensureJsonLocalStorageValue(key, initialValue)
+
+  return useLocalStorageBase<T>(key, initialValue)
+}

--- a/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.ts
+++ b/libs/shared/util-hooks/src/lib/use-local-storage/use-local-storage.ts
@@ -51,7 +51,7 @@ export function useLocalStorage<T>(key: string, initialValue?: T): [T, Dispatch<
   const setState = useCallback(
     (value: SetStateAction<T>) => {
       try {
-        const currentValue = parseLocalStorageValue(store, initialValue as T)
+        const currentValue = parseLocalStorageValue(getLocalStorageItem(key), initialValue as T)
         const nextState = typeof value === 'function' ? (value as (previousValue: T) => T)(currentValue) : value
 
         if (nextState === undefined || nextState === null) {
@@ -63,7 +63,7 @@ export function useLocalStorage<T>(key: string, initialValue?: T): [T, Dispatch<
         console.warn(error)
       }
     },
-    [initialValue, key, store]
+    [initialValue, key]
   )
 
   useEffect(() => {


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Commit [1d0f05d9](https://github.com/Qovery/console/commit/1d0f05d903adbbfb7b20621656e4b15016c8c442) introduced `useLocalStorage` from `@uidotdev/usehooks`, which reads stored values with `JSON.parse`. Some existing users already had raw strings in `localStorage` from previous direct usage, for example:

```ts
lastUsedLogin = github
currentOrganizationId = 12345678-1234-1234-1234-123456789
```

Because these values are not valid JSON, `JSON.parse` throws on mount:

```txt
SyntaxError: Unexpected non-whitespace character after JSON at position 8
```

Result: affected users could hit a white screen on routes consuming those keys.

### Fix

Add a custom `useLocalStorage` wrapper in `use-local-storage.ts` that keeps the existing hook API but makes reads resilient to legacy values, without mutating `localStorage` during render/read.

Behavior:

- Valid JSON values are parsed normally.
- Legacy raw strings are returned as-is when the hook expects a string value.
- Corrupted/non-JSON values fallback to the provided initial value for non-string usage.
- String updates are stored as raw strings to stay compatible with existing direct `localStorage` consumers.
- Object/array updates continue to be stored as JSON.
- The direct re-export of `useLocalStorage` from `@uidotdev/usehooks` is removed from `index.ts`, so consumers use the shared wrapper.

Updated impacted direct reads in touched files to use the shared hook for:

- `currentOrganizationId`
- `currentProjectId`

Unit tests cover valid JSON values, legacy raw strings, `currentOrganizationId`, string updates, object storage, and corrupted values without mutating existing storage.

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
