### PR TITLE
feat(shell): Display the requestId also after deconnection

### DIFF
--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -254,6 +254,7 @@ export function ServiceTerminal({
         <div className="relative min-h-0 flex-1">
           {terminalLaunchError ? (
             <EmptyState icon="terminal" title="Unable to launch CLI" description={terminalUnavailableDescription}>
+              <p className="text-xs text-neutral-subtle">Request ID: {requestId}</p>
               <Button size="md" color="neutral" onClick={onRetryCliLaunch}>
                 Relaunch
               </Button>


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary
<img width="1189" height="444" alt="image" src="https://github.com/user-attachments/assets/58a8db91-877f-49c9-80a4-5c0fde9a9a0a" />

**Issue**: <!-- QOV-1234 -->

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
