### PR TITLE
fix(service-last-deployment-cell): enhance error handling and status display for deployment actions

### DIFF
--- a/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.spec.tsx
@@ -1,0 +1,83 @@
+import { type Environment } from 'qovery-typescript-axios'
+import { type AnyService } from '@qovery/domains/services/data-access'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { useServiceDeploymentAndRunningStatuses } from '../../hooks/use-service-deployment-and-running-statuses/use-service-deployment-and-running-statuses'
+import { ServiceLastDeploymentCell } from './service-last-deployment-cell'
+
+jest.mock('@qovery/shared/devops-copilot/feature', () => ({
+  DevopsCopilotTroubleshootTrigger: () => <button type="button">Launch diagnostic</button>,
+}))
+
+jest.mock(
+  '../../hooks/use-service-deployment-and-running-statuses/use-service-deployment-and-running-statuses',
+  () => ({
+    useServiceDeploymentAndRunningStatuses: jest.fn(),
+  })
+)
+
+const mockUseServiceDeploymentAndRunningStatuses = useServiceDeploymentAndRunningStatuses as jest.Mock
+
+const environment = {
+  id: 'environment-id',
+  organization: {
+    id: 'organization-id',
+  },
+  project: {
+    id: 'project-id',
+  },
+} as Environment
+
+const service = {
+  id: 'service-id',
+  name: 'Admin API',
+  serviceType: 'CONTAINER',
+} as AnyService
+
+describe('ServiceLastDeploymentCell', () => {
+  it('highlights failed deployments with negative status colors', () => {
+    mockUseServiceDeploymentAndRunningStatuses.mockReturnValue({
+      data: {
+        deploymentStatus: {
+          execution_id: 'execution-id',
+          last_deployment_date: '2026-05-25T07:00:00Z',
+          state: 'DEPLOYMENT_ERROR',
+          status_details: {
+            action: 'DEPLOY',
+            status: 'ERROR',
+            sub_action: 'NONE',
+          },
+        },
+      },
+    })
+
+    const { container } = renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} />)
+
+    expect(screen.getByText('Launch diagnostic')).toBeInTheDocument()
+    expect(screen.getByText('Deploy').previousElementSibling).toHaveClass('text-negative')
+    expect(container.querySelector('svg.text-negative')).toBeInTheDocument()
+    expect(container.querySelector('svg.text-neutral-subtle')).not.toBeInTheDocument()
+  })
+
+  it('keeps successful deployment indicators monochrome', () => {
+    mockUseServiceDeploymentAndRunningStatuses.mockReturnValue({
+      data: {
+        deploymentStatus: {
+          execution_id: 'execution-id',
+          last_deployment_date: '2026-05-25T07:00:00Z',
+          state: 'DEPLOYED',
+          status_details: {
+            action: 'DEPLOY',
+            status: 'SUCCESS',
+            sub_action: 'NONE',
+          },
+        },
+      },
+    })
+
+    const { container } = renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} />)
+
+    expect(screen.queryByText('Launch diagnostic')).not.toBeInTheDocument()
+    expect(screen.getByText('Deploy').previousElementSibling).toHaveClass('text-neutral-subtle')
+    expect(container.querySelector('svg.text-neutral-subtle')).toBeInTheDocument()
+  })
+})

--- a/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.tsx
@@ -17,6 +17,7 @@ export function ServiceLastDeploymentCell({ service, environment }: ServiceLastD
   } = useServiceDeploymentAndRunningStatuses({ environmentId: environment.id, service })
   const subAction = deploymentStatus?.status_details?.sub_action
   const triggerAction = subAction !== 'NONE' ? subAction : deploymentStatus?.status_details?.action
+  const hasDeploymentError = deploymentStatus?.status_details?.status === 'ERROR'
 
   const WrappingLink = useCallback(
     ({ children }: PropsWithChildren) => {
@@ -49,7 +50,11 @@ export function ServiceLastDeploymentCell({ service, environment }: ServiceLastD
     <div className="flex w-full items-center justify-between gap-4">
       <WrappingLink>
         <div className="group flex items-center gap-2">
-          <DeploymentAction status={triggerAction} textClassName="group-hover:underline" />
+          <DeploymentAction
+            status={triggerAction}
+            iconClassName={hasDeploymentError ? 'text-negative' : 'text-neutral-subtle'}
+            textClassName="group-hover:underline"
+          />
           {deploymentStatus?.last_deployment_date && (
             <span className="font-normal text-neutral-subtle group-hover:text-neutral-subtle group-hover:underline">
               {timeAgo(new Date(deploymentStatus.last_deployment_date))} ago
@@ -59,7 +64,7 @@ export function ServiceLastDeploymentCell({ service, environment }: ServiceLastD
       </WrappingLink>
       <div>
         <div className="flex items-center gap-2">
-          {deploymentStatus?.status_details?.status === 'ERROR' && (
+          {hasDeploymentError && (
             <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
               <DevopsCopilotTroubleshootTrigger
                 source="service-deployment-list"
@@ -73,7 +78,10 @@ export function ServiceLastDeploymentCell({ service, environment }: ServiceLastD
             </div>
           )}
           <WrappingLink>
-            <StatusChip status={deploymentStatus?.status_details?.status} variant="monochrome" />
+            <StatusChip
+              status={deploymentStatus?.status_details?.status}
+              variant={hasDeploymentError ? 'default' : 'monochrome'}
+            />
           </WrappingLink>
         </div>
       </div>


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

https://qovery.slack.com/archives/C0A4CDDJBRQ/p1779556195536009

- Add service deployment color to red if error
- Fix snapshot for variable list

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
