### PR TITLE
feat(shell): Add and display request id to user

### DIFF
--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -6,6 +6,7 @@ import Color from 'color'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { XTerm } from 'react-xtermjs'
 import { match } from 'ts-pattern'
+import { v7 as uuidv7 } from 'uuid'
 import { type ServiceType } from '@qovery/domains/services/data-access'
 import { Button, EmptyState, ExternalLink, Icon, LoaderSpinner, toast } from '@qovery/shared/ui'
 import { useTerminalReadiness } from '@qovery/shared/util-hooks'
@@ -39,6 +40,7 @@ export function ServiceTerminal({
 }: ServiceTerminalProps) {
   const { data: runningStatuses } = useRunningStatus({ environmentId, serviceId })
   const hasWrittenShellBannerRef = useRef(false)
+  const [requestId, setRequestId] = useState(() => uuidv7())
 
   const [addons, setAddons] = useState<Array<ITerminalAddon>>([])
   const [terminalLaunchError, setTerminalLaunchError] = useState<string | null>(null)
@@ -122,11 +124,12 @@ export function ServiceTerminal({
           terminalBannerColors,
           getPortForwardCommand,
           getShellCommand,
-          shouldWriteShellBanner
+          shouldWriteShellBanner,
+          requestId
         ),
       ])
     },
-    [attachWebSocket, getPortForwardCommand, getShellCommand, setAddons, terminalBannerColors]
+    [attachWebSocket, getPortForwardCommand, getShellCommand, requestId, setAddons, terminalBannerColors]
   )
 
   const onCloseHandler = useCallback(
@@ -147,6 +150,7 @@ export function ServiceTerminal({
     hasWrittenShellBannerRef.current = false
     setAddons([])
     setTerminalLaunchError(null)
+    setRequestId(uuidv7())
     resetTerminalReadiness()
   }, [detachWebSocket, resetTerminalReadiness])
   const terminalUnavailableDescription = useMemo(
@@ -177,6 +181,7 @@ export function ServiceTerminal({
       container_name: selectedContainer,
       tty_height: rows.toString(),
       tty_width: cols.toString(),
+      external_request_id: requestId,
     },
     onOpen: onOpenHandler,
     onClose: onCloseHandler,

--- a/libs/domains/services/feature/src/lib/service-terminal/terminal-shell-banner-addon.ts
+++ b/libs/domains/services/feature/src/lib/service-terminal/terminal-shell-banner-addon.ts
@@ -37,7 +37,8 @@ export class TerminalShellActionsAddon implements ITerminalAddon {
     private readonly colors: TerminalBannerColors,
     private readonly getPortForwardCommand: () => string,
     private readonly getShellCommand: () => string,
-    private readonly shouldWriteBanner: boolean
+    private readonly shouldWriteBanner: boolean,
+    private readonly requestId: string
   ) {}
 
   private toAnsiColor(color: string): string {
@@ -182,6 +183,8 @@ export class TerminalShellActionsAddon implements ITerminalAddon {
       secondCommandLine,
       [{ color: this.colors.subtle, text: 'Forward a pod port to localhost' }],
       [{ text: TerminalShellActionsAddon.COPY_COMMAND_LABEL }],
+      [{ text: '' }],
+      [{ color: this.colors.subtle, text: `Request ID: ${this.requestId}` }],
     ]
 
     const maxBannerLineLength = Math.max(


### PR DESCRIPTION
Went we wants to troubleshoot the shell from the browser it is super hard to be because we don't have the request id. We can't get the one generated by the websocket as it is in the response header and the js does not have access to it in websocket.

So add a new parameter id, and display it in the banner, to avoid user having to have the developper tool open.
<img width="966" height="544" alt="image" src="https://github.com/user-attachments/assets/20e4bc5b-abfd-4a0f-b40a-af5725f5480e" />

<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: <!-- QOV-1234 -->

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
