### PR TITLE
fix(variables): improve empty state

### DIFF
--- a/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.spec.tsx
@@ -288,10 +288,14 @@ describe('ExternalSecretsTab', () => {
     )
 
     await userEvent.click(screen.getByRole('button', { name: /add secret/i }))
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Add secret as variable' }))
 
     const modalContent = openModal.mock.calls[0][0].content as ReactElement<{
       onSubmit: (secret: AddSecretModalSubmitData) => Promise<void>
+      isFile?: boolean
     }>
+
+    expect(modalContent.props.isFile).toBe(false)
 
     await modalContent.props.onSubmit({
       name: 'MY_EXTERNAL_SECRET',
@@ -313,6 +317,43 @@ describe('ExternalSecretsTab', () => {
       },
     })
     expect(onCreateSecret).toHaveBeenCalled()
+  })
+
+  it('should open the file secret creation modal from the empty state dropdown', async () => {
+    const openModal = jest.fn()
+    useModalMock.mockReturnValue({
+      openModal,
+      closeModal: jest.fn(),
+    })
+    useVariablesMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as ReturnType<typeof useVariables>)
+    useVariablesSecretManagersMock.mockReturnValue({
+      secretManagers: [
+        {
+          id: 'sm-1',
+          name: 'Prod secret manager',
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+          endpoint: { mode: 'AWS_SECRET_MANAGER' },
+          authentication: { mode: 'STS' },
+        },
+      ],
+      hasClusterSecretManagerConfigured: true,
+      clusterId: 'cluster-id',
+    })
+
+    const { userEvent } = renderWithProviders(<ExternalSecretsTab scope="APPLICATION" parentId="service-id" />)
+
+    await userEvent.click(screen.getByRole('button', { name: /add secret/i }))
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Add secret as file' }))
+
+    const modalContent = openModal.mock.calls[0][0].content as ReactElement<{
+      isFile?: boolean
+    }>
+
+    expect(modalContent.props.isFile).toBe(true)
   })
 
   it('should call delete callback after deleting an external secret', async () => {

--- a/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.spec.tsx
@@ -288,13 +288,16 @@ describe('ExternalSecretsTab', () => {
     )
 
     await userEvent.click(screen.getByRole('button', { name: /add secret/i }))
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Add secret as variable' }))
 
     const modalContent = openModal.mock.calls[0][0].content as ReactElement<{
       scope?: string
       onSubmit: (secret: AddSecretModalSubmitData) => Promise<void>
+      isFile?: boolean
     }>
 
     expect(modalContent.props.scope).toBe('APPLICATION')
+    expect(modalContent.props.isFile).toBe(false)
 
     await modalContent.props.onSubmit({
       name: 'MY_EXTERNAL_SECRET',
@@ -346,12 +349,52 @@ describe('ExternalSecretsTab', () => {
     const { userEvent } = renderWithProviders(<ExternalSecretsTab scope="ENVIRONMENT" parentId="environment-id" />)
 
     await userEvent.click(screen.getByRole('button', { name: /add secret/i }))
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Add secret as variable' }))
 
     const modalContent = openModal.mock.calls[0][0].content as ReactElement<{
       scope?: string
+      isFile?: boolean
     }>
 
     expect(modalContent.props.scope).toBe('ENVIRONMENT')
+    expect(modalContent.props.isFile).toBe(false)
+  })
+
+  it('should open the file secret creation modal from the empty state dropdown', async () => {
+    const openModal = jest.fn()
+    useModalMock.mockReturnValue({
+      openModal,
+      closeModal: jest.fn(),
+    })
+    useVariablesMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as ReturnType<typeof useVariables>)
+    useVariablesSecretManagersMock.mockReturnValue({
+      secretManagers: [
+        {
+          id: 'sm-1',
+          name: 'Prod secret manager',
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+          endpoint: { mode: 'AWS_SECRET_MANAGER' },
+          authentication: { mode: 'STS' },
+        },
+      ],
+      hasClusterSecretManagerConfigured: true,
+      clusterId: 'cluster-id',
+    })
+
+    const { userEvent } = renderWithProviders(<ExternalSecretsTab scope="APPLICATION" parentId="service-id" />)
+
+    await userEvent.click(screen.getByRole('button', { name: /add secret/i }))
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Add secret as file' }))
+
+    const modalContent = openModal.mock.calls[0][0].content as ReactElement<{
+      isFile?: boolean
+    }>
+
+    expect(modalContent.props.isFile).toBe(true)
   })
 
   it('should call delete callback after deleting an external secret', async () => {

--- a/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
@@ -74,6 +74,36 @@ type ExternalSecretRow = {
 
 const columnHelper = createColumnHelper<ExternalSecretRow>()
 
+type AddSecretDropdownProps = {
+  color?: 'brand' | 'neutral'
+  onSelect: (isFile: boolean) => void
+}
+
+function AddSecretDropdown({ color = 'brand', onSelect }: AddSecretDropdownProps) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <Button color={color} variant="solid" size="md" type="button">
+          <Icon iconName="circle-plus" iconStyle="regular" />
+          Add secret
+          <Icon iconName="angle-down" />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content className="w-[240px]">
+        {ADD_SECRET_OPTIONS.map((option) => (
+          <DropdownMenu.Item
+            key={option.value}
+            icon={<Icon iconName={option.icon} />}
+            onSelect={() => onSelect(option.value === 'file')}
+          >
+            {option.label}
+          </DropdownMenu.Item>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  )
+}
+
 export type ExternalSecretsTabProps = {
   scope: VariableScope
   parentId: string
@@ -308,19 +338,7 @@ export function ExternalSecretsTab({
       title: 'No external secrets yet',
       description: 'Add a secret or connect a secret manager to sync external secrets.',
       icon: 'lock-keyhole' as const,
-      actions: (
-        <Button
-          color="neutral"
-          size="md"
-          variant="solid"
-          type="button"
-          disabled={!hasClusterSecretManagerConfigured}
-          onClick={() => handleOpenAddSecret(false)}
-        >
-          <Icon iconName="circle-plus" iconStyle="regular" />
-          Add secret
-        </Button>
-      ),
+      actions: <AddSecretDropdown color="neutral" onSelect={handleOpenAddSecret} />,
     }
   }, [clusterId, handleOpenAddSecret, hasClusterSecretManagerConfigured, organizationId, secrets.length])
 
@@ -518,26 +536,7 @@ export function ExternalSecretsTab({
               value={search}
               onChange={(e) => setSearch(e.target.value)}
             />
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <Button color="brand" variant="solid" size="md">
-                  <Icon iconName="circle-plus" iconStyle="regular" />
-                  Add secret
-                  <Icon iconName="chevron-down" className="text-[10px]" />
-                </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content className="w-[240px]">
-                {ADD_SECRET_OPTIONS.map((option) => (
-                  <DropdownMenu.Item
-                    key={option.value}
-                    icon={<Icon iconName={option.icon} />}
-                    onSelect={() => handleOpenAddSecret(option.value === 'file')}
-                  >
-                    {option.label}
-                  </DropdownMenu.Item>
-                ))}
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
+            <AddSecretDropdown onSelect={handleOpenAddSecret} />
           </div>
         </div>
       )}

--- a/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
@@ -75,6 +75,36 @@ type ExternalSecretRow = {
 
 const columnHelper = createColumnHelper<ExternalSecretRow>()
 
+type AddSecretDropdownProps = {
+  color?: 'brand' | 'neutral'
+  onSelect: (isFile: boolean) => void
+}
+
+function AddSecretDropdown({ color = 'brand', onSelect }: AddSecretDropdownProps) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <Button color={color} variant="solid" size="md" type="button">
+          <Icon iconName="circle-plus" iconStyle="regular" />
+          Add secret
+          <Icon iconName="angle-down" />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content className="w-[240px]">
+        {ADD_SECRET_OPTIONS.map((option) => (
+          <DropdownMenu.Item
+            key={option.value}
+            icon={<Icon iconName={option.icon} />}
+            onSelect={() => onSelect(option.value === 'file')}
+          >
+            {option.label}
+          </DropdownMenu.Item>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  )
+}
+
 export type ExternalSecretsTabProps = {
   scope: VariableScope
   parentId: string
@@ -314,19 +344,7 @@ export function ExternalSecretsTab({
       title: 'No external secrets yet',
       description: 'Add a secret or connect a secret manager to sync external secrets.',
       icon: 'lock-keyhole' as const,
-      actions: (
-        <Button
-          color="neutral"
-          size="md"
-          variant="solid"
-          type="button"
-          disabled={!hasClusterSecretManagerConfigured}
-          onClick={() => handleOpenAddSecret(false)}
-        >
-          <Icon iconName="circle-plus" iconStyle="regular" />
-          Add secret
-        </Button>
-      ),
+      actions: <AddSecretDropdown color="neutral" onSelect={handleOpenAddSecret} />,
     }
   }, [clusterId, handleOpenAddSecret, hasClusterSecretManagerConfigured, organizationId, secrets.length])
 
@@ -524,26 +542,7 @@ export function ExternalSecretsTab({
               value={search}
               onChange={(e) => setSearch(e.target.value)}
             />
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <Button color="brand" variant="solid" size="md">
-                  <Icon iconName="circle-plus" iconStyle="regular" />
-                  Add secret
-                  <Icon iconName="chevron-down" className="text-[10px]" />
-                </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content className="w-[240px]">
-                {ADD_SECRET_OPTIONS.map((option) => (
-                  <DropdownMenu.Item
-                    key={option.value}
-                    icon={<Icon iconName={option.icon} />}
-                    onSelect={() => handleOpenAddSecret(option.value === 'file')}
-                  >
-                    {option.label}
-                  </DropdownMenu.Item>
-                ))}
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
+            <AddSecretDropdown onSelect={handleOpenAddSecret} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

**Issue**:

This PR improves the empty state of [the "External secrets" tab](http://localhost:4200/organization/460616f0-94da-4d35-b631-6fa4ed08eb9a/project/2479bd82-f40b-4baf-95ce-eedbaec62212/environment/8460453b-8555-4066-b0ca-ce95a7435074/service/a71d2ee6-5eb5-48f0-843c-6f0e01d9c6f1/variables/external-secrets). We used to have a single "Add secret" button, but we were missing the "Add secret as file" option. This PR adds it.


## Screenshots / Recordings

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/39a6cb1c-09d0-4c76-bb10-ddd0ff94490e" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
