### PR TITLE
feat(ui): change brand color from violet to green

### DIFF
--- a/libs/shared/ui/src/lib/styles/base/themes.scss
+++ b/libs/shared/ui/src/lib/styles/base/themes.scss
@@ -34,20 +34,20 @@
   --neutral-invert-11: hsla(258, 7%, 72%, 1);
   --neutral-invert-12: hsla(300, 100%, 100%, 1);
 
-  /* Brand */
-  --brand-1: hsla(240, 100%, 100%, 1);
-  --brand-2: hsla(233, 100%, 98%, 1);
-  --brand-3: hsla(233, 100%, 97%, 1);
-  --brand-4: hsla(236, 100%, 95%, 1);
-  --brand-5: hsla(237, 100%, 92%, 1);
-  --brand-6: hsla(239, 100%, 90%, 1);
-  --brand-7: hsla(239, 100%, 85%, 1);
-  --brand-alpha-7: hsla(238, 100%, 40%, 0.3);
-  --brand-8: hsla(243, 100%, 79%, 1);
-  --brand-9: hsla(256, 100%, 59%, 1);
-  --brand-10: hsla(256, 78%, 51%, 1);
-  --brand-11: hsla(254, 86%, 57%, 1);
-  --brand-12: hsla(252, 64%, 29%, 1);
+  /* Brand - Green (Italian flag) */
+  --brand-1: hsla(140, 60%, 99%, 1);
+  --brand-2: hsla(137, 47%, 97%, 1);
+  --brand-3: hsla(139, 47%, 93%, 1);
+  --brand-4: hsla(140, 49%, 89%, 1);
+  --brand-5: hsla(142, 44%, 84%, 1);
+  --brand-6: hsla(144, 41%, 77%, 1);
+  --brand-7: hsla(146, 40%, 68%, 1);
+  --brand-alpha-7: hsla(146, 100%, 28%, 0.44);
+  --brand-8: hsla(151, 40%, 54%, 1);
+  --brand-9: hsla(145, 63%, 42%, 1);
+  --brand-10: hsla(145, 63%, 38%, 1);
+  --brand-11: hsla(145, 70%, 36%, 1);
+  --brand-12: hsla(145, 50%, 20%, 1);
 
   /* Positive */
   --positive-1: hsla(140, 60%, 99%, 1);
@@ -168,20 +168,20 @@
   --neutral-invert-11: hsla(252, 5%, 41%, 1);
   --neutral-invert-12: hsla(257, 10%, 14%, 1);
 
-  /* Brand */
-  --brand-1: hsla(257, 33%, 8%, 1);
-  --brand-2: hsla(254, 29%, 12%, 1);
-  --brand-3: hsla(258, 41%, 19%, 1);
-  --brand-4: hsla(260, 47%, 25%, 1);
-  --brand-5: hsla(259, 43%, 29%, 1);
-  --brand-6: hsla(258, 39%, 34%, 1);
-  --brand-7: hsla(258, 36%, 41%, 1);
-  --brand-alpha-7: hsla(258, 100%, 74%, 0.56);
-  --brand-8: hsla(258, 37%, 51%, 1);
-  --brand-9: hsla(256, 100%, 79%, 1);
-  --brand-10: hsla(256, 81%, 75%, 1);
-  --brand-11: hsla(258, 100%, 82%, 1);
-  --brand-12: hsla(252, 100%, 93%, 1);
+  /* Brand - Green (Italian flag) */
+  --brand-1: hsla(154, 20%, 7%, 1);
+  --brand-2: hsla(153, 20%, 9%, 1);
+  --brand-3: hsla(152, 41%, 13%, 1);
+  --brand-4: hsla(154, 55%, 15%, 1);
+  --brand-5: hsla(154, 52%, 19%, 1);
+  --brand-6: hsla(153, 46%, 23%, 1);
+  --brand-7: hsla(152, 44%, 28%, 1);
+  --brand-alpha-7: hsla(152, 98%, 65%, 0.37);
+  --brand-8: hsla(151, 45%, 34%, 1);
+  --brand-9: hsla(145, 63%, 50%, 1);
+  --brand-10: hsla(145, 63%, 55%, 1);
+  --brand-11: hsla(145, 70%, 60%, 1);
+  --brand-12: hsla(144, 70%, 82%, 1);
 
   /* Positive */
   --positive-1: hsla(154, 20%, 7%, 1);


### PR DESCRIPTION
## Summary
- Updated the console color scheme to use green (Italian flag inspired 🇮🇹) for the brand/primary color instead of violet
- Changes apply to both light and dark themes
- The existing color scheme already includes white (neutrals) and red (negative/error states), completing the Italian flag theme

## Changed Files
- `libs/shared/ui/src/lib/styles/base/themes.scss` - Updated brand color HSL values from violet (233-256°) to green (140-145°)

## Test plan
- [ ] Verify brand colors appear green in light theme
- [ ] Verify brand colors appear green in dark theme
- [ ] Check buttons, links, and accent colors use the new green palette

Slack thread: https://qovery.slack.com/archives/C0A4CDDJBRQ/p1780311859777419

https://claude.ai/code/session_01L4wnjSkKyjHMA9hyh6DKt8

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4wnjSkKyjHMA9hyh6DKt8)_