### PR TITLE
feat(argocd): add posthog events for argocd connect form and environment access

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
@@ -1,7 +1,8 @@
 import { type IconName } from '@fortawesome/fontawesome-common-types'
 import { Outlet, createFileRoute, useMatchRoute } from '@tanstack/react-router'
 import { Link as RouterLink } from '@tanstack/react-router'
-import { useMemo } from 'react'
+import posthog from 'posthog-js'
+import { useEffect, useMemo } from 'react'
 import {
   ClusterAvatar,
   ClusterRunningStatusIndicator,
@@ -73,6 +74,17 @@ function RouteComponent() {
   const shouldDisplayArgoCdServicesAboveQovery = isServicesListTab && hasArgoCdServices && !hasQoveryServices
   const shouldDisplayArgoCdServicesBelowQovery = isServicesListTab && hasArgoCdServices && hasQoveryServices
   const isEnvironmentManagedByArgoCd = isArgoCdEnvironment(environmentOverview?.[0])
+
+  useEffect(() => {
+    if (isEnvironmentManagedByArgoCd) {
+      posthog.capture('argocd-environment-accessed', {
+        organization_id: organizationId,
+        project_id: projectId,
+        environment_id: environmentId,
+      })
+    }
+  }, [isEnvironmentManagedByArgoCd, organizationId, projectId, environmentId])
+
   const manageDeploymentDisabledTooltip = hasArgoCdServices
     ? 'ArgoCD environments can only be deployed from ArgoCD'
     : 'Add at least one service to deploy this environment'

--- a/libs/domains/organizations/feature/src/lib/settings-argocd-integration/connect-argocd-modal/connect-argocd-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-argocd-integration/connect-argocd-modal/connect-argocd-modal.tsx
@@ -1,9 +1,9 @@
-import { useCheckArgoCdConnection, useClusters, useSaveArgoCdCredentials } from '@qovery/domains/clusters/feature'
-import { ExternalLink, Heading, InputSelect, InputText, ModalCrud, Section } from '@qovery/shared/ui'
 import posthog from 'posthog-js'
 import { type ArgoCdInstanceMappingResponse } from 'qovery-typescript-axios'
 import { useMemo } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
+import { useCheckArgoCdConnection, useClusters, useSaveArgoCdCredentials } from '@qovery/domains/clusters/feature'
+import { ExternalLink, Heading, InputSelect, InputText, ModalCrud, Section } from '@qovery/shared/ui'
 
 interface ConnectArgoCdFormValues {
   targetCluster: string

--- a/libs/domains/organizations/feature/src/lib/settings-argocd-integration/connect-argocd-modal/connect-argocd-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-argocd-integration/connect-argocd-modal/connect-argocd-modal.tsx
@@ -1,8 +1,9 @@
+import { useCheckArgoCdConnection, useClusters, useSaveArgoCdCredentials } from '@qovery/domains/clusters/feature'
+import { ExternalLink, Heading, InputSelect, InputText, ModalCrud, Section } from '@qovery/shared/ui'
+import posthog from 'posthog-js'
 import { type ArgoCdInstanceMappingResponse } from 'qovery-typescript-axios'
 import { useMemo } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
-import { useCheckArgoCdConnection, useClusters, useSaveArgoCdCredentials } from '@qovery/domains/clusters/feature'
-import { ExternalLink, Heading, InputSelect, InputText, ModalCrud, Section } from '@qovery/shared/ui'
 
 interface ConnectArgoCdFormValues {
   targetCluster: string
@@ -101,12 +102,25 @@ export function ConnectArgoCdModal({
       methods.setError(errorField, {
         message: errorMessage,
       })
+
+      posthog.capture('argocd-connect-form-error', {
+        organization_id: organizationId,
+        cluster_id: targetCluster,
+        is_edit: isEdit,
+        reason: checkResponse.reason,
+      })
       return
     }
 
     await saveArgoCdCredentials({
       clusterId: targetCluster,
       argoCdCredentialsRequest,
+    })
+
+    posthog.capture('argocd-connect-form-success', {
+      organization_id: organizationId,
+      cluster_id: targetCluster,
+      is_edit: isEdit,
     })
 
     onClose()


### PR DESCRIPTION

## Summary

**Issue**: QOV-1960

Add argoCD posthog events:
* for connect form success/error
* for ArgoCD env access

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
