### PR TITLE
fix(environments): status inconsistencies

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
@@ -103,8 +103,8 @@ function RouteComponent() {
               <Tooltip content={environment.name}>
                 <Heading className="min-w-0 max-w-full truncate">{environment.name}</Heading>
               </Tooltip>
-              <div className="flex h-4 w-4 items-center">
-                <EnvironmentStateChip className="ml-0.5 shrink-0" mode="running" environmentId={environment.id} />
+              <div className="ml-0.5 flex h-4 w-4 items-center">
+                <EnvironmentStateChip className="shrink-0" mode="running" environmentId={environment.id} />
               </div>
               {isEnvironmentManagedByArgoCd && (
                 <>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
@@ -103,7 +103,9 @@ function RouteComponent() {
               <Tooltip content={environment.name}>
                 <Heading className="min-w-0 max-w-full truncate">{environment.name}</Heading>
               </Tooltip>
-              <EnvironmentStateChip className="ml-0.5 shrink-0" mode="running" environmentId={environment.id} />
+              <div className="flex h-4 w-4 items-center">
+                <EnvironmentStateChip className="ml-0.5 shrink-0" mode="running" environmentId={environment.id} />
+              </div>
               {isEnvironmentManagedByArgoCd && (
                 <>
                   <span className="ml-0.5 mr-2 h-4 w-px shrink-0 bg-surface-neutral-component" />

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
@@ -97,6 +97,14 @@ function RouteComponent() {
     return clusters ?? []
   }, [environmentId, environment, clusters, projectId, projectEnvironments])
 
+  const environmentsForStatusWebSockets = useMemo(() => {
+    if (environmentId || !projectId || !projectEnvironments?.length) {
+      return []
+    }
+
+    return projectEnvironments.filter((environment) => Boolean(environment.cluster_id))
+  }, [environmentId, projectId, projectEnvironments])
+
   const deployingClusters = useMemo(() => {
     if (!clusters || !clusterStatuses) return []
     return clusters.filter((cluster) => {
@@ -146,6 +154,19 @@ function RouteComponent() {
             )
         )
       }
+      {environmentsForStatusWebSockets.map(
+        (environment) =>
+          organizationId && (
+            <StatusWebSocketListenerMemo
+              key={`environment-${environment.id}`}
+              organizationId={organizationId}
+              clusterId={environment.cluster_id}
+              projectId={projectId}
+              environmentId={environment.id}
+              versionId={versionId}
+            />
+          )
+      )}
       {!shouldHideProgressCard && deployingClusters && deployingClusters.length > 0 && (
         <ClusterDeploymentProgressCard
           organizationId={organizationId}

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
@@ -7,7 +7,7 @@ import { ClusterDeploymentProgressCard, useClusterStatuses, useClusters } from '
 import { useEnvironment } from '@qovery/domains/environments/feature'
 import { LoaderSpinner } from '@qovery/shared/ui'
 import { useLocalStorage } from '@qovery/shared/util-hooks'
-import { StatusWebSocketListener } from '@qovery/shared/util-web-sockets'
+import { DeploymentStatusWebSocketListener, RunningStatusWebSocketListener } from '@qovery/shared/util-web-sockets'
 import { queries } from '@qovery/state/util-queries'
 import { type FileRouteTypes } from '../../../../routeTree.gen'
 
@@ -36,7 +36,8 @@ const Loader = () => {
   )
 }
 
-const StatusWebSocketListenerMemo = memo(StatusWebSocketListener)
+const DeploymentStatusWebSocketListenerMemo = memo(DeploymentStatusWebSocketListener)
+const RunningStatusWebSocketListenerMemo = memo(RunningStatusWebSocketListener)
 
 const isDeployingStatus = (status?: ClusterStateEnum): boolean =>
   status === ClusterState.DEPLOYMENT_QUEUED || status === ClusterState.DEPLOYING
@@ -143,29 +144,35 @@ function RouteComponent() {
         clustersForStatusWebSockets.map(
           ({ id }) =>
             organizationId && (
-              <StatusWebSocketListenerMemo
-                key={id}
+              <DeploymentStatusWebSocketListenerMemo
+                key={`deployment-${id}`}
                 organizationId={organizationId}
                 clusterId={id}
                 projectId={projectId}
                 environmentId={environmentId}
                 versionId={versionId}
-                runningStatusEnabled={Boolean(environmentId)}
               />
             )
         )
       }
+      {environmentId && organizationId && environment && (
+        <RunningStatusWebSocketListenerMemo
+          key={`running-${environment.id}`}
+          organizationId={organizationId}
+          clusterId={environment.cluster_id}
+          projectId={projectId}
+          environmentId={environment.id}
+        />
+      )}
       {environmentsForStatusWebSockets.map(
         (environment) =>
           organizationId && (
-            <StatusWebSocketListenerMemo
-              key={`environment-${environment.id}`}
+            <RunningStatusWebSocketListenerMemo
+              key={`running-${environment.id}`}
               organizationId={organizationId}
               clusterId={environment.cluster_id}
               projectId={projectId}
               environmentId={environment.id}
-              versionId={versionId}
-              deploymentStatusEnabled={false}
             />
           )
       )}

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/route.tsx
@@ -150,6 +150,7 @@ function RouteComponent() {
                 projectId={projectId}
                 environmentId={environmentId}
                 versionId={versionId}
+                runningStatusEnabled={Boolean(environmentId)}
               />
             )
         )
@@ -164,6 +165,7 @@ function RouteComponent() {
               projectId={projectId}
               environmentId={environment.id}
               versionId={versionId}
+              deploymentStatusEnabled={false}
             />
           )
       )}

--- a/libs/domains/clusters/feature/src/lib/cluster-running-status-indicator/cluster-running-status-indicator.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-running-status-indicator/cluster-running-status-indicator.tsx
@@ -76,7 +76,13 @@ export function ClusterRunningStatusIndicator({
   }
 
   if (isLoading && !runningStatus && !isTimeout) {
-    return <Skeleton width={type === 'dot' ? 20 : 80} height={type === 'dot' ? 20 : 24} rounded={type === 'dot'} />
+    return type === 'dot' ? (
+      <span className="flex h-5 w-5 items-center justify-center">
+        <Skeleton width={9} height={9} rounded />
+      </span>
+    ) : (
+      <Skeleton width={80} height={24} />
+    )
   }
 
   if (isTimeout && !runningStatus) {

--- a/libs/domains/environments/data-access/src/lib/domains-environments-data-access.ts
+++ b/libs/domains/environments/data-access/src/lib/domains-environments-data-access.ts
@@ -44,6 +44,19 @@ export interface EnvironmentRunningStatusQueryParams {
   projectId?: string
 }
 
+function getEnvironmentRunningStatusQueryKey({
+  environmentId,
+  scope = 'environment',
+  clusterId,
+  projectId,
+}: EnvironmentRunningStatusQueryParams) {
+  if (scope === 'project') {
+    return [environmentId, scope, clusterId, projectId] as const
+  }
+
+  return [environmentId, scope] as const
+}
+
 export const environments = createQueryKeys('environments', {
   // NOTE: Value is set by WebSocket
   deploymentStatus: (environmentId: string) => ({
@@ -62,13 +75,8 @@ export const environments = createQueryKeys('environments', {
     },
   }),
   // NOTE: Value is set by WebSocket
-  runningStatus: ({
-    environmentId,
-    scope = 'environment',
-    clusterId = '',
-    projectId = '',
-  }: EnvironmentRunningStatusQueryParams) => ({
-    queryKey: [environmentId, scope, clusterId, projectId],
+  runningStatus: (params: EnvironmentRunningStatusQueryParams) => ({
+    queryKey: getEnvironmentRunningStatusQueryKey(params),
     queryFn() {
       return new Promise<{ state: RunningState; triggered_action: ServiceActionDetailsDto | undefined } | null>(
         // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/libs/domains/environments/data-access/src/lib/domains-environments-data-access.ts
+++ b/libs/domains/environments/data-access/src/lib/domains-environments-data-access.ts
@@ -35,6 +35,15 @@ const deploymentStageMainCallApi = new DeploymentStageMainCallsApi()
 const lifecycleTemplateMainCallsApi = new LifecycleTemplateMainCallsApi()
 const deploymentQueueActionsApi = new DeploymentQueueActionsApi()
 
+export type EnvironmentRunningStatusScope = 'environment' | 'project'
+
+export interface EnvironmentRunningStatusQueryParams {
+  environmentId: string
+  scope?: EnvironmentRunningStatusScope
+  clusterId?: string
+  projectId?: string
+}
+
 export const environments = createQueryKeys('environments', {
   // NOTE: Value is set by WebSocket
   deploymentStatus: (environmentId: string) => ({
@@ -53,8 +62,13 @@ export const environments = createQueryKeys('environments', {
     },
   }),
   // NOTE: Value is set by WebSocket
-  runningStatus: (environmentId: string) => ({
-    queryKey: [environmentId],
+  runningStatus: ({
+    environmentId,
+    scope = 'environment',
+    clusterId = '',
+    projectId = '',
+  }: EnvironmentRunningStatusQueryParams) => ({
+    queryKey: [environmentId, scope, clusterId, projectId],
     queryFn() {
       return new Promise<{ state: RunningState; triggered_action: ServiceActionDetailsDto | undefined } | null>(
         // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/libs/domains/environments/feature/src/lib/environment-state-chip/environment-state-chip.tsx
+++ b/libs/domains/environments/feature/src/lib/environment-state-chip/environment-state-chip.tsx
@@ -31,7 +31,7 @@ function DeploymentStateChip({ environmentId, mode, ...props }: DeploymentStateC
 
   if (mode === 'last-deployment') {
     return (
-      <Skeleton width={16} height={16} show={!deploymentStatus?.last_deployment_state} rounded>
+      <Skeleton width={14} height={14} show={!deploymentStatus?.last_deployment_state} rounded>
         <StatusChip status={deploymentStatus?.last_deployment_state} {...props} />
       </Skeleton>
     )
@@ -46,7 +46,7 @@ function RunningStateChip({ environmentId, ...props }: RunningStateChipProps) {
   const { data: runningStatus } = useRunningStatus({ environmentId })
 
   return (
-    <Skeleton width={16} height={16} show={!runningStatus?.state} rounded>
+    <Skeleton width={14} height={14} show={!runningStatus?.state} rounded>
       <StatusChip status={runningStatus?.state} {...props} />
     </Skeleton>
   )

--- a/libs/domains/environments/feature/src/lib/hooks/use-environments/use-environments.ts
+++ b/libs/domains/environments/feature/src/lib/hooks/use-environments/use-environments.ts
@@ -27,7 +27,7 @@ export function useEnvironments({ projectId, suspense = false }: UseEnvironments
 
   const runningStatusResults = useQueries({
     queries: (environments ?? []).map(({ id }) => ({
-      ...queries.environments.runningStatus(id),
+      ...queries.environments.runningStatus({ environmentId: id, scope: 'environment' }),
     })),
   })
 

--- a/libs/domains/environments/feature/src/lib/hooks/use-running-status/use-running-status.ts
+++ b/libs/domains/environments/feature/src/lib/hooks/use-running-status/use-running-status.ts
@@ -1,17 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
-import { type EnvironmentRunningStatusScope } from '@qovery/domains/environments/data-access'
 import { queries } from '@qovery/state/util-queries'
 
 export interface UseRunningStatusProps {
   environmentId?: string
-  scope?: EnvironmentRunningStatusScope
 }
 
-export function useRunningStatus({ environmentId, scope = 'environment' }: UseRunningStatusProps) {
+export function useRunningStatus({ environmentId }: UseRunningStatusProps) {
+  const enabled = Boolean(environmentId)
+
   return useQuery({
-    // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
-    ...queries.environments.runningStatus({ environmentId: environmentId!!, scope }),
-    enabled: Boolean(environmentId),
+    ...queries.environments.runningStatus({ environmentId: environmentId ?? '', scope: 'environment' }),
+    enabled,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/libs/domains/environments/feature/src/lib/hooks/use-running-status/use-running-status.ts
+++ b/libs/domains/environments/feature/src/lib/hooks/use-running-status/use-running-status.ts
@@ -1,14 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
+import { type EnvironmentRunningStatusScope } from '@qovery/domains/environments/data-access'
 import { queries } from '@qovery/state/util-queries'
 
 export interface UseRunningStatusProps {
   environmentId?: string
+  scope?: EnvironmentRunningStatusScope
 }
 
-export function useRunningStatus({ environmentId }: UseRunningStatusProps) {
+export function useRunningStatus({ environmentId, scope = 'environment' }: UseRunningStatusProps) {
   return useQuery({
     // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
-    ...queries.environments.runningStatus(environmentId!!),
+    ...queries.environments.runningStatus({ environmentId: environmentId!!, scope }),
     enabled: Boolean(environmentId),
     refetchOnMount: false,
     refetchOnWindowFocus: false,

--- a/libs/shared/util-web-sockets/src/lib/status-web-socket-listener/status-web-socket-listener.tsx
+++ b/libs/shared/util-web-sockets/src/lib/status-web-socket-listener/status-web-socket-listener.tsx
@@ -1,35 +1,26 @@
-import useStatusWebSockets from '../use-status-web-sockets/use-status-web-sockets'
+import {
+  useDeploymentStatusWebSocket,
+  useRunningStatusWebSocket,
+} from '../use-status-web-sockets/use-status-web-sockets'
 
-export interface StatusWebSocketListenerProps {
+export interface DeploymentStatusWebSocketListenerProps {
   clusterId: string
   organizationId: string
   projectId?: string
   environmentId?: string
   versionId?: string
-  deploymentStatusEnabled?: boolean
-  runningStatusEnabled?: boolean
 }
 
-export function StatusWebSocketListener({
-  clusterId,
-  organizationId,
-  projectId,
-  environmentId,
-  versionId,
-  deploymentStatusEnabled,
-  runningStatusEnabled,
-}: StatusWebSocketListenerProps) {
-  useStatusWebSockets({
-    organizationId,
-    clusterId,
-    projectId,
-    environmentId,
-    versionId,
-    deploymentStatusEnabled,
-    runningStatusEnabled,
-  })
+export function DeploymentStatusWebSocketListener(props: DeploymentStatusWebSocketListenerProps) {
+  useDeploymentStatusWebSocket(props)
 
   return null
 }
 
-export default StatusWebSocketListener
+export type RunningStatusWebSocketListenerProps = Omit<DeploymentStatusWebSocketListenerProps, 'versionId'>
+
+export function RunningStatusWebSocketListener(props: RunningStatusWebSocketListenerProps) {
+  useRunningStatusWebSocket(props)
+
+  return null
+}

--- a/libs/shared/util-web-sockets/src/lib/status-web-socket-listener/status-web-socket-listener.tsx
+++ b/libs/shared/util-web-sockets/src/lib/status-web-socket-listener/status-web-socket-listener.tsx
@@ -6,6 +6,8 @@ export interface StatusWebSocketListenerProps {
   projectId?: string
   environmentId?: string
   versionId?: string
+  deploymentStatusEnabled?: boolean
+  runningStatusEnabled?: boolean
 }
 
 export function StatusWebSocketListener({
@@ -14,6 +16,8 @@ export function StatusWebSocketListener({
   projectId,
   environmentId,
   versionId,
+  deploymentStatusEnabled,
+  runningStatusEnabled,
 }: StatusWebSocketListenerProps) {
   useStatusWebSockets({
     organizationId,
@@ -21,6 +25,8 @@ export function StatusWebSocketListener({
     projectId,
     environmentId,
     versionId,
+    deploymentStatusEnabled,
+    runningStatusEnabled,
   })
 
   return null

--- a/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
+++ b/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
@@ -24,6 +24,8 @@ export interface UseStatusWebSocketsProps {
   projectId?: string
   environmentId?: string
   versionId?: string
+  deploymentStatusEnabled?: boolean
+  runningStatusEnabled?: boolean
 }
 
 export function useStatusWebSockets({
@@ -32,6 +34,8 @@ export function useStatusWebSockets({
   projectId,
   environmentId,
   versionId,
+  deploymentStatusEnabled = true,
+  runningStatusEnabled = true,
 }: UseStatusWebSocketsProps) {
   const [externalRequestId] = useState(() => uuidv7())
   const queryClient = useQueryClient()
@@ -59,7 +63,7 @@ export function useStatusWebSockets({
       project: projectId,
       version: versionId,
     },
-    enabled: wsEnabled,
+    enabled: wsEnabled && deploymentStatusEnabled,
     shouldReconnect: true,
     onMessage(queryClient, message: WSDeploymentStatus) {
       if (environmentId) {
@@ -104,11 +108,10 @@ export function useStatusWebSockets({
       external_request_id: externalRequestId,
     },
     // NOTE: projectId is not required by the API but it limits WS messages when cluster handles my environments / services
-    enabled: wsEnabled,
+    enabled: wsEnabled && runningStatusEnabled,
     onMessage(queryClient, message: ServiceStatusDto) {
       for (const env of message.environments) {
         const scope = environmentId ? 'environment' : 'project'
-        // TODO [To update once rust-backed will be deployed]: check against current value and update it only if it has changed (to avoid too many re-render)
         queryClient.setQueryData(
           queries.environments.runningStatus({
             environmentId: env.id,
@@ -119,9 +122,8 @@ export function useStatusWebSockets({
             state: env.state,
           })
         )
-        // // NOTE: we have to force this reset change because of the way the socket works.
-        // // You can have information about an service (eg. if it's stopping)
-        // TODO [To update once rust-backed will be deployed]: Remove reset cache strategy
+        // NOTE: we have to force this reset change because of the way the socket works.
+        // You can have information about an service (eg. if it's stopping)
         queryClient.resetQueries([...queries.services.runningStatus._def, env.id])
         const services: (ApplicationStatusDto | ArgoCdAppStatusDto | DatabaseStatusDto | TerraformStatusDto)[] = [
           ...env.applications,
@@ -133,7 +135,6 @@ export function useStatusWebSockets({
           ...env.terraform,
         ]
         for (const serviceRunningStatus of services) {
-          // TODO [To update once rust-backed will be deployed]: check against current value and update it only if it has changed (to avoid too many re-render)
           queryClient.setQueryData(
             queries.services.runningStatus(env.id, serviceRunningStatus.id).queryKey,
             () => serviceRunningStatus

--- a/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
+++ b/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
@@ -18,41 +18,24 @@ interface WSDeploymentStatus extends EnvironmentStatusesWithStages {
   results?: EnvironmentStatus[]
 }
 
-export interface UseStatusWebSocketsProps {
+export interface UseDeploymentStatusWebSocketProps {
   organizationId: string
   clusterId: string
   projectId?: string
   environmentId?: string
   versionId?: string
-  deploymentStatusEnabled?: boolean
-  runningStatusEnabled?: boolean
 }
 
-export function useStatusWebSockets({
+export type UseRunningStatusWebSocketProps = Omit<UseDeploymentStatusWebSocketProps, 'versionId'>
+
+export function useDeploymentStatusWebSocket({
   organizationId,
   clusterId,
   projectId,
   environmentId,
   versionId,
-  deploymentStatusEnabled = true,
-  runningStatusEnabled = true,
-}: UseStatusWebSocketsProps) {
-  const [externalRequestId] = useState(() => uuidv7())
-  const queryClient = useQueryClient()
+}: UseDeploymentStatusWebSocketProps) {
   const wsEnabled = Boolean(organizationId) && Boolean(clusterId) && Boolean(projectId)
-
-  // NOTE: remove running status cache when the environment is changed to avoid stale data
-  // @see https://qovery.atlassian.net/browse/QOV-1886
-  useEffect(() => {
-    return () => {
-      if (environmentId) {
-        queryClient.removeQueries({
-          queryKey: queries.environments.runningStatus({ environmentId, scope: 'environment' }).queryKey,
-          exact: true,
-        })
-      }
-    }
-  }, [environmentId, queryClient])
 
   useReactQueryWsSubscription({
     url: QOVERY_WS + '/deployment/status',
@@ -63,7 +46,7 @@ export function useStatusWebSockets({
       project: projectId,
       version: versionId,
     },
-    enabled: wsEnabled && deploymentStatusEnabled,
+    enabled: wsEnabled,
     shouldReconnect: true,
     onMessage(queryClient, message: WSDeploymentStatus) {
       if (environmentId) {
@@ -97,6 +80,30 @@ export function useStatusWebSockets({
       }
     },
   })
+}
+
+export function useRunningStatusWebSocket({
+  organizationId,
+  clusterId,
+  projectId,
+  environmentId,
+}: UseRunningStatusWebSocketProps) {
+  const [externalRequestId] = useState(() => uuidv7())
+  const queryClient = useQueryClient()
+  const wsEnabled = Boolean(organizationId) && Boolean(clusterId) && Boolean(projectId)
+
+  // NOTE: remove running status cache when the environment is changed to avoid stale data
+  // @see https://qovery.atlassian.net/browse/QOV-1886
+  useEffect(() => {
+    return () => {
+      if (environmentId) {
+        queryClient.removeQueries({
+          queryKey: queries.environments.runningStatus({ environmentId, scope: 'environment' }).queryKey,
+          exact: true,
+        })
+      }
+    }
+  }, [environmentId, queryClient])
 
   useReactQueryWsSubscription({
     url: QOVERY_WS + '/service/status',
@@ -108,16 +115,21 @@ export function useStatusWebSockets({
       external_request_id: externalRequestId,
     },
     // NOTE: projectId is not required by the API but it limits WS messages when cluster handles my environments / services
-    enabled: wsEnabled && runningStatusEnabled,
+    enabled: wsEnabled,
     onMessage(queryClient, message: ServiceStatusDto) {
       for (const env of message.environments) {
-        const scope = environmentId ? 'environment' : 'project'
         queryClient.setQueryData(
-          queries.environments.runningStatus({
-            environmentId: env.id,
-            scope,
-            ...(scope === 'project' ? { clusterId, projectId } : {}),
-          }).queryKey,
+          environmentId
+            ? queries.environments.runningStatus({
+                environmentId: env.id,
+                scope: 'environment',
+              }).queryKey
+            : queries.environments.runningStatus({
+                environmentId: env.id,
+                scope: 'project',
+                clusterId,
+                projectId,
+              }).queryKey,
           () => ({
             state: env.state,
           })
@@ -144,5 +156,3 @@ export function useStatusWebSockets({
     },
   })
 }
-
-export default useStatusWebSockets

--- a/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
+++ b/libs/shared/util-web-sockets/src/lib/use-status-web-sockets/use-status-web-sockets.ts
@@ -43,7 +43,7 @@ export function useStatusWebSockets({
     return () => {
       if (environmentId) {
         queryClient.removeQueries({
-          queryKey: queries.environments.runningStatus(environmentId).queryKey,
+          queryKey: queries.environments.runningStatus({ environmentId, scope: 'environment' }).queryKey,
           exact: true,
         })
       }
@@ -107,10 +107,18 @@ export function useStatusWebSockets({
     enabled: wsEnabled,
     onMessage(queryClient, message: ServiceStatusDto) {
       for (const env of message.environments) {
+        const scope = environmentId ? 'environment' : 'project'
         // TODO [To update once rust-backed will be deployed]: check against current value and update it only if it has changed (to avoid too many re-render)
-        queryClient.setQueryData(queries.environments.runningStatus(env.id).queryKey, () => ({
-          state: env.state,
-        }))
+        queryClient.setQueryData(
+          queries.environments.runningStatus({
+            environmentId: env.id,
+            scope,
+            ...(scope === 'project' ? { clusterId, projectId } : {}),
+          }).queryKey,
+          () => ({
+            state: env.state,
+          })
+        )
         // // NOTE: we have to force this reset change because of the way the socket works.
         // // You can have information about an service (eg. if it's stopping)
         // TODO [To update once rust-backed will be deployed]: Remove reset cache strategy


### PR DESCRIPTION
## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1777368505997529)

This PR corrects the environment's status inconsistencies.

[URL to test](http://localhost:4200/organization/9c983a44-eb28-4716-b701-1979a145cf5a/project/4f559663-f27a-49a4-8a42-835935f3d3ff/overview)

## Screenshots / Recordings
<img width="2560" height="1440" alt="SCR-20260603-kspw" src="https://github.com/user-attachments/assets/585f0e99-4ae8-4882-a4f0-7e43838bdd40" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
