### PR TITLE
fix(organization): crash due to undefined initial form value

### DIFF
--- a/libs/domains/organizations/feature/src/lib/settings-general/settings-general.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-general/settings-general.spec.tsx
@@ -42,6 +42,19 @@ describe('SettingsGeneral', () => {
     expect(baseElement).toBeTruthy()
   })
 
+  it('should render successfully when organization admin emails are missing', async () => {
+    useOrganizationMock.mockReturnValue({
+      data: {
+        ...mockOrganization,
+        admin_emails: undefined,
+      },
+    } as unknown as ReturnType<typeof useOrganization>)
+
+    renderWithProviders(<SettingsGeneral />)
+
+    expect(await screen.findByTestId('input-emails')).toBeInTheDocument()
+  })
+
   it('should dispatch editOrganization if form is submitted', async () => {
     const { userEvent } = renderWithProviders(<SettingsGeneral />)
 

--- a/libs/domains/organizations/feature/src/lib/settings-general/settings-general.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-general/settings-general.tsx
@@ -2,7 +2,7 @@ import { useParams } from '@tanstack/react-router'
 import { type Organization } from 'qovery-typescript-axios'
 import { useEffect } from 'react'
 import { type FormEventHandler } from 'react'
-import { type FieldValues, FormProvider, useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import { Controller, useFormContext } from 'react-hook-form'
 import { SettingsHeading } from '@qovery/shared/console-shared'
 import { BlockContent, Button, InputFile, InputTags, InputText, InputTextArea, Section } from '@qovery/shared/ui'
@@ -17,9 +17,17 @@ export interface PageOrganizationGeneralProps {
   created_at: string
 }
 
+interface OrganizationGeneralFormValues {
+  logo_url: string
+  name: string
+  description: string
+  website_url: string
+  admin_emails: string[]
+}
+
 export function PageOrganizationGeneral(props: PageOrganizationGeneralProps) {
   const { onSubmit, loading, created_at } = props
-  const { control, formState, watch } = useFormContext()
+  const { control, formState, watch } = useFormContext<OrganizationGeneralFormValues>()
 
   return (
     <div className="flex w-full flex-col justify-between">
@@ -124,14 +132,14 @@ export function PageOrganizationGeneral(props: PageOrganizationGeneralProps) {
   )
 }
 
-export const handleSubmit = (data: FieldValues, organization: Organization) => {
+export const handleSubmit = (data: OrganizationGeneralFormValues, organization: Organization) => {
   return {
     ...organization,
-    logo_url: data['logo_url'],
-    name: data['name'],
-    description: data['description'],
-    website_url: data['website_url'] === '' ? undefined : data['website_url'],
-    admin_emails: data['admin_emails'],
+    logo_url: data.logo_url,
+    name: data.name,
+    description: data.description,
+    website_url: data.website_url === '' ? undefined : data.website_url,
+    admin_emails: data.admin_emails,
   }
 }
 
@@ -142,8 +150,15 @@ export function SettingsGeneral() {
   const { data: organization } = useOrganization({ organizationId })
   const { mutateAsync: editOrganization, isLoading: isLoadingEditOrganization } = useEditOrganization()
 
-  const methods = useForm({
+  const methods = useForm<OrganizationGeneralFormValues>({
     mode: 'onChange',
+    defaultValues: {
+      logo_url: '',
+      name: '',
+      description: '',
+      website_url: '',
+      admin_emails: [],
+    },
   })
 
   useEffect(() => {
@@ -152,7 +167,7 @@ export function SettingsGeneral() {
       logo_url: organization?.logo_url || '',
       description: organization?.description || '',
       website_url: organization?.website_url || '',
-      admin_emails: organization?.admin_emails || '',
+      admin_emails: organization?.admin_emails ?? [],
     })
   }, [
     methods,


### PR DESCRIPTION
## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1780648148959019)

The app is crashing when directly visiting [this page](https://console.qovery.com/organization/3d542888-3d2c-474a-b1ad-712556db66da/settings/general). This PR fixes this bug by making sure initial default values are correct.

## Screenshots / Recordings

<img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/38677675-b15c-4b40-9375-cf0db7870150" />

_Prod on the left side; localhost on the right side_

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
