### PR TITLE
fix(service-last-deployment-cell): remove deployment action icon styles for failed deployments

### DIFF
--- a/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.spec.tsx
@@ -50,12 +50,11 @@ describe('ServiceLastDeploymentCell', () => {
       },
     })
 
-    const { container } = renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} />)
+    renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} />)
 
     expect(screen.getByText('Launch diagnostic')).toBeInTheDocument()
     expect(screen.getByText('Deploy').previousElementSibling).toHaveClass('text-neutral-subtle')
-    expect(container.querySelector('svg.text-neutral-subtle')).toBeInTheDocument()
-    expect(container.querySelector('svg.text-negative')).not.toBeInTheDocument()
+    expect(screen.getByText('Deploy').previousElementSibling).not.toHaveClass('text-negative')
   })
 
   it('keeps successful deployment indicators monochrome', () => {
@@ -74,10 +73,9 @@ describe('ServiceLastDeploymentCell', () => {
       },
     })
 
-    const { container } = renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} />)
+    renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} />)
 
     expect(screen.queryByText('Launch diagnostic')).not.toBeInTheDocument()
     expect(screen.getByText('Deploy').previousElementSibling).toHaveClass('text-neutral-subtle')
-    expect(container.querySelector('svg.text-neutral-subtle')).toBeInTheDocument()
   })
 })

--- a/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.spec.tsx
@@ -34,7 +34,7 @@ const service = {
 } as AnyService
 
 describe('ServiceLastDeploymentCell', () => {
-  it('highlights failed deployments with negative status colors', () => {
+  it('keeps the deployment action icon neutral for failed deployments', () => {
     mockUseServiceDeploymentAndRunningStatuses.mockReturnValue({
       data: {
         deploymentStatus: {
@@ -53,9 +53,9 @@ describe('ServiceLastDeploymentCell', () => {
     const { container } = renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} />)
 
     expect(screen.getByText('Launch diagnostic')).toBeInTheDocument()
-    expect(screen.getByText('Deploy').previousElementSibling).toHaveClass('text-negative')
-    expect(container.querySelector('svg.text-negative')).toBeInTheDocument()
-    expect(container.querySelector('svg.text-neutral-subtle')).not.toBeInTheDocument()
+    expect(screen.getByText('Deploy').previousElementSibling).toHaveClass('text-neutral-subtle')
+    expect(container.querySelector('svg.text-neutral-subtle')).toBeInTheDocument()
+    expect(container.querySelector('svg.text-negative')).not.toBeInTheDocument()
   })
 
   it('keeps successful deployment indicators monochrome', () => {

--- a/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.tsx
@@ -52,7 +52,7 @@ export function ServiceLastDeploymentCell({ service, environment }: ServiceLastD
         <div className="group flex items-center gap-2">
           <DeploymentAction
             status={triggerAction}
-            iconClassName={hasDeploymentError ? 'text-negative' : 'text-neutral-subtle'}
+            iconClassName="text-neutral-subtle"
             textClassName="group-hover:underline"
           />
           {deploymentStatus?.last_deployment_date && (


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Remove useless color for the rocket icon

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
