### PR TITLE
feat(service-list): add copy button for containers tag

### DIFF
--- a/libs/domains/services/feature/src/lib/last-version/__snapshots__/last-version.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/last-version/__snapshots__/last-version.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`LastVersion should match snapshot 1`] = `
       class="flex"
     >
       <button
-        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 px-1.5 gap-x-1 rounded bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral flex min-w-[81px] justify-center pl-1 rounded-r-none border-r-0"
+        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 px-1.5 gap-x-1 rounded bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral flex min-w-fit justify-center pl-1 rounded-r-none border-r-0"
         type="button"
       >
         <i

--- a/libs/domains/services/feature/src/lib/last-version/__snapshots__/last-version.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/last-version/__snapshots__/last-version.spec.tsx.snap
@@ -6,15 +6,16 @@ exports[`LastVersion should match snapshot 1`] = `
     <span
       class="flex"
     >
-      <span
-        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded min-w-7 max-w-[81px] rounded-r-none border-r-0 bg-surface-neutral"
+      <button
+        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 px-1.5 gap-x-1 rounded bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral flex min-w-[81px] justify-center pl-1 rounded-r-none border-r-0"
+        type="button"
       >
-        <span
-          class="flex h-full w-full items-center justify-center truncate"
-        >
-          1.0
-        </span>
-      </span>
+        <i
+          aria-hidden="true"
+          class="fa-regular fa-tag w-4"
+        />
+        1.0
+      </button>
       <button
         aria-label="Deploy from another version"
         class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 gap-x-1 rounded bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-7 justify-center rounded-l-none px-1.5"

--- a/libs/domains/services/feature/src/lib/last-version/last-version.tsx
+++ b/libs/domains/services/feature/src/lib/last-version/last-version.tsx
@@ -120,7 +120,7 @@ export function LastVersion({ organizationId, projectId, service, version }: Las
 
   return (
     <span className="flex">
-      <CopyToClipboard text={version} className="flex min-w-[81px] justify-center">
+      <CopyToClipboard text={version} className="flex min-w-fit justify-center">
         <Button
           type="button"
           variant="outline"

--- a/libs/domains/services/feature/src/lib/last-version/last-version.tsx
+++ b/libs/domains/services/feature/src/lib/last-version/last-version.tsx
@@ -1,9 +1,10 @@
+import clsx from 'clsx'
 import { type ContainerSource, type HelmSourceRepositoryResponse } from 'qovery-typescript-axios'
-import { type MouseEvent } from 'react'
+import { type MouseEvent, useState } from 'react'
 import { P, match } from 'ts-pattern'
 import { type Container, type Helm, type Job } from '@qovery/domains/services/data-access'
 import { isHelmRepositorySource, isJobContainerSource } from '@qovery/shared/enums'
-import { Badge, Button, Icon, Tooltip, Truncate, useModal } from '@qovery/shared/ui'
+import { Badge, Button, CopyToClipboard, Icon, Tooltip, Truncate, useModal } from '@qovery/shared/ui'
 import { useDeployService } from '../hooks/use-deploy-service/use-deploy-service'
 import SelectVersionModal from '../select-version-modal/select-version-modal'
 
@@ -15,6 +16,8 @@ export interface LastVersionProps {
 }
 
 export function LastVersion({ organizationId, projectId, service, version }: LastVersionProps) {
+  const [hover, setHover] = useState(false)
+
   const { mutate: deployService } = useDeployService({
     organizationId,
     projectId,
@@ -117,11 +120,22 @@ export function LastVersion({ organizationId, projectId, service, version }: Las
 
   return (
     <span className="flex">
-      <Badge variant="outline" className="min-w-7 max-w-[81px] rounded-r-none border-r-0 bg-surface-neutral">
-        <span className="flex h-full w-full items-center justify-center truncate">
+      <CopyToClipboard text={version} className="flex min-w-[81px] justify-center">
+        <Button
+          type="button"
+          variant="outline"
+          color="neutral"
+          size="xs"
+          className={clsx('pl-1', {
+            'rounded-r-none border-r-0': true,
+          })}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+        >
+          {hover ? <Icon iconName="copy" className="w-4" /> : <Icon iconName="tag" className="w-4" />}
           <Truncate text={version} truncateLimit={8} />
-        </span>
-      </Badge>
+        </Button>
+      </CopyToClipboard>
       <Tooltip content="Deploy from another version">
         <Button
           type="button"
@@ -133,7 +147,7 @@ export function LastVersion({ organizationId, projectId, service, version }: Las
           onClick={(e) => deployVersion(e)}
         >
           <span className="flex h-full items-center justify-center">
-            <Icon iconName="clock-rotate-left" iconStyle="regular" />
+            <Icon iconName="clock-rotate-left" />
           </span>
         </Button>
       </Tooltip>

--- a/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
@@ -800,15 +800,16 @@ exports[`ServiceList should match snapshot 1`] = `
                     <span
                       class="flex"
                     >
-                      <span
-                        class="text-neutral inline-flex items-center shrink-0 text-xs px-1.5 h-6 border-neutral border rounded min-w-7 max-w-[81px] rounded-r-none border-r-0 bg-surface-neutral"
+                      <button
+                        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 px-1.5 gap-x-1 rounded bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral flex min-w-[81px] justify-center pl-1 rounded-r-none border-r-0"
+                        type="button"
                       >
-                        <span
-                          class="flex h-full w-full items-center justify-center truncate"
-                        >
-                          6.5.2
-                        </span>
-                      </span>
+                        <i
+                          aria-hidden="true"
+                          class="fa-regular fa-tag w-4"
+                        />
+                        6.5.2
+                      </button>
                       <button
                         aria-label="Deploy from another version"
                         class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 gap-x-1 rounded bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral w-7 justify-center rounded-l-none px-1.5"

--- a/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-list/__snapshots__/service-list.spec.tsx.snap
@@ -801,7 +801,7 @@ exports[`ServiceList should match snapshot 1`] = `
                       class="flex"
                     >
                       <button
-                        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 px-1.5 gap-x-1 rounded bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral flex min-w-[81px] justify-center pl-1 rounded-r-none border-r-0"
+                        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 px-1.5 gap-x-1 rounded bg-surface-neutral border border-neutral hover:border-neutral-component hover:bg-surface-neutral-subtle data-[state=open]:bg-surface-neutral-subtle text-neutral flex min-w-fit justify-center pl-1 rounded-r-none border-r-0"
                         type="button"
                       >
                         <i


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**:  In the service list of an environment, it wasn't possible to copy the tag of an application deployed through an image.

## Screenshots / Recordings


https://github.com/user-attachments/assets/265a273a-2bfc-467b-a7eb-f1d8859dfca4




## Testing

- [ X] Changes tested locally in the relevant Console's pages and Storybooks
- [ X] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ X] `yarn format`
- [ X] `yarn lint`

## PR Checklist

- [ X] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ X] I performed a self-review (diff inspected, dead code removed)
- [ X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ X] I only kept necessary comments, written in English (watch for useless AI comments)
- [  ] I involved a designer to validate UI changes if I am not a designer
- [ X] I covered new business logic with tests (unit)
- [X ] I confirmed CI is green (Codecov red can be accepted)
- [X ] I reviewed and executed locally any AI-assisted code
