### PR TITLE
feat(blueprint): Support no history and last operations for undeployed blueprint

### DIFF
--- a/libs/domains/services/feature/src/lib/hooks/use-deployment-status/use-deployment-status.spec.tsx
+++ b/libs/domains/services/feature/src/lib/hooks/use-deployment-status/use-deployment-status.spec.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import { type PropsWithChildren } from 'react'
+import useListStatuses from '../use-list-statuses/use-list-statuses'
+import { useDeploymentStatus } from './use-deployment-status'
+
+jest.mock('../use-list-statuses/use-list-statuses')
+
+const mockUseListStatuses = useListStatuses as jest.MockedFunction<typeof useListStatuses>
+
+const helmStatus = { id: 'helm-svc-1', state: 'RUNNING' } as never
+const terraformStatus = { id: 'tf-svc-1', state: 'STOPPED' } as never
+
+const emptyEnvStatus = {
+  data: { applications: [], containers: [], databases: [], jobs: [], helms: [], terraforms: [] },
+  isLoading: false,
+} as never
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: PropsWithChildren) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+describe('useDeploymentStatus HTTP fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns helm service status when helms array contains the service', () => {
+    mockUseListStatuses.mockReturnValue({
+      ...emptyEnvStatus,
+      data: { ...emptyEnvStatus.data, helms: [helmStatus] },
+    })
+
+    const { result } = renderHook(() => useDeploymentStatus({ environmentId: 'env-1', serviceId: 'helm-svc-1' }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.data).toEqual(helmStatus)
+  })
+
+  it('returns terraform service status when terraforms array contains the service', () => {
+    mockUseListStatuses.mockReturnValue({
+      ...emptyEnvStatus,
+      data: { ...emptyEnvStatus.data, terraforms: [terraformStatus] },
+    })
+
+    const { result } = renderHook(() => useDeploymentStatus({ environmentId: 'env-1', serviceId: 'tf-svc-1' }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.data).toEqual(terraformStatus)
+  })
+
+  it('returns undefined when service id is not found in any status list', () => {
+    mockUseListStatuses.mockReturnValue(emptyEnvStatus)
+
+    const { result } = renderHook(() => useDeploymentStatus({ environmentId: 'env-1', serviceId: 'unknown-id' }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.data).toBeUndefined()
+  })
+})

--- a/libs/domains/services/feature/src/lib/hooks/use-deployment-status/use-deployment-status.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-deployment-status/use-deployment-status.ts
@@ -29,6 +29,7 @@ export function useDeploymentStatus({ environmentId, serviceId, suspense = false
     ...(environmentStatus?.containers ?? []),
     ...(environmentStatus?.databases ?? []),
     ...(environmentStatus?.jobs ?? []),
+    ...(environmentStatus?.helms ?? []),
     ...(environmentStatus?.terraforms ?? []),
   ]
   return webSocketResult.data

--- a/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.spec.tsx
@@ -101,6 +101,24 @@ describe('ServiceLastDeployment', () => {
     expect(screen.getByRole('button', { name: /deploy now/i })).toBeInTheDocument()
   })
 
+  it('renders service type name in description when service has service_type', () => {
+    mockUseDeploymentHistory.mockReturnValue({
+      data: [],
+      isFetched: true,
+    })
+
+    renderWithProviders(
+      <ServiceLastDeployment
+        serviceId="service-123"
+        serviceType="HELM"
+        service={{ id: 'service-123', name: 'my-helm', service_type: 'HELM' } as never}
+      />
+    )
+
+    expect(screen.getByText('Helm has never been deployed')).toBeInTheDocument()
+    expect(screen.getByText('Deploy the helm first')).toBeInTheDocument()
+  })
+
   it('renders the image tag version pill when deployment details contains an image tag', () => {
     mockUseDeploymentHistory.mockReturnValue({
       data: [baseDeployment],

--- a/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.tsx
+++ b/libs/domains/services/feature/src/lib/service-overview/service-last-deployment/service-last-deployment.tsx
@@ -98,7 +98,7 @@ function ServiceLastDeploymentContent({ serviceId, serviceType, service }: Servi
         icon="play"
         iconStyle="solid"
         title={`${upperCaseFirstLetter(service?.service_type ?? 'Service')} has never been deployed`}
-        description={`Deploy the ${service?.serviceType.toLowerCase() ?? 'service'} first`}
+        description={`Deploy the ${service?.service_type?.toLowerCase() ?? 'service'} first`}
       >
         <Button
           color="neutral"


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary
- Display Actions for created but not deployed blueprint
- Fix last deployment for blueprint by using service_type instead of `serviceType` following 
```
// XXX: Need to remove `serviceType` and use only `service_type` since the the API now supports it.
// Waiting to have this implementation available in the edition interfaces.
```
to be able to render blueprint state correctly.


## Testing

- [X] Changes tested locally in the relevant Console's pages and Storybooks
- [X] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [X] `yarn format`
- [X] `yarn lint`

## PR Checklist

- [X] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [X] I performed a self-review (diff inspected, dead code removed)
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [X] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [X] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [X] I reviewed and executed locally any AI-assisted code
