### PR TITLE
fix(secretManager): add missing "Beta" label in creation flow

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.spec.tsx
@@ -137,6 +137,13 @@ describe('StepAddons', () => {
     jest.useRealTimers()
   })
 
+  it('should display beta badge on secret manager integration', () => {
+    renderWithProviders(<StepAddons {...defaultProps} />, { wrapper: getWrapper() })
+
+    expect(screen.getByText('Secret manager integration')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+  })
+
   it('should sync KEDA activation to addons data', async () => {
     const { userEvent } = renderWithProviders(<StepAddons {...defaultProps} />, { wrapper: getWrapper() })
 

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -121,10 +121,10 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                 <div className="flex flex-col gap-1">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-neutral">Secret manager integration</span>
-                    <Badge size="sm" radius="full" variant="surface" color="green" className="text-[13px]">
+                    <Badge size="sm" radius="full" variant="surface" color="green" className="text-ssm">
                       Free
                     </Badge>
-                    <Badge size="sm" radius="full" variant="surface" color="purple" className="text-[13px]">
+                    <Badge size="sm" radius="full" variant="surface" color="purple" className="text-ssm">
                       Beta
                     </Badge>
                   </div>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -124,6 +124,9 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                     <Badge size="sm" radius="full" variant="surface" color="green" className="text-[13px]">
                       Free
                     </Badge>
+                    <Badge size="sm" radius="full" variant="surface" color="purple" className="text-[13px]">
+                      Beta
+                    </Badge>
                   </div>
                   <p className="text-sm text-neutral-subtle">
                     Link any secret manager on your cluster to add external secrets variables to all the services


### PR DESCRIPTION
## Summary

**Issue**: 

PR adding the missing "Beta" label next to the "Secret manager integration" title of the Add-ons section of the Cluster creation flow.


## Screenshots / Recordings

<img width="1417" height="895" alt="image" src="https://github.com/user-attachments/assets/d1302ec2-15e9-4cc5-a5e4-613f1e1473fe" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
