### PR TITLE
fix(gcp): fix GCP WIF selection on cluster mirroring registry

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/image-registry.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/image-registry.tsx
@@ -5,8 +5,8 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { useCluster } from '@qovery/domains/clusters/feature'
 import {
   ContainerRegistryForm,
-  getDefaultType,
-  getPayloadConfig,
+  getContainerRegistryDefaultType,
+  getContainerRegistryPayloadConfig,
   useContainerRegistries,
   useEditContainerRegistry,
 } from '@qovery/domains/organizations/feature'
@@ -56,7 +56,7 @@ function ImageRegistrySettings() {
   const methods = useForm<ContainerRegistryRequest & { type: 'STATIC' | 'STS' | 'WIF' }>({
     mode: 'onChange',
     defaultValues: {
-      type: getDefaultType(containerRegistry),
+      type: getContainerRegistryDefaultType(containerRegistry),
       ...containerRegistry,
     },
   })
@@ -72,7 +72,7 @@ function ImageRegistrySettings() {
       containerRegistryId: containerRegistry.id,
       containerRegistryRequest: {
         ...rest,
-        config: getPayloadConfig({
+        config: getContainerRegistryPayloadConfig({
           type,
           kind: rest.kind,
           config: containerRegistryRequest.config,

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/image-registry.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/image-registry.tsx
@@ -5,6 +5,8 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { useCluster } from '@qovery/domains/clusters/feature'
 import {
   ContainerRegistryForm,
+  getDefaultType,
+  getPayloadConfig,
   useContainerRegistries,
   useEditContainerRegistry,
 } from '@qovery/domains/organizations/feature'
@@ -51,10 +53,10 @@ function ImageRegistrySettings() {
   const { mutate: editContainerRegistry, isLoading: isLoadingEditContainerRegistry } = useEditContainerRegistry()
   const { data: cluster } = useCluster({ organizationId, clusterId })
 
-  const methods = useForm<ContainerRegistryRequest & { type: 'STATIC' | 'STS' }>({
+  const methods = useForm<ContainerRegistryRequest & { type: 'STATIC' | 'STS' | 'WIF' }>({
     mode: 'onChange',
     defaultValues: {
-      type: containerRegistry?.config?.role_arn ? 'STS' : 'STATIC',
+      type: getDefaultType(containerRegistry),
       ...containerRegistry,
     },
   })
@@ -70,16 +72,11 @@ function ImageRegistrySettings() {
       containerRegistryId: containerRegistry.id,
       containerRegistryRequest: {
         ...rest,
-        config:
-          type === 'STS'
-            ? {
-                role_arn: containerRegistryRequest.config?.role_arn,
-                region: containerRegistryRequest.config?.region,
-              }
-            : {
-                role_arn: undefined,
-                ...containerRegistryRequest.config,
-              },
+        config: getPayloadConfig({
+          type,
+          kind: rest.kind,
+          config: containerRegistryRequest.config,
+        }),
       },
     })
   })

--- a/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.spec.tsx
@@ -436,6 +436,21 @@ describe('ContainerRegistryCreateEditModal', () => {
       },
     } as ContainerRegistryResponse
     expect(getDefaultType(gcpStaticRegistry)).toBe('WIF')
+
+    const gcpWifRegistryWithoutEmail = {
+      id: '4444',
+      created_at: '',
+      updated_at: '',
+      name: 'my-registry',
+      url: 'https://us-east1-docker.pkg.dev',
+      kind: ContainerRegistryKindEnum.GCP_ARTIFACT_REGISTRY,
+      config: {
+        region: 'us-east1',
+        workload_identity_provider_resource:
+          'projects/123456789/locations/global/workloadIdentityPools/qovery/providers/qovery-provider',
+      },
+    } as ContainerRegistryResponse
+    expect(getDefaultType(gcpWifRegistryWithoutEmail)).toBe('WIF')
   })
 
   it('should build payload for registry based on type and kind', () => {
@@ -470,6 +485,26 @@ describe('ContainerRegistryCreateEditModal', () => {
       project_id: 'my-project',
       region: 'europe-west1',
       service_account_email: 'qovery@my-project.iam.gserviceaccount.com',
+      workload_identity_provider_resource:
+        'projects/123456789/locations/global/workloadIdentityPools/qovery/providers/qovery-provider',
+    })
+
+    expect(
+      getPayloadConfig({
+        type: 'WIF',
+        kind: ContainerRegistryKindEnum.GCP_ARTIFACT_REGISTRY,
+        config: {
+          region: 'europe-west1',
+          workload_identity_provider_resource:
+            'projects/123456789/locations/global/workloadIdentityPools/qovery/providers/qovery-provider',
+          project_id: 'my-project',
+        } as unknown as Omit<ContainerRegistryRequest['config'], 'login_type'>,
+      })
+    ).toEqual({
+      gcp_credentials_type: 'workload_identity_federation',
+      project_id: 'my-project',
+      region: 'europe-west1',
+      service_account_email: undefined,
       workload_identity_provider_resource:
         'projects/123456789/locations/global/workloadIdentityPools/qovery/providers/qovery-provider',
     })

--- a/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.spec.tsx
@@ -11,9 +11,9 @@ import * as useCreateContainerRegistry from '../hooks/use-create-container-regis
 import * as useEditContainerRegistry from '../hooks/use-edit-container-registry/use-edit-container-registry'
 import ContainerRegistryCreateEditModal, {
   type ContainerRegistryCreateEditModalProps,
-  getDefaultType,
+  getContainerRegistryDefaultType,
+  getContainerRegistryPayloadConfig,
   getGcpProjectIdFromServiceAccountEmail,
-  getPayloadConfig,
 } from './container-registry-create-edit-modal'
 
 const useCreateContainerRegistryMockSpy = jest.spyOn(
@@ -394,7 +394,7 @@ describe('ContainerRegistryCreateEditModal', () => {
   }, 30000)
 
   it('should set default registry type based on existing registry config', () => {
-    expect(getDefaultType(undefined)).toBe('STS')
+    expect(getContainerRegistryDefaultType(undefined)).toBe('STS')
 
     const awsStaticRegistry = {
       id: '1111',
@@ -407,7 +407,7 @@ describe('ContainerRegistryCreateEditModal', () => {
         region: 'eu-west-1',
       },
     } as ContainerRegistryResponse
-    expect(getDefaultType(awsStaticRegistry)).toBe('STATIC')
+    expect(getContainerRegistryDefaultType(awsStaticRegistry)).toBe('STATIC')
 
     const awsStsRegistry = {
       id: '2222',
@@ -421,7 +421,7 @@ describe('ContainerRegistryCreateEditModal', () => {
         role_arn: 'arn:aws:iam::123456789012:role/MyRole',
       },
     } as ContainerRegistryResponse
-    expect(getDefaultType(awsStsRegistry)).toBe('STS')
+    expect(getContainerRegistryDefaultType(awsStsRegistry)).toBe('STS')
 
     const gcpStaticRegistry = {
       id: '3333',
@@ -435,7 +435,7 @@ describe('ContainerRegistryCreateEditModal', () => {
         service_account_email: 'qovery@my-project.iam.gserviceaccount.com',
       },
     } as ContainerRegistryResponse
-    expect(getDefaultType(gcpStaticRegistry)).toBe('WIF')
+    expect(getContainerRegistryDefaultType(gcpStaticRegistry)).toBe('WIF')
 
     const gcpWifRegistryWithoutEmail = {
       id: '4444',
@@ -450,12 +450,12 @@ describe('ContainerRegistryCreateEditModal', () => {
           'projects/123456789/locations/global/workloadIdentityPools/qovery/providers/qovery-provider',
       },
     } as ContainerRegistryResponse
-    expect(getDefaultType(gcpWifRegistryWithoutEmail)).toBe('WIF')
+    expect(getContainerRegistryDefaultType(gcpWifRegistryWithoutEmail)).toBe('WIF')
   })
 
   it('should build payload for registry based on type and kind', () => {
     expect(
-      getPayloadConfig({
+      getContainerRegistryPayloadConfig({
         type: 'STS',
         kind: ContainerRegistryKindEnum.ECR,
         config: {
@@ -470,7 +470,7 @@ describe('ContainerRegistryCreateEditModal', () => {
     })
 
     expect(
-      getPayloadConfig({
+      getContainerRegistryPayloadConfig({
         type: 'WIF',
         kind: ContainerRegistryKindEnum.GCP_ARTIFACT_REGISTRY,
         config: {
@@ -490,7 +490,7 @@ describe('ContainerRegistryCreateEditModal', () => {
     })
 
     expect(
-      getPayloadConfig({
+      getContainerRegistryPayloadConfig({
         type: 'WIF',
         kind: ContainerRegistryKindEnum.GCP_ARTIFACT_REGISTRY,
         config: {
@@ -510,7 +510,7 @@ describe('ContainerRegistryCreateEditModal', () => {
     })
 
     expect(
-      getPayloadConfig({
+      getContainerRegistryPayloadConfig({
         type: 'STATIC',
         kind: ContainerRegistryKindEnum.DOCKER_HUB,
         config: {

--- a/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.tsx
@@ -32,7 +32,9 @@ type ContainerRegistryCreateEditFormConfig = ContainerRegistryCreateEditFormValu
 export const getGcpProjectIdFromServiceAccountEmail = (serviceAccountEmail?: string): string | undefined =>
   serviceAccountEmail?.match(/^[^@]+@([^.]+)\.iam\.gserviceaccount\.com$/)?.[1]
 
-export const getDefaultType = (registry: ContainerRegistryResponse | undefined): 'STATIC' | 'STS' | 'WIF' => {
+export const getContainerRegistryDefaultType = (
+  registry: ContainerRegistryResponse | undefined
+): 'STATIC' | 'STS' | 'WIF' => {
   if (!registry) return 'STS'
   if (registry.kind !== ContainerRegistryKindEnum.GCP_ARTIFACT_REGISTRY) {
     return registry.config?.role_arn ? 'STS' : 'STATIC'
@@ -50,7 +52,7 @@ export const getDefaultType = (registry: ContainerRegistryResponse | undefined):
     : 'STATIC'
 }
 
-export const getPayloadConfig = ({
+export const getContainerRegistryPayloadConfig = ({
   type,
   kind,
   config,
@@ -113,7 +115,7 @@ export function ContainerRegistryCreateEditModal({
       description: registry?.description,
       url: registry?.url,
       kind: registry?.kind,
-      type: getDefaultType(registry),
+      type: getContainerRegistryDefaultType(registry),
       config: {
         username: registry?.config?.username,
         password: undefined,
@@ -173,7 +175,7 @@ export function ContainerRegistryCreateEditModal({
         containerRegistryRequest: {
           ...rest,
           kind,
-          config: getPayloadConfig({
+          config: getContainerRegistryPayloadConfig({
             type,
             kind,
             config,

--- a/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-create-edit-modal/container-registry-create-edit-modal.tsx
@@ -40,8 +40,12 @@ export const getDefaultType = (registry: ContainerRegistryResponse | undefined):
   const config = registry.config as typeof registry.config & {
     gcp_credentials_type?: string
     service_account_email?: string
+    project_id?: string
+    workload_identity_provider_resource?: string
   }
-  return config?.gcp_credentials_type === 'workload_identity_federation' || config?.service_account_email
+  return config?.gcp_credentials_type === 'workload_identity_federation' ||
+    config?.service_account_email ||
+    config?.workload_identity_provider_resource
     ? 'WIF'
     : 'STATIC'
 }
@@ -70,9 +74,11 @@ export const getPayloadConfig = ({
   }
 
   if (type === 'WIF' && kind === ContainerRegistryKindEnum.GCP_ARTIFACT_REGISTRY) {
+    const projectIdFromServiceAccount = getGcpProjectIdFromServiceAccountEmail(config?.service_account_email)
+
     return {
       gcp_credentials_type: 'workload_identity_federation' as const,
-      project_id: getGcpProjectIdFromServiceAccountEmail(config?.service_account_email),
+      project_id: projectIdFromServiceAccount ?? config?.project_id,
       region: config?.region,
       service_account_email: config?.service_account_email,
       workload_identity_provider_resource: config?.workload_identity_provider_resource,
@@ -97,6 +103,7 @@ export function ContainerRegistryCreateEditModal({
   const { enableAlertClickOutside } = useModal()
   const gcpConfig = registry?.config as ContainerRegistryResponse['config'] & {
     service_account_email?: string
+    project_id?: string
     workload_identity_provider_resource?: string
   }
   const methods = useForm<ContainerRegistryCreateEditFormValues>({
@@ -122,6 +129,7 @@ export function ContainerRegistryCreateEditModal({
         azure_subscription_id: registry?.config?.azure_subscription_id,
         azure_application_id: registry?.config?.azure_application_id,
         service_account_email: gcpConfig?.service_account_email,
+        project_id: gcpConfig?.project_id,
         workload_identity_provider_resource: gcpConfig?.workload_identity_provider_resource,
         login_type:
           registry?.config?.username || registry?.kind === ContainerRegistryKindEnum.GITHUB_ENTERPRISE_CR


### PR DESCRIPTION

## Summary
 keep GCP Artifact Registry in WIF mode for cluster mirroring settings

## Screenshots / Recordings

<img width="919" height="1070" alt="Screenshot 2026-06-09 at 15 06 58" src="https://github.com/user-attachments/assets/15ee09f9-d498-4717-9e3c-9582e3356c9b" />



<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
