### PR TITLE
fix(datepicker): error when selecting a start date

### DIFF
--- a/apps/console/public/changelog/latest.json
+++ b/apps/console/public/changelog/latest.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "Remote Dev Environments Alpha, New UI is default, Kubernetes 1.35 available",
-    "summary": "Hey Team, Two platform-wide changes ship in this release: the new UI is now the default for all organizations, and Kubernetes 1.35 is available for self-service upgrade. We are also sharing an early look at Remote Dev Environments, something we have been co-building with a handful of customers. -...",
-    "url": "https://www.qovery.com/changelog/2026-05-20",
-    "firstPublishedAt": "2026-05-20T00:00:00.000Z"
+    "name": "ArgoCD Integration, Remote Dev Environments Improvements, Restrict Copilot Access",
+    "summary": "Hey Team, This release brings three things worth your attention: ArgoCD is now a first-class integration in Qovery, the AI Copilot gets proper access controls, and Remote Dev Environments ship a round of improvements shaped directly by feedback from early customers. --- 🔗 ArgoCD Integration ...",
+    "url": "https://www.qovery.com/changelog/2026-06-03",
+    "firstPublishedAt": "2026-06-03T00:00:00.000Z"
   }
 ]

--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/header-service-logs/header-service-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/header-service-logs/header-service-logs.tsx
@@ -73,6 +73,8 @@ export function HeaderServiceLogs({ logs, isLiveMode, refetchHistoryLogs }: Head
     () => (startDate && endDate ? ([startDate, endDate] as [Date, Date]) : undefined),
     [startDate, endDate]
   )
+  const maxDate = useMemo(() => new Date(), [isOpenDatePicker])
+  const minDate = useMemo(() => subDays(maxDate, 84), [maxDate])
 
   return (
     <>
@@ -124,8 +126,8 @@ export function HeaderServiceLogs({ logs, isLiveMode, refetchHistoryLogs }: Head
               setIsOpenDatePicker(false)
             }}
             isOpen={isOpenDatePicker}
-            maxDate={new Date()}
-            minDate={subDays(new Date(), 84)}
+            maxDate={maxDate}
+            minDate={minDate}
             defaultDates={defaultDates}
             showDateTimeInputs
             useLocalTime

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-calendar.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-calendar.tsx
@@ -15,6 +15,13 @@ import {
   validateTime,
 } from '../date-picker.utils'
 
+const areSameDates = (firstDate: Date | null, secondDate: Date | null) => {
+  if (!firstDate || !secondDate) return firstDate === secondDate
+  return firstDate.getTime() === secondDate.getTime()
+}
+
+const getDateRangeKey = (dates?: [Date, Date]) => dates?.map((date) => date.getTime()).join('-') ?? ''
+
 export function DatePickerCalendar({
   onChange,
   minDate,
@@ -53,6 +60,8 @@ export function DatePickerCalendar({
   const selectedTimezoneLabel =
     timezoneOptions.find((option) => option.value === (useLocalTime ? 'local' : 'utc'))?.label ?? ''
 
+  const defaultDatesKey = getDateRangeKey(defaultDates)
+  const previousDefaultDatesKeyRef = useRef(defaultDatesKey)
   const lastInteractionRef = useRef<'calendar' | 'input' | 'default'>('default')
   const previousUseLocalTimeRef = useRef(useLocalTime)
 
@@ -80,14 +89,35 @@ export function DatePickerCalendar({
 
   const handleChange = (dates: [Date | null, Date | null] | null) => {
     if (!dates) {
-      setStartDate(null)
-      setEndDate(null)
+      if (startDate) {
+        setStartDate(null)
+      }
+      if (endDate) {
+        setEndDate(null)
+      }
       return
     }
 
     const [start, end] = dates
+    const updateRange = (nextStartDate: Date | null, nextEndDate: Date | null) => {
+      const hasStartDateChanged = !areSameDates(startDate, nextStartDate)
+      const hasEndDateChanged = !areSameDates(endDate, nextEndDate)
+
+      if (!hasStartDateChanged && !hasEndDateChanged) return false
+
+      lastInteractionRef.current = 'calendar'
+
+      if (hasStartDateChanged) {
+        setStartDate(nextStartDate)
+      }
+      if (hasEndDateChanged) {
+        setEndDate(nextEndDate)
+      }
+
+      return true
+    }
+
     lastInteractionRef.current = 'calendar'
-    onRangeSelection?.()
 
     if (maxRangeInDays && start && end) {
       const adjustedEndDateOnly = clampEndDateForMaxRange({ startDate: start, endDate: end, maxRangeInDays })
@@ -100,18 +130,19 @@ export function DatePickerCalendar({
           end.getMinutes(),
           end.getSeconds()
         )
-        setStartDate(start)
-        setEndDate(adjustedEndDate)
+        const didUpdateRange = updateRange(start, adjustedEndDate)
         setStartDateText(formatDateInput(start, useLocalTime))
         setEndDateText(formatDateInput(adjustedEndDate, useLocalTime))
         setStartDateError('')
         setEndDateError('')
+        if (didUpdateRange) {
+          onRangeSelection?.()
+        }
         return
       }
     }
 
-    setStartDate(start)
-    setEndDate(end)
+    const didUpdateRange = updateRange(start, end)
 
     if (start) {
       setStartDateText(formatDateInput(start, useLocalTime))
@@ -124,15 +155,23 @@ export function DatePickerCalendar({
       setEndDateText('')
       setEndDateError('')
     }
+
+    if (didUpdateRange) {
+      onRangeSelection?.()
+    }
   }
 
   useEffect(() => {
-    if (defaultDates) {
-      lastInteractionRef.current = 'default'
-      setStartDate(defaultDates[0])
-      setEndDate(defaultDates[1])
-    }
-  }, [defaultDates])
+    if (previousDefaultDatesKeyRef.current === defaultDatesKey) return
+
+    previousDefaultDatesKeyRef.current = defaultDatesKey
+    if (!defaultDates) return
+
+    const [nextStartDate, nextEndDate] = defaultDates
+    lastInteractionRef.current = 'default'
+    setStartDate(nextStartDate)
+    setEndDate(nextEndDate)
+  }, [defaultDates, defaultDatesKey])
 
   const handleClickOutside = (event: React.MouseEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement
@@ -209,19 +248,24 @@ export function DatePickerCalendar({
     setEndDateError(endDateError)
     setEndTimeError(endTimeError)
 
-    let didUpdateRange = false
+    if (type === 'startTime' || type === 'endTime') return
 
-    if (!startDateError && !startTimeError) {
-      setStartDate(getCombinedDateTime(nextStartDateText, nextStartTimeText, useLocalTime))
-      didUpdateRange = true
+    if (type === 'startDate') {
+      if (startDateError || startTimeError) return
+
+      const nextStartDate = getCombinedDateTime(nextStartDateText, nextStartTimeText, useLocalTime)
+      if (startDate?.getTime() !== nextStartDate.getTime()) {
+        setStartDate(nextStartDate)
+        onRangeSelection?.()
+      }
+      return
     }
 
-    if (!endDateError && !endTimeError) {
-      setEndDate(getCombinedDateTime(nextEndDateText, nextEndTimeText, useLocalTime))
-      didUpdateRange = true
-    }
+    if (endDateError || endTimeError) return
 
-    if (didUpdateRange) {
+    const nextEndDate = getCombinedDateTime(nextEndDateText, nextEndTimeText, useLocalTime)
+    if (endDate?.getTime() !== nextEndDate.getTime()) {
+      setEndDate(nextEndDate)
       onRangeSelection?.()
     }
   }

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-calendar.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-calendar.tsx
@@ -2,8 +2,6 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import DatePickerLib, { type ReactDatePickerCustomHeaderProps } from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import Button from '../../button/button'
-import Icon from '../../icon/icon'
-import InputTextSmall from '../../inputs/input-text-small/input-text-small'
 import DatePickerHeader from '../date-picker-header/date-picker-header'
 import { type DatePickerCalendarProps } from '../date-picker.types'
 import {
@@ -14,13 +12,9 @@ import {
   validateDate,
   validateTime,
 } from '../date-picker.utils'
-
-const areSameDates = (firstDate: Date | null, secondDate: Date | null) => {
-  if (!firstDate || !secondDate) return firstDate === secondDate
-  return firstDate.getTime() === secondDate.getTime()
-}
-
-const getDateRangeKey = (dates?: [Date, Date]) => dates?.map((date) => date.getTime()).join('-') ?? ''
+import { areSameDates, getDateRangeKey, getTimeInputValue, mergeDateWithTimeText } from './date-picker-calendar.utils'
+import DatePickerDateTimeInputs, { type DateTimeInputType } from './date-picker-date-time-inputs'
+import DatePickerTimezoneSelect from './date-picker-timezone-select'
 
 export function DatePickerCalendar({
   onChange,
@@ -78,13 +72,8 @@ export function DatePickerCalendar({
     setStartDateText(formatDateInput(startDate, useLocalTime))
     setEndDateText(formatDateInput(endDate, useLocalTime))
 
-    if (useLocalTime) {
-      setStartTimeText(startDate.toTimeString().substring(0, 5))
-      setEndTimeText(endDate.toTimeString().substring(0, 5))
-    } else {
-      setStartTimeText(startDate.toISOString().substring(11, 16))
-      setEndTimeText(endDate.toISOString().substring(11, 16))
-    }
+    setStartTimeText(getTimeInputValue(startDate, useLocalTime))
+    setEndTimeText(getTimeInputValue(endDate, useLocalTime))
   }, [endDate, startDate, useLocalTime])
 
   const handleChange = (dates: [Date | null, Date | null] | null) => {
@@ -98,7 +87,17 @@ export function DatePickerCalendar({
       return
     }
 
-    const [start, end] = dates
+    const [selectedStart, selectedEnd] = dates
+    const start = mergeDateWithTimeText({
+      date: selectedStart,
+      timeText: startTimeText,
+      useLocalTime,
+    })
+    const end = mergeDateWithTimeText({
+      date: selectedEnd,
+      timeText: endTimeText,
+      useLocalTime,
+    })
     const updateRange = (nextStartDate: Date | null, nextEndDate: Date | null) => {
       const hasStartDateChanged = !areSameDates(startDate, nextStartDate)
       const hasEndDateChanged = !areSameDates(endDate, nextEndDate)
@@ -210,7 +209,7 @@ export function DatePickerCalendar({
     return ''
   }
 
-  const handleInputChange = (type: 'startDate' | 'startTime' | 'endDate' | 'endTime', value: string) => {
+  const handleInputChange = (type: DateTimeInputType, value: string) => {
     lastInteractionRef.current = 'input'
     const nextStartDateText = type === 'startDate' ? value : startDateText
     const nextStartTimeText = type === 'startTime' ? value : startTimeText
@@ -352,60 +351,17 @@ export function DatePickerCalendar({
       />
       <div className="border-t border-neutral px-4 py-3">
         {showDateTimeInputs && (
-          <div className="space-y-3">
-            <div>
-              <div className="mb-1 flex items-center justify-between">
-                <p className="text-sm text-neutral">Start</p>
-                {(startDateError || startTimeError) && (
-                  <span className="text-xs text-negative">{startDateError || startTimeError}</span>
-                )}
-              </div>
-              <div className="flex gap-2">
-                <InputTextSmall
-                  label="Date"
-                  name="start-date"
-                  type="text"
-                  className="flex-1"
-                  value={startDateText}
-                  onChange={(e) => handleInputChange('startDate', e.target.value)}
-                />
-                <InputTextSmall
-                  label="Time"
-                  name="start-time"
-                  type="text"
-                  className="w-20"
-                  value={startTimeText}
-                  onChange={(e) => handleInputChange('startTime', e.target.value)}
-                />
-              </div>
-            </div>
-            <div>
-              <div className="mb-1 flex items-center justify-between">
-                <p className="text-sm text-neutral">End</p>
-                {(endDateError || endTimeError) && (
-                  <span className="text-xs text-negative">{endDateError || endTimeError}</span>
-                )}
-              </div>
-              <div className="flex gap-2">
-                <InputTextSmall
-                  label="Date"
-                  name="end-date"
-                  type="text"
-                  className="flex-1"
-                  value={endDateText}
-                  onChange={(e) => handleInputChange('endDate', e.target.value)}
-                />
-                <InputTextSmall
-                  label="Time"
-                  name="end-time"
-                  type="text"
-                  className="w-20"
-                  value={endTimeText}
-                  onChange={(e) => handleInputChange('endTime', e.target.value)}
-                />
-              </div>
-            </div>
-          </div>
+          <DatePickerDateTimeInputs
+            startDateText={startDateText}
+            startTimeText={startTimeText}
+            endDateText={endDateText}
+            endTimeText={endTimeText}
+            startDateError={startDateError}
+            startTimeError={startTimeError}
+            endDateError={endDateError}
+            endTimeError={endTimeError}
+            onInputChange={handleInputChange}
+          />
         )}
         <Button
           type="button"
@@ -416,24 +372,12 @@ export function DatePickerCalendar({
           Apply
         </Button>
         {showTimezoneSelect && (
-          <div className="relative my-1 flex w-full items-center justify-center gap-1 text-xs font-medium  text-neutral-subtle transition-colors hover:text-neutral">
-            <span>{selectedTimezoneLabel}</span>
-            <Icon iconName="chevron-down" iconStyle="regular" className="pointer-events-none text-xs" />
-            <select
-              name="timezone"
-              value={useLocalTime ? 'local' : 'utc'}
-              className="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0"
-              onChange={(event) => {
-                onTimezoneChange?.(event.target.value === 'local')
-              }}
-            >
-              {timezoneOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </div>
+          <DatePickerTimezoneSelect
+            selectedTimezoneLabel={selectedTimezoneLabel}
+            timezoneValue={useLocalTime ? 'local' : 'utc'}
+            timezoneOptions={timezoneOptions}
+            onTimezoneChange={onTimezoneChange}
+          />
         )}
       </div>
     </div>

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-calendar.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-calendar.tsx
@@ -16,6 +16,8 @@ import { areSameDates, getDateRangeKey, getTimeInputValue, mergeDateWithTimeText
 import DatePickerDateTimeInputs, { type DateTimeInputType } from './date-picker-date-time-inputs'
 import DatePickerTimezoneSelect from './date-picker-timezone-select'
 
+type TimezoneOption = { label: string; value: 'local' | 'utc' }
+
 export function DatePickerCalendar({
   onChange,
   minDate,
@@ -47,7 +49,7 @@ export function DatePickerCalendar({
       return 'Local'
     }
   }, [])
-  const timezoneOptions = [
+  const timezoneOptions: TimezoneOption[] = [
     { label: localTimeZone ? `Browser time (${localTimeZone})` : 'Browser time', value: 'local' },
     { label: 'UTC', value: 'utc' },
   ]

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-calendar.utils.ts
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-calendar.utils.ts
@@ -1,0 +1,25 @@
+import { formatDateInput, getCombinedDateTime, validateTime } from '../date-picker.utils'
+
+export const areSameDates = (firstDate: Date | null, secondDate: Date | null) => {
+  if (!firstDate || !secondDate) return firstDate === secondDate
+  return firstDate.getTime() === secondDate.getTime()
+}
+
+export const getDateRangeKey = (dates?: [Date, Date]) => dates?.map((date) => date.getTime()).join('-') ?? ''
+
+export const getTimeInputValue = (date: Date, useLocalTime: boolean) =>
+  useLocalTime ? date.toTimeString().substring(0, 5) : date.toISOString().substring(11, 16)
+
+export const mergeDateWithTimeText = ({
+  date,
+  timeText,
+  useLocalTime,
+}: {
+  date: Date | null
+  timeText: string
+  useLocalTime: boolean
+}) => {
+  if (!date || !validateTime(timeText)) return date
+
+  return getCombinedDateTime(formatDateInput(date, useLocalTime), timeText, useLocalTime)
+}

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-date-time-inputs.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-date-time-inputs.tsx
@@ -1,0 +1,107 @@
+import InputTextSmall from '../../inputs/input-text-small/input-text-small'
+
+export type DateTimeInputType = 'startDate' | 'startTime' | 'endDate' | 'endTime'
+
+interface DatePickerDateTimeInputsProps {
+  startDateText: string
+  startTimeText: string
+  endDateText: string
+  endTimeText: string
+  startDateError: string
+  startTimeError: string
+  endDateError: string
+  endTimeError: string
+  onInputChange: (type: DateTimeInputType, value: string) => void
+}
+
+const DateTimeInputGroup = ({
+  label,
+  dateName,
+  timeName,
+  dateType,
+  timeType,
+  dateValue,
+  timeValue,
+  dateError,
+  timeError,
+  onInputChange,
+}: {
+  label: string
+  dateName: string
+  timeName: string
+  dateType: DateTimeInputType
+  timeType: DateTimeInputType
+  dateValue: string
+  timeValue: string
+  dateError: string
+  timeError: string
+  onInputChange: (type: DateTimeInputType, value: string) => void
+}) => (
+  <div>
+    <div className="mb-1 flex items-center justify-between">
+      <p className="text-sm text-neutral">{label}</p>
+      {(dateError || timeError) && <span className="text-xs text-negative">{dateError || timeError}</span>}
+    </div>
+    <div className="flex gap-2">
+      <InputTextSmall
+        label="Date"
+        name={dateName}
+        type="text"
+        className="flex-1"
+        value={dateValue}
+        onChange={(event) => onInputChange(dateType, event.target.value)}
+      />
+      <InputTextSmall
+        label="Time"
+        name={timeName}
+        type="text"
+        className="w-20"
+        value={timeValue}
+        onChange={(event) => onInputChange(timeType, event.target.value)}
+      />
+    </div>
+  </div>
+)
+
+export function DatePickerDateTimeInputs({
+  startDateText,
+  startTimeText,
+  endDateText,
+  endTimeText,
+  startDateError,
+  startTimeError,
+  endDateError,
+  endTimeError,
+  onInputChange,
+}: DatePickerDateTimeInputsProps) {
+  return (
+    <div className="space-y-3">
+      <DateTimeInputGroup
+        label="Start"
+        dateName="start-date"
+        timeName="start-time"
+        dateType="startDate"
+        timeType="startTime"
+        dateValue={startDateText}
+        timeValue={startTimeText}
+        dateError={startDateError}
+        timeError={startTimeError}
+        onInputChange={onInputChange}
+      />
+      <DateTimeInputGroup
+        label="End"
+        dateName="end-date"
+        timeName="end-time"
+        dateType="endDate"
+        timeType="endTime"
+        dateValue={endDateText}
+        timeValue={endTimeText}
+        dateError={endDateError}
+        timeError={endTimeError}
+        onInputChange={onInputChange}
+      />
+    </div>
+  )
+}
+
+export default DatePickerDateTimeInputs

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-timezone-select.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-timezone-select.tsx
@@ -3,8 +3,9 @@ import Icon from '../../icon/icon'
 interface DatePickerTimezoneSelectProps {
   selectedTimezoneLabel: string
   timezoneValue: 'local' | 'utc'
-  timezoneOptions: Array<{ label: string; value: string }>
+  timezoneOptions: Array<{ label: string; value: 'local' | 'utc' }>
   onTimezoneChange?: (useLocalTime: boolean) => void
+}
 }
 
 export function DatePickerTimezoneSelect({

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-timezone-select.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-timezone-select.tsx
@@ -6,7 +6,6 @@ interface DatePickerTimezoneSelectProps {
   timezoneOptions: Array<{ label: string; value: 'local' | 'utc' }>
   onTimezoneChange?: (useLocalTime: boolean) => void
 }
-}
 
 export function DatePickerTimezoneSelect({
   selectedTimezoneLabel,
@@ -19,6 +18,7 @@ export function DatePickerTimezoneSelect({
       <span>{selectedTimezoneLabel}</span>
       <Icon iconName="chevron-down" iconStyle="regular" className="pointer-events-none text-xs" />
       <select
+        aria-label="Timezone"
         name="timezone"
         value={timezoneValue}
         className="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0"

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-timezone-select.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker-calendar/date-picker-timezone-select.tsx
@@ -1,0 +1,38 @@
+import Icon from '../../icon/icon'
+
+interface DatePickerTimezoneSelectProps {
+  selectedTimezoneLabel: string
+  timezoneValue: 'local' | 'utc'
+  timezoneOptions: Array<{ label: string; value: string }>
+  onTimezoneChange?: (useLocalTime: boolean) => void
+}
+
+export function DatePickerTimezoneSelect({
+  selectedTimezoneLabel,
+  timezoneValue,
+  timezoneOptions,
+  onTimezoneChange,
+}: DatePickerTimezoneSelectProps) {
+  return (
+    <div className="relative my-1 flex w-full items-center justify-center gap-1 text-xs font-medium  text-neutral-subtle transition-colors hover:text-neutral">
+      <span>{selectedTimezoneLabel}</span>
+      <Icon iconName="chevron-down" iconStyle="regular" className="pointer-events-none text-xs" />
+      <select
+        name="timezone"
+        value={timezoneValue}
+        className="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0"
+        onChange={(event) => {
+          onTimezoneChange?.(event.target.value === 'local')
+        }}
+      >
+        {timezoneOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export default DatePickerTimezoneSelect

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker.spec.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker.spec.tsx
@@ -152,16 +152,19 @@ describe('DatePicker', () => {
   })
 
   it('updates start and end dates when selecting a date range on calendar with max range days defined', async () => {
-    const { userEvent } = renderWithProviders(<DatePicker onChange={mockOnChange} isOpen maxRangeInDays={6} />)
-
-    // Click on two different days to select a range
-    const days = screen.getAllByRole('option')
-    const availableDays = days.filter((day) => !day.classList.contains('react-datepicker__day--outside-month'))
+    const { userEvent } = renderWithProviders(
+      <DatePicker
+        onChange={mockOnChange}
+        isOpen
+        maxRangeInDays={6}
+        defaultDates={[new Date('2024-01-01T00:00:00.000Z'), new Date('2024-01-02T00:00:00.000Z')]}
+      />
+    )
 
     // Select first day (start date)
-    await userEvent.click(availableDays[0])
+    await userEvent.click(screen.getByLabelText('Choose Wednesday, January 3rd, 2024'))
     // Select another day (end date)
-    await userEvent.click(availableDays[5])
+    await userEvent.click(screen.getByLabelText('Choose Monday, January 8th, 2024'))
 
     // Click Apply and verify onChange was called with both dates
     await userEvent.click(screen.getByText('Apply'))
@@ -232,10 +235,7 @@ describe('DatePicker', () => {
   })
 
   it('keeps the selected range stable when rerendered with equivalent default dates', () => {
-    const defaultDates = [new Date('2024-01-01T10:30:00.000Z'), new Date('2024-01-01T11:45:00.000Z')] as [
-      Date,
-      Date,
-    ]
+    const defaultDates = [new Date('2024-01-01T10:30:00.000Z'), new Date('2024-01-01T11:45:00.000Z')] as [Date, Date]
     const { rerender } = renderWithProviders(
       <DatePicker onChange={mockOnChange} isOpen showDateTimeInputs defaultDates={defaultDates} />
     )
@@ -265,6 +265,46 @@ describe('DatePicker', () => {
     await userEvent.click(selectedDay)
 
     expect(screen.getAllByTestId('input-value')[0]).toHaveValue('2024-01-17')
+  })
+
+  it('applies the selected calendar day with the current time inputs', async () => {
+    const startDate = new Date('2024-01-10T10:30:00.000Z')
+    const endDate = new Date('2024-01-12T11:45:00.000Z')
+    const { userEvent } = renderWithProviders(
+      <DatePicker onChange={mockOnChange} isOpen showDateTimeInputs defaultDates={[startDate, endDate]} />
+    )
+
+    await userEvent.click(screen.getByLabelText('Choose Thursday, January 11th, 2024'))
+    await userEvent.click(screen.getByLabelText('Choose Friday, January 12th, 2024'))
+    await userEvent.click(screen.getByText('Apply'))
+
+    expect(mockOnChange).toHaveBeenCalledWith(new Date('2024-01-11T10:30:00.000Z'), endDate)
+  })
+
+  it('syncs inputs when default dates change to a different range', () => {
+    const { rerender } = renderWithProviders(
+      <DatePicker
+        onChange={mockOnChange}
+        isOpen
+        showDateTimeInputs
+        defaultDates={[new Date('2024-01-10T10:30:00.000Z'), new Date('2024-01-12T11:45:00.000Z')]}
+      />
+    )
+
+    rerender(
+      <DatePicker
+        onChange={mockOnChange}
+        isOpen
+        showDateTimeInputs
+        defaultDates={[new Date('2024-02-01T08:15:00.000Z'), new Date('2024-02-02T09:45:00.000Z')]}
+      />
+    )
+
+    const inputs = screen.getAllByTestId('input-value')
+    expect(inputs[0]).toHaveValue('2024-02-01')
+    expect(inputs[1]).toHaveValue('08:15')
+    expect(inputs[2]).toHaveValue('2024-02-02')
+    expect(inputs[3]).toHaveValue('09:45')
   })
 })
 

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker.spec.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker.spec.tsx
@@ -187,6 +187,85 @@ describe('DatePicker', () => {
 
     expect(mockOnPeriodChange).toHaveBeenCalledWith('')
   })
+
+  it('does not clear the period selection while typing an invalid partial time', async () => {
+    const mockOnPeriodChange = jest.fn()
+    const startDate = new Date('2024-01-01T00:00:00.000Z')
+    const endDate = new Date('2024-01-01T23:59:00.000Z')
+    const { userEvent } = renderWithProviders(
+      <DatePicker
+        onChange={mockOnChange}
+        isOpen
+        showDateTimeInputs
+        showPeriodSelect
+        periodOptions={[{ label: 'Last 15 minutes', value: '15m' }]}
+        periodValue="15m"
+        onPeriodChange={mockOnPeriodChange}
+        defaultDates={[startDate, endDate]}
+      />
+    )
+
+    const inputs = screen.getAllByTestId('input-value')
+    await userEvent.clear(inputs[1])
+    await userEvent.type(inputs[1], '0')
+
+    expect(mockOnPeriodChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps time input edits as draft values until Apply', async () => {
+    const startDate = new Date('2024-01-01T00:00:00.000Z')
+    const endDate = new Date('2024-01-01T23:59:00.000Z')
+    const { userEvent } = renderWithProviders(
+      <DatePicker onChange={mockOnChange} isOpen showDateTimeInputs defaultDates={[startDate, endDate]} />
+    )
+
+    const inputs = screen.getAllByTestId('input-value')
+    await userEvent.clear(inputs[1])
+    await userEvent.type(inputs[1], '01:30')
+
+    expect(mockOnChange).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByText('Apply'))
+
+    expect(mockOnChange).toHaveBeenCalledWith(expect.any(Date), endDate)
+    expect(mockOnChange.mock.calls[0][0]).toEqual(new Date('2024-01-01T01:30:00.000Z'))
+  })
+
+  it('keeps the selected range stable when rerendered with equivalent default dates', () => {
+    const defaultDates = [new Date('2024-01-01T10:30:00.000Z'), new Date('2024-01-01T11:45:00.000Z')] as [
+      Date,
+      Date,
+    ]
+    const { rerender } = renderWithProviders(
+      <DatePicker onChange={mockOnChange} isOpen showDateTimeInputs defaultDates={defaultDates} />
+    )
+
+    rerender(
+      <DatePicker
+        onChange={mockOnChange}
+        isOpen
+        showDateTimeInputs
+        defaultDates={[new Date(defaultDates[0]), new Date(defaultDates[1])]}
+      />
+    )
+
+    const inputs = screen.getAllByTestId('input-value')
+    expect(inputs[1]).toHaveValue('10:30')
+    expect(inputs[3]).toHaveValue('11:45')
+  })
+
+  it('updates the date input when selecting a different calendar day with default dates', async () => {
+    const startDate = new Date('2024-01-10T10:30:00.000Z')
+    const endDate = new Date('2024-01-12T11:45:00.000Z')
+    const { userEvent } = renderWithProviders(
+      <DatePicker onChange={mockOnChange} isOpen showDateTimeInputs defaultDates={[startDate, endDate]} />
+    )
+
+    const selectedDay = screen.getByLabelText('Choose Wednesday, January 17th, 2024')
+    await userEvent.click(selectedDay)
+
+    expect(screen.getAllByTestId('input-value')[0]).toHaveValue('2024-01-17')
+  })
 })
 
 describe('validateDate', () => {

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker.tsx
@@ -5,6 +5,8 @@ import DatePickerPeriodList from './date-picker-period-list/date-picker-period-l
 import { type DatePickerProps } from './date-picker.types'
 import { getPeriodDates } from './date-picker.utils'
 
+const getDateRangeKey = (dates?: [Date, Date]) => dates?.map((date) => date.getTime()).join('-') ?? ''
+
 export function DatePicker({
   isOpen,
   children,
@@ -24,12 +26,13 @@ export function DatePicker({
   const shouldShowCalendar = showCalendar !== false
   const hasPanels = shouldShowCalendar || shouldShowPeriodList
   const [periodDates, setPeriodDates] = useState<[Date, Date] | undefined>()
+  const defaultDatesKey = getDateRangeKey(defaultDates)
 
   useEffect(() => {
-    if (defaultDates) {
+    if (defaultDatesKey) {
       setPeriodDates(undefined)
     }
-  }, [defaultDates])
+  }, [defaultDatesKey])
 
   useEffect(() => {
     if (!isOpen || shouldShowCalendar || !onClickOutside) return

--- a/libs/shared/ui/src/lib/components/date-picker/date-picker.tsx
+++ b/libs/shared/ui/src/lib/components/date-picker/date-picker.tsx
@@ -1,11 +1,10 @@
 import { type PropsWithChildren, useEffect, useState } from 'react'
 import { twMerge } from '@qovery/shared/util-js'
 import DatePickerCalendar from './date-picker-calendar/date-picker-calendar'
+import { getDateRangeKey } from './date-picker-calendar/date-picker-calendar.utils'
 import DatePickerPeriodList from './date-picker-period-list/date-picker-period-list'
 import { type DatePickerProps } from './date-picker.types'
 import { getPeriodDates } from './date-picker.utils'
-
-const getDateRangeKey = (dates?: [Date, Date]) => dates?.map((date) => date.getTime()).join('-') ?? ''
 
 export function DatePicker({
   isOpen,


### PR DESCRIPTION
## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1780313685616249)

When changing the timeframe in service logs, the UI was crashing. The issue can be consistently reproduced when trying to type in a start time for the timeframe filter.

This PR fixes this bug and refactors the internals of the DatePicker component, splitting it into smaller meaningful chunks. 

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
