### PR TITLE
feat(cluster-creation): show no arm badge for unsupported gcp regions

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.spec.tsx
@@ -1,5 +1,6 @@
 import { CloudProviderEnum } from 'qovery-typescript-axios'
 import { type PropsWithChildren } from 'react'
+import selectEvent from 'react-select-event'
 import * as cloudProvidersDomain from '@qovery/domains/cloud-providers/feature'
 import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import {
@@ -74,6 +75,7 @@ const useCloudProviderCredentialsMockSpy = jest.spyOn(cloudProvidersDomain, 'use
 const defaultProps: StepGeneralProps = {
   organizationId: 'org-123',
   onSubmit: mockOnSubmit,
+  labelsSetting: null,
 }
 
 describe('StepGeneral', () => {
@@ -111,5 +113,28 @@ describe('StepGeneral', () => {
     renderWithProviders(<StepGeneral {...defaultProps} />, { wrapper: Wrapper })
 
     expect(screen.getByTestId('button-submit')).toBeDisabled()
+  })
+
+  it('should display an ARM not supported badge for GCP regions without ARM support', async () => {
+    useCloudProvidersMockSpy.mockReturnValue({
+      data: [
+        {
+          name: 'GCP',
+          short_name: CloudProviderEnum.GCP,
+          regions: [
+            { name: 'us-east1', city: 'South Carolina', country_code: 'US', arm_supported: true },
+            { name: 'europe-west9', city: 'Paris', country_code: 'FR', arm_supported: false },
+          ],
+        },
+      ],
+    })
+
+    renderWithProviders(<StepGeneral {...defaultProps} />, { wrapper: Wrapper })
+
+    await selectEvent.select(screen.getByLabelText('Cloud provider'), 'Gcp', { container: document.body })
+    const regionSelect = await screen.findByLabelText('Region')
+    selectEvent.openMenu(regionSelect)
+
+    expect(screen.getByText('No ARM')).toBeInTheDocument()
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.spec.tsx
@@ -135,6 +135,6 @@ describe('StepGeneral', () => {
     const regionSelect = await screen.findByLabelText('Region')
     selectEvent.openMenu(regionSelect)
 
-    expect(screen.getByText('No ARM')).toBeInTheDocument()
+    expect(await screen.findAllByText('No ARM')).toHaveLength(1)
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
@@ -5,6 +5,7 @@ import { match } from 'ts-pattern'
 import { useCloudProviderCredentials, useCloudProviders } from '@qovery/domains/cloud-providers/feature'
 import { type ClusterGeneralData, type Value } from '@qovery/shared/interfaces'
 import {
+  Badge,
   Button,
   Callout,
   FunnelFlowBody,
@@ -69,13 +70,36 @@ export function StepGeneral({ organizationId, onSubmit, labelsSetting }: StepGen
 
   const buildRegions: Value[] = useMemo(
     () =>
-      currentProvider?.regions?.map((region: ClusterRegion) => ({
-        label: `${region.city} (${region.name})`,
-        value: region.name,
-        icon: <IconFlag code={region.country_code} />,
-      })) || [],
+      currentProvider?.regions?.map((region: ClusterRegion) => {
+        const label = `${region.city} (${region.name})`
+        const showArmUnsupportedBadge =
+          currentProvider.short_name === CloudProviderEnum.GCP && region.arm_supported === false
+
+        return {
+          label: (
+            <span className="flex items-center gap-2">
+              <span className="truncate">{label}</span>
+              {showArmUnsupportedBadge && (
+                <Badge color="yellow" variant="surface" size="sm" className="gap-1">
+                  No ARM
+                </Badge>
+              )}
+            </span>
+          ),
+          value: region.name,
+          icon: <IconFlag code={region.country_code} />,
+          searchText: label,
+        }
+      }) || [],
     [currentProvider?.regions]
   )
+
+  const filterRegionOption = (option: any, inputValue: string) => {
+    if (!inputValue) return true
+
+    const searchString = option.data.searchText || (typeof option.data.label === 'string' ? option.data.label : '')
+    return searchString.toLowerCase().includes(inputValue.toLowerCase())
+  }
 
   const watchCloudProvider = watch('cloud_provider')
   const watchInstallationType = watch('installation_type')
@@ -175,6 +199,7 @@ export function StepGeneral({ organizationId, onSubmit, labelsSetting }: StepGen
                             value={field.value}
                             error={error?.message}
                             isSearchable
+                            filterOption={filterRegionOption}
                             portal
                           />
                         )}

--- a/libs/domains/organizations/feature/src/lib/settings-cloud-credentials/settings-cloud-credentials.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-cloud-credentials/settings-cloud-credentials.tsx
@@ -28,6 +28,7 @@ const convertToCloudProviderEnum = (cloudProvider: ClusterCredentials['object_ty
     .with('SCW', () => CloudProviderEnum.SCW)
     .with('OTHER', () => CloudProviderEnum.ON_PREMISE)
     .with('GCP', () => CloudProviderEnum.GCP)
+    .with('GCP_WORKLOAD_IDENTITY_FEDERATION', () => CloudProviderEnum.GCP)
     .exhaustive()
 }
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mermaid": "11.6.0",
     "monaco-editor": "0.53.0",
     "posthog-js": "1.345.1",
-    "qovery-typescript-axios": "1.1.895",
+    "qovery-typescript-axios": "1.1.897",
     "react": "18.3.1",
     "react-country-flag": "3.0.2",
     "react-datepicker": "4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6342,7 +6342,7 @@ __metadata:
     prettier: 3.2.5
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
-    qovery-typescript-axios: 1.1.895
+    qovery-typescript-axios: 1.1.897
     qovery-ws-typescript-axios: 0.1.586
     react: 18.3.1
     react-country-flag: 3.0.2
@@ -25836,12 +25836,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:1.1.895":
-  version: 1.1.895
-  resolution: "qovery-typescript-axios@npm:1.1.895"
+"qovery-typescript-axios@npm:1.1.897":
+  version: 1.1.897
+  resolution: "qovery-typescript-axios@npm:1.1.897"
   dependencies:
     axios: 1.15.2
-  checksum: 132dfde9e5b785571aa54dabd4b27be89c7395299e29f56e2a9d0b22c74106ddc6c55caa2dfe5d3dd0826b2a8b299f4805863496919678548f574f0b78b22e63
+  checksum: 06c1543a0b77f404649399cf30a2c162b45322a78408965a3de380044b1a948bd558fa74b9feb81a44078b2c56cebcd82089ad1de8b2cf1441fa32d2f6aadf69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

indicate ARM support on GCP regions during cluster creation


## Screenshots / Recordings

<img width="1210" height="1236" alt="Screenshot 2026-06-01 at 16 33 49" src="https://github.com/user-attachments/assets/65a34893-dc5e-4493-bac1-44893a45aedb" />


<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
