### PR TITLE
feat(devops-copilot): action confirmation for the write mode

### DIFF
--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-panel.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-panel.tsx
@@ -27,12 +27,21 @@ import { MessageList } from './message-list/message-list'
 import { StatusFooter } from './status-footer/status-footer'
 import { renderStreamingMessageWithMermaid } from './streaming-mermaid-renderer/streaming-mermaid-renderer'
 
+export type PlanStep = {
+  messageId: string
+  description: string
+  toolName: string
+  status: 'not_started' | 'in_progress' | 'completed' | 'waiting' | 'error'
+}
+
 export type Message = {
   id: string
   text: string
   owner: 'user' | 'assistant'
   timestamp: number
   vote?: 'upvote' | 'downvote'
+  mediaType?: string
+  planData?: PlanStep[]
 }
 
 export type Thread = Message[]
@@ -41,13 +50,6 @@ export interface DevopsCopilotPanelProps {
   onClose: () => void
   smaller?: boolean
   style?: CSSProperties
-}
-
-export type PlanStep = {
-  messageId: string
-  description: string
-  toolName: string
-  status: 'not_started' | 'in_progress' | 'completed' | 'waiting' | 'error'
 }
 
 export type CopilotContextData = {
@@ -124,7 +126,7 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
     enabled: isPanelActive,
   })
 
-  const { handleSendMessage, lastSubmitResult } = useMessageSubmission({
+  const { handleSendMessage, lastSubmitResult, pendingConfirmationRef } = useMessageSubmission({
     refs: {
       controller: controllerRef,
       scrollArea: scrollAreaRef,
@@ -157,6 +159,13 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
   })
 
   const appStatus = data?.find(({ id }) => id === INSTATUS_APP_ID)
+
+  const lastMsg = thread[thread.length - 1]
+  const pendingConfirmation = !isLoading && lastMsg?.mediaType === 'pending_confirmation'
+  const effectivePlan =
+    pendingConfirmation && plan.length === 0 && lastMsg?.planData?.length
+      ? lastMsg.planData.map((step) => ({ ...step, messageId: String(lastMsg.id) }))
+      : plan
 
   const handleOnClose = useCallback(() => {
     onClose()
@@ -257,6 +266,7 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
             text: streamingMessage,
             owner: 'assistant',
             timestamp: Date.now(),
+            mediaType: pendingConfirmationRef.current ? 'pending_confirmation' : undefined,
           },
         ])
 
@@ -271,6 +281,7 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
             text: streamingMessage,
             owner: 'assistant',
             timestamp: Date.now(),
+            mediaType: pendingConfirmationRef.current ? 'pending_confirmation' : undefined,
           },
         ])
       }
@@ -406,7 +417,7 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
                   streamingMessage={streamingMessage}
                   displayedStreamingMessage={displayedStreamingMessage}
                   loadingText={loadingText}
-                  plan={plan}
+                  plan={effectivePlan}
                   showPlans={showPlans}
                   setShowPlans={setShowPlans}
                   threadId={threadId}
@@ -446,16 +457,34 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
                   <div
                     className={twMerge(
                       clsx('relative animate-[fadein_0.22s_ease-in-out_forwards_0.15s] pt-3 opacity-0', {
-                        'pt-[42px]': withContext,
+                        'pt-[42px]': withContext && !(pendingConfirmation && !isLoading),
+                        'pt-[52px]': pendingConfirmation && !isLoading,
                       })
                     )}
                   >
-                    {withContext && (
-                      <ContextBanner
-                        currentType={String(current?.type)}
-                        currentName={String(current?.name ?? 'No context')}
-                        onClose={() => setWithContext(false)}
-                      />
+                    {pendingConfirmation && !isLoading ? (
+                      <div className="absolute top-2.5 flex w-full items-center rounded-t-xl border border-neutral bg-surface-neutral-subtle pb-4 pl-2 pr-2 pt-2 text-xs text-neutral-subtle">
+                        <span className="flex items-center gap-2">
+                          <Icon iconName="circle-exclamation" iconStyle="regular" />
+                          <span className="font-medium text-neutral">Action confirmation</span>
+                        </span>
+                        <div className="ml-auto flex gap-1">
+                          <Button type="button" size="xs" variant="surface" onClick={() => handleSendMessage('no')}>
+                            Cancel
+                          </Button>
+                          <Button type="button" size="xs" variant="solid" onClick={() => handleSendMessage('yes')}>
+                            Confirm
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      withContext && (
+                        <ContextBanner
+                          currentType={String(current?.type)}
+                          currentName={String(current?.name ?? 'No context')}
+                          onClose={() => setWithContext(false)}
+                        />
+                      )
                     )}
                     <Input
                       disabled={!isCopilotEnabled}

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/hooks/use-message-submission/parse-stream-chunk.ts
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/hooks/use-message-submission/parse-stream-chunk.ts
@@ -8,7 +8,7 @@ const CHUNK_PREFIXES = {
 } as const
 
 export type ParsedChunkType = {
-  type: 'start' | 'plan' | 'step' | 'step_plan' | 'step_plan_reset' | 'content'
+  type: 'start' | 'plan' | 'step' | 'step_plan' | 'step_plan_reset' | 'content' | 'pending_confirmation'
   data?: {
     threadId?: string
     plan?: PlanStep[]
@@ -24,6 +24,10 @@ export function parseStreamChunk(chunk: string, currentContent: string): ParsedC
 
     if (parsed.type === 'start' && parsed.content?.thread_id) {
       return { type: 'start', data: { threadId: parsed.content.thread_id } }
+    }
+
+    if (parsed.type === 'pending_confirmation') {
+      return { type: 'pending_confirmation' }
     }
 
     if (parsed.type === 'chunk' && parsed.content) {

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/hooks/use-message-submission/use-message-submission.ts
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/hooks/use-message-submission/use-message-submission.ts
@@ -44,12 +44,14 @@ interface UseMessageSubmissionParams {
 export function useMessageSubmission({ refs, state, actions }: UseMessageSubmissionParams) {
   const lastSubmitResult = useRef<{ id: string; messageId: string } | null>(null)
   const fullContentRef = useRef('')
+  const pendingConfirmationRef = useRef(false)
 
   const handleSendMessage = useCallback(
     async (messageOverride?: string, newThread = false) => {
       refs.controller.current = new AbortController()
       lastSubmitResult.current = null
       fullContentRef.current = ''
+      pendingConfirmationRef.current = false
 
       const node = refs.scrollArea.current
       if (node) {
@@ -152,6 +154,10 @@ export function useMessageSubmission({ refs, state, actions }: UseMessageSubmiss
                   actions.setStreamingMessage(parsedChunk.data.content)
                 }
                 break
+
+              case 'pending_confirmation':
+                pendingConfirmationRef.current = true
+                break
             }
           },
           refs.controller.current.signal
@@ -188,5 +194,5 @@ export function useMessageSubmission({ refs, state, actions }: UseMessageSubmiss
     ]
   )
 
-  return { handleSendMessage, lastSubmitResult }
+  return { handleSendMessage, lastSubmitResult, pendingConfirmationRef }
 }

--- a/libs/shared/devops-copilot/feature/src/lib/hooks/use-thread-state/use-thread-state.ts
+++ b/libs/shared/devops-copilot/feature/src/lib/hooks/use-thread-state/use-thread-state.ts
@@ -19,6 +19,7 @@ interface UseCurrentThreadResult {
 type RawMessage = {
   id: number
   media_content: string
+  media_type: string
   owner: 'user' | 'assistant'
   created_at: string
   vote_type?: 'upvote' | 'downvote'
@@ -55,13 +56,32 @@ export function useThreadState({
       try {
         const messages = data.results || []
 
-        const formattedMessages: Thread = messages.map((msg: RawMessage) => ({
-          id: msg.id,
-          text: msg.media_content,
-          owner: msg.owner,
-          timestamp: new Date(msg.created_at).getTime(),
-          vote: msg.vote_type,
-        }))
+        const formattedMessages: Thread = messages.map((msg: RawMessage) => {
+          if (msg.media_type === 'pending_confirmation') {
+            try {
+              const parsed = JSON.parse(msg.media_content)
+              return {
+                id: String(msg.id),
+                text: parsed.text ?? msg.media_content,
+                owner: msg.owner,
+                timestamp: new Date(msg.created_at).getTime(),
+                vote: msg.vote_type,
+                mediaType: msg.media_type,
+                planData: parsed.plan,
+              }
+            } catch (e) {
+              console.error('Failed to parse pending_confirmation content:', e)
+            }
+          }
+          return {
+            id: String(msg.id),
+            text: msg.media_content,
+            owner: msg.owner,
+            timestamp: new Date(msg.created_at).getTime(),
+            vote: msg.vote_type,
+            mediaType: msg.media_type,
+          }
+        })
 
         setThread(formattedMessages)
       } catch (error) {


### PR DESCRIPTION
## Summary

**Issue**: QOV-1295

Adds a confirmation banner when the copilot requests user approval before executing a write action.      

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
|  | <img width="1512" height="955" alt="image" src="https://github.com/user-attachments/assets/d2b53a89-1cf2-4f33-922f-c16718bf50a7" /> |


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
