### PR TITLE
feat(analytics): add data-action attributes on org overview clickable elements

### DIFF
--- a/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.tsx
+++ b/libs/domains/clusters/feature/src/lib/section-production-health/section-production-health.tsx
@@ -19,6 +19,7 @@ type ClusterOption = {
   description: string
   icon: IconName | ReactNode
   compatibleWith?: IconEnum[]
+  dataAction: string
 } & (
   | {
       action: 'create-cluster'
@@ -40,6 +41,7 @@ const CLUSTERS_OPTIONS: ClusterOption[] = [
     icon: <LogoIcon width="14" height="14" />,
     compatibleWith: [IconEnum.AWS, IconEnum.GCP, IconEnum.AZURE, IconEnum.SCW_GRAY],
     action: 'create-cluster',
+    dataAction: 'org-overview__cluster-option-managed',
   },
   {
     highlight: false,
@@ -62,6 +64,7 @@ const CLUSTERS_OPTIONS: ClusterOption[] = [
     ],
     action: 'installation-guide',
     requiresCreditCardOnFreeTrial: true,
+    dataAction: 'org-overview__cluster-option-byoc',
   },
   {
     highlight: false,
@@ -72,6 +75,7 @@ const CLUSTERS_OPTIONS: ClusterOption[] = [
       'Deploy a local Kubernetes cluster on your laptop using Docker. No cloud account or credit card required!',
     action: 'installation-guide',
     isDemo: true,
+    dataAction: 'org-overview__cluster-option-demo',
   },
 ]
 
@@ -180,6 +184,7 @@ export function SectionProductionHealth() {
           params={{ organizationId }}
           color="neutral"
           size="ssm"
+          data-action="org-overview__all-clusters"
           className="gap-0.5 text-neutral-subtle hover:text-neutral"
         >
           All clusters
@@ -197,6 +202,7 @@ export function SectionProductionHealth() {
               as="button"
               color="neutral"
               size="md"
+              data-action="org-overview__create-cluster"
               to="/organization/$organizationId/cluster/new"
               params={{ organizationId }}
             >
@@ -221,6 +227,7 @@ export function SectionProductionHealth() {
                     key={option.title}
                     to="/organization/$organizationId/cluster/new"
                     params={{ organizationId }}
+                    data-action={option.dataAction}
                     className={getOptionCardClassName(option.highlight)}
                   >
                     {renderOptionCardContent(option)}
@@ -229,6 +236,7 @@ export function SectionProductionHealth() {
                   <button
                     key={option.title}
                     type="button"
+                    data-action={option.dataAction}
                     onClick={() =>
                       option.requiresCreditCardOnFreeTrial && isNoCreditCardRestriction
                         ? openCreditCardModal()
@@ -251,6 +259,7 @@ export function SectionProductionHealth() {
                     title={doc.title}
                     target="_blank"
                     rel="noreferrer"
+                    data-action="org-overview__cluster-doc"
                     className="group flex h-12 w-full items-center justify-between border-b border-neutral p-4 text-ssm text-neutral transition-colors last:border-b-0 hover:bg-surface-neutral-subtle focus:outline-none focus-visible:bg-surface-neutral-subtle"
                   >
                     {doc.title}

--- a/libs/domains/organizations/feature/src/lib/organization-overview/section-changelog/section-changelog.tsx
+++ b/libs/domains/organizations/feature/src/lib/organization-overview/section-changelog/section-changelog.tsx
@@ -48,6 +48,7 @@ export function SectionChangelog() {
             title={changelog.name}
             target="_blank"
             rel="noreferrer"
+            data-action="org-overview__changelog"
             onClick={() => {
               if (isLatest && showNewBadge) {
                 setSeenChangelogDate(changelog.firstPublishedAt)

--- a/libs/domains/organizations/feature/src/lib/organization-overview/section-links/section-links.tsx
+++ b/libs/domains/organizations/feature/src/lib/organization-overview/section-links/section-links.tsx
@@ -75,6 +75,7 @@ export function SectionLinks() {
               key={link.title}
               type="button"
               title={link.title}
+              data-action="org-overview__support"
               onClick={showChat}
               className="group flex justify-between gap-2 rounded-lg border border-neutral p-4 text-sm text-neutral transition-colors hover:bg-surface-neutral-subtle"
             >
@@ -89,6 +90,7 @@ export function SectionLinks() {
               key={link.title}
               type="button"
               title={link.title}
+              data-action="org-overview__give-feedback"
               onClick={handleGiveFeedbackClick}
               className="group flex justify-between gap-2 rounded-lg border border-neutral p-4 text-sm text-neutral transition-colors hover:bg-surface-neutral-subtle"
             >
@@ -104,6 +106,7 @@ export function SectionLinks() {
             title={link.title}
             target="_blank"
             rel="noreferrer"
+            data-action="org-overview__documentation"
             className="group flex justify-between gap-2 rounded-lg border border-neutral p-4 text-sm text-neutral transition-colors hover:bg-surface-neutral-subtle"
           >
             {content}

--- a/libs/domains/projects/feature/src/lib/project-list/project-list.tsx
+++ b/libs/domains/projects/feature/src/lib/project-list/project-list.tsx
@@ -27,7 +27,7 @@ export function ProjectList() {
         <Heading className="flex items-center gap-2">
           Your {pluralize(projects?.length ?? 0, 'project', 'projects')}
         </Heading>
-        <Button type="button" color="brand" size="sm" onClick={() => createProjectModal()}>
+        <Button type="button" color="brand" size="sm" data-action="org-overview__new-project" onClick={() => createProjectModal()}>
           <Icon iconName="circle-plus" />
           New project
         </Button>
@@ -38,7 +38,7 @@ export function ProjectList() {
           description="Create your first project and environments to start deploying apps"
           icon="folder-closed"
         >
-          <Button color="neutral" size="md" onClick={() => createProjectModal()}>
+          <Button color="neutral" size="md" data-action="org-overview__create-project" onClick={() => createProjectModal()}>
             <Icon iconName="circle-plus" />
             Create project
           </Button>
@@ -63,6 +63,7 @@ export function ProjectList() {
                   to="/organization/$organizationId/project/$projectId/overview"
                   params={{ organizationId, projectId: project.id }}
                   aria-label={`Open project ${project.name}`}
+                  data-action="org-overview__project-card"
                   className="absolute inset-0 rounded-lg"
                 />
                 <div className="pointer-events-none relative flex items-center justify-between gap-3">

--- a/libs/domains/projects/feature/src/lib/project-list/project-list.tsx
+++ b/libs/domains/projects/feature/src/lib/project-list/project-list.tsx
@@ -27,7 +27,13 @@ export function ProjectList() {
         <Heading className="flex items-center gap-2">
           Your {pluralize(projects?.length ?? 0, 'project', 'projects')}
         </Heading>
-        <Button type="button" color="brand" size="sm" data-action="org-overview__new-project" onClick={() => createProjectModal()}>
+        <Button
+          type="button"
+          color="brand"
+          size="sm"
+          data-action="org-overview__new-project"
+          onClick={() => createProjectModal()}
+        >
           <Icon iconName="circle-plus" />
           New project
         </Button>
@@ -38,7 +44,12 @@ export function ProjectList() {
           description="Create your first project and environments to start deploying apps"
           icon="folder-closed"
         >
-          <Button color="neutral" size="md" data-action="org-overview__create-project" onClick={() => createProjectModal()}>
+          <Button
+            color="neutral"
+            size="md"
+            data-action="org-overview__create-project"
+            onClick={() => createProjectModal()}
+          >
             <Icon iconName="circle-plus" />
             Create project
           </Button>


### PR DESCRIPTION

## Summary

**Issue**: QOV-1934

Add data attributes on org overview page

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
