### PR TITLE
fix(auth): issue with token expiration

### DIFF
--- a/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.spec.ts
+++ b/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.spec.ts
@@ -1,16 +1,27 @@
 import { renderHook } from '__tests__/utils/setup-jest'
-import axios from 'axios'
-import { useAuthInterceptor } from './auth-interceptor'
+import axios, { AxiosHeaders, type AxiosInstance } from 'axios'
+import { buildLoginRedirectUrl, useAuthInterceptor } from './auth-interceptor'
+
+const mockGetAccessTokenSilently = jest.fn()
 
 jest.mock('@auth0/auth0-react', () => ({
   useAuth0: () => {
     return {
-      getAccessTokenSilently: () => 'someAuthToken',
+      getAccessTokenSilently: mockGetAccessTokenSilently,
     }
   },
 }))
 
 describe('UseAuthInterceptor', () => {
+  beforeEach(() => {
+    mockGetAccessTokenSilently.mockResolvedValue('someAuthToken')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    window.history.pushState({}, '', '/')
+  })
+
   it('should render successfully', () => {
     const { result } = renderHook(() => useAuthInterceptor(axios, 'some-url'))
 
@@ -18,6 +29,71 @@ describe('UseAuthInterceptor', () => {
   })
 
   it('should add the authorization to the headers of the incoming request', async () => {
-    renderHook(() => useAuthInterceptor(axios, 'some-url'))
+    const requestUse = jest.fn().mockReturnValue(1)
+    const responseUse = jest.fn().mockReturnValue(2)
+    const axiosInstance = createAxiosInstanceMock(requestUse, responseUse)
+
+    renderHook(() => useAuthInterceptor(axiosInstance, 'https://api.qovery.com'))
+
+    const requestHandler = requestUse.mock.calls[0][0]
+    const config = await requestHandler({ url: '/organizations', headers: new AxiosHeaders() })
+
+    expect(config.url).toBe('https://api.qovery.com/organizations')
+    expect(config.headers.get('Authorization')).toBe('Bearer someAuthToken')
+  })
+
+  it('should redirect to login when silent token renewal fails', async () => {
+    const authError = new Error('login_required')
+    const requestUse = jest.fn().mockReturnValue(1)
+    const responseUse = jest.fn().mockReturnValue(2)
+    const axiosInstance = createAxiosInstanceMock(requestUse, responseUse)
+    mockGetAccessTokenSilently.mockRejectedValue(authError)
+    window.history.pushState({}, '', '/login')
+
+    renderHook(() => useAuthInterceptor(axiosInstance, 'https://api.qovery.com'))
+
+    const requestHandler = requestUse.mock.calls[0][0]
+
+    await expect(requestHandler({ url: '/organizations', headers: new AxiosHeaders() })).rejects.toThrow(
+      'login_required'
+    )
+  })
+
+  it('should redirect to login when the API returns unauthorized', async () => {
+    const requestUse = jest.fn().mockReturnValue(1)
+    const responseUse = jest.fn().mockReturnValue(2)
+    const axiosInstance = createAxiosInstanceMock(requestUse, responseUse)
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    window.history.pushState({}, '', '/login')
+
+    renderHook(() => useAuthInterceptor(axiosInstance, 'https://api.qovery.com'))
+
+    const responseErrorHandler = responseUse.mock.calls[0][1]
+
+    await expect(responseErrorHandler({ response: { status: 401, data: { status: 401 } } })).rejects.toMatchObject({
+      code: '401',
+    })
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error', undefined)
+  })
+
+  it('should build the login redirect url from the current location', () => {
+    expect(buildLoginRedirectUrl('/organization/123', '?tab=clusters', '#overview')).toBe(
+      '/login?redirect=%2Forganization%2F123%3Ftab%3Dclusters%23overview'
+    )
   })
 })
+
+function createAxiosInstanceMock(requestUse: jest.Mock, responseUse: jest.Mock): AxiosInstance {
+  return {
+    interceptors: {
+      request: {
+        use: requestUse,
+        eject: jest.fn(),
+      },
+      response: {
+        use: responseUse,
+        eject: jest.fn(),
+      },
+    },
+  } as unknown as AxiosInstance
+}

--- a/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.spec.ts
+++ b/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.spec.ts
@@ -19,7 +19,6 @@ describe('UseAuthInterceptor', () => {
 
   afterEach(() => {
     jest.clearAllMocks()
-    window.history.pushState({}, '', '/')
   })
 
   it('should render successfully', () => {
@@ -47,16 +46,17 @@ describe('UseAuthInterceptor', () => {
     const requestUse = jest.fn().mockReturnValue(1)
     const responseUse = jest.fn().mockReturnValue(2)
     const axiosInstance = createAxiosInstanceMock(requestUse, responseUse)
+    const navigateToLogin = jest.fn()
     mockGetAccessTokenSilently.mockRejectedValue(authError)
-    window.history.pushState({}, '', '/login')
 
-    renderHook(() => useAuthInterceptor(axiosInstance, 'https://api.qovery.com'))
+    renderHook(() => useAuthInterceptor(axiosInstance, 'https://api.qovery.com', navigateToLogin))
 
     const requestHandler = requestUse.mock.calls[0][0]
 
     await expect(requestHandler({ url: '/organizations', headers: new AxiosHeaders() })).rejects.toThrow(
       'login_required'
     )
+    expect(navigateToLogin).toHaveBeenCalledTimes(1)
   })
 
   it('should redirect to login when the API returns unauthorized', async () => {
@@ -64,9 +64,9 @@ describe('UseAuthInterceptor', () => {
     const responseUse = jest.fn().mockReturnValue(2)
     const axiosInstance = createAxiosInstanceMock(requestUse, responseUse)
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
-    window.history.pushState({}, '', '/login')
+    const navigateToLogin = jest.fn()
 
-    renderHook(() => useAuthInterceptor(axiosInstance, 'https://api.qovery.com'))
+    renderHook(() => useAuthInterceptor(axiosInstance, 'https://api.qovery.com', navigateToLogin))
 
     const responseErrorHandler = responseUse.mock.calls[0][1]
 
@@ -74,6 +74,7 @@ describe('UseAuthInterceptor', () => {
       code: '401',
     })
     expect(consoleErrorSpy).toHaveBeenCalledWith('Error', undefined)
+    expect(navigateToLogin).toHaveBeenCalledTimes(1)
   })
 
   it('should build the login redirect url from the current location', () => {

--- a/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.tsx
+++ b/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.tsx
@@ -13,6 +13,19 @@ export interface SerializedError {
 
 const E2E_AUTH_TOKEN_STORAGE_KEY = 'qovery-e2e-auth-token'
 
+export function buildLoginRedirectUrl(pathname: string, search: string, hash: string) {
+  const redirect = `${pathname}${search}${hash}`
+  const searchParams = new URLSearchParams({ redirect })
+
+  return `/login?${searchParams.toString()}`
+}
+
+function redirectToLogin() {
+  if (window.location.pathname.startsWith('/login')) return
+
+  window.location.assign(buildLoginRedirectUrl(window.location.pathname, window.location.search, window.location.hash))
+}
+
 export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string) {
   const { getAccessTokenSilently } = useAuth0()
 
@@ -27,7 +40,8 @@ export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string)
       try {
         token = token || (await getAccessTokenSilently())
       } catch (e) {
-        return config
+        redirectToLogin()
+        return Promise.reject(e)
       }
 
       if (token) {
@@ -46,6 +60,10 @@ export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string)
             error.response?.data?.error || error.code || 'Error',
             error.response?.data?.detail || error.detail
           )
+        }
+
+        if (error.response?.status === 401) {
+          redirectToLogin()
         }
 
         // we reformat the error output to improve the dev experience

--- a/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.tsx
+++ b/libs/shared/utils/src/lib/http/interceptors/auth-interceptor/auth-interceptor.tsx
@@ -26,7 +26,11 @@ function redirectToLogin() {
   window.location.assign(buildLoginRedirectUrl(window.location.pathname, window.location.search, window.location.hash))
 }
 
-export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string) {
+export function useAuthInterceptor(
+  axiosInstance: AxiosInstance,
+  apiUrl: string,
+  navigateToLogin: () => void = redirectToLogin
+) {
   const { getAccessTokenSilently } = useAuth0()
 
   useEffect(() => {
@@ -40,7 +44,7 @@ export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string)
       try {
         token = token || (await getAccessTokenSilently())
       } catch (e) {
-        redirectToLogin()
+        navigateToLogin()
         return Promise.reject(e)
       }
 
@@ -63,7 +67,7 @@ export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string)
         }
 
         if (error.response?.status === 401) {
-          redirectToLogin()
+          navigateToLogin()
         }
 
         // we reformat the error output to improve the dev experience
@@ -83,7 +87,13 @@ export function useAuthInterceptor(axiosInstance: AxiosInstance, apiUrl: string)
       axiosInstance.interceptors.request.eject(requestInterceptor)
       axiosInstance.interceptors.response.eject(responseInterceptor)
     }
-  }, [axiosInstance.interceptors.request, axiosInstance.interceptors.response, apiUrl, getAccessTokenSilently])
+  }, [
+    axiosInstance.interceptors.request,
+    axiosInstance.interceptors.response,
+    apiUrl,
+    getAccessTokenSilently,
+    navigateToLogin,
+  ])
 
   const removeBaseUrl = (url = '') => {
     if (!url) return ''


### PR DESCRIPTION
## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1780322671806749)

When the auth token expires, rather than being redirected to the login page, we were displaying a "Something went wrong!" error message. This PR fixes this issue.

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
