### PR TITLE
fix(secret-manager): UI fixes

### DIFF
--- a/libs/domains/clusters/feature/src/lib/hooks/use-secret-manager-provider-secrets/use-secret-manager-provider-secrets.ts
+++ b/libs/domains/clusters/feature/src/lib/hooks/use-secret-manager-provider-secrets/use-secret-manager-provider-secrets.ts
@@ -6,6 +6,7 @@ interface UseClusterProps {
   namePrefix?: string
   enabled?: boolean
   suspense?: boolean
+  retry?: boolean | number
 }
 
 export function useSecretManagerProviderSecrets({
@@ -13,10 +14,12 @@ export function useSecretManagerProviderSecrets({
   namePrefix,
   enabled = true,
   suspense = false,
+  retry,
 }: UseClusterProps) {
   return useQuery({
     ...queries.clusters.listSecretManagerSecretsFromProvider({ secretManagerAccessId, namePrefix }),
     enabled: Boolean(secretManagerAccessId) && enabled,
     suspense,
+    retry,
   })
 }

--- a/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.spec.tsx
@@ -31,9 +31,7 @@ describe('AddSecretModal', () => {
   })
 
   it('should not retry provider secret requests', () => {
-    renderWithProviders(
-      <AddSecretModal secretSources={secretSources} onClose={jest.fn()} onSubmit={jest.fn()} />
-    )
+    renderWithProviders(<AddSecretModal secretSources={secretSources} onClose={jest.fn()} onSubmit={jest.fn()} />)
 
     expect(useSecretManagerProviderSecretsMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -61,6 +59,33 @@ describe('AddSecretModal', () => {
         reference: 'custom/path/db-password',
         secretManagerAccessId: 'secret-manager-access-id',
       })
+    })
+  })
+
+  it('should require acknowledgement before creating an environment-level external secret', async () => {
+    const onSubmit = jest.fn()
+    const { userEvent } = renderWithProviders(
+      <AddSecretModal secretSources={secretSources} scope="ENVIRONMENT" onClose={jest.fn()} onSubmit={onSubmit} />
+    )
+
+    expect(screen.getByText('Be careful when defining an external secret at environment level:')).toBeInTheDocument()
+
+    await userEvent.type(screen.getByLabelText('Reference'), 'custom/path/db-password')
+    await userEvent.type(screen.getByLabelText('Secret name'), 'DATABASE_PASSWORD')
+
+    expect(screen.getByRole('button', { name: 'Add secret' })).toBeDisabled()
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /I understand the secret can be fetched/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add secret' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'DATABASE_PASSWORD',
+          reference: 'custom/path/db-password',
+          secretManagerAccessId: 'secret-manager-access-id',
+        })
+      )
     })
   })
 })

--- a/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.spec.tsx
@@ -1,0 +1,66 @@
+import { useSecretManagerProviderSecrets } from '@qovery/domains/clusters/feature'
+import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { AddSecretModal, type SecretSourceOption } from './add-secret-modal'
+
+jest.mock('@qovery/domains/clusters/feature', () => ({
+  ...jest.requireActual('@qovery/domains/clusters/feature'),
+  useSecretManagerProviderSecrets: jest.fn(),
+}))
+
+describe('AddSecretModal', () => {
+  const useSecretManagerProviderSecretsMock = useSecretManagerProviderSecrets as jest.MockedFunction<
+    typeof useSecretManagerProviderSecrets
+  >
+
+  const secretSources: SecretSourceOption[] = [
+    {
+      value: 'secret-manager-access-id',
+      label: 'Prod secret manager',
+      tableLabel: 'Prod secret manager',
+      icon: 'aws',
+    },
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useSecretManagerProviderSecretsMock.mockReturnValue({
+      data: undefined,
+      isError: true,
+      isFetching: false,
+    } as ReturnType<typeof useSecretManagerProviderSecrets>)
+  })
+
+  it('should not retry provider secret requests', () => {
+    renderWithProviders(
+      <AddSecretModal secretSources={secretSources} onClose={jest.fn()} onSubmit={jest.fn()} />
+    )
+
+    expect(useSecretManagerProviderSecretsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retry: false,
+      })
+    )
+  })
+
+  it('should render reference as a text input when provider secrets fail to load', async () => {
+    const onSubmit = jest.fn()
+    const { userEvent } = renderWithProviders(
+      <AddSecretModal secretSources={secretSources} onClose={jest.fn()} onSubmit={onSubmit} />
+    )
+
+    await userEvent.type(screen.getByLabelText('Reference'), 'custom/path/db-password')
+    await userEvent.type(screen.getByLabelText('Secret name'), 'DATABASE_PASSWORD')
+    await userEvent.click(screen.getByRole('button', { name: 'Add secret' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: 'DATABASE_PASSWORD',
+        description: undefined,
+        filePath: undefined,
+        isFile: false,
+        reference: 'custom/path/db-password',
+        secretManagerAccessId: 'secret-manager-access-id',
+      })
+    })
+  })
+})

--- a/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
@@ -89,10 +89,15 @@ export function AddSecretModal({
   const secretNameValue = methods.watch('secretName')
   const selectedSourceId = methods.watch('source')
 
-  const { data: providerSecrets, isFetching: isFetchingProviderSecrets } = useSecretManagerProviderSecrets({
+  const {
+    data: providerSecrets,
+    isError: isProviderSecretsError,
+    isFetching: isFetchingProviderSecrets,
+  } = useSecretManagerProviderSecrets({
     secretManagerAccessId: selectedSourceId,
     namePrefix: debouncedReferenceInput,
     enabled: Boolean(selectedSourceId),
+    retry: false,
   })
 
   const sourceOptions = useMemo(
@@ -204,27 +209,40 @@ export function AddSecretModal({
             control={methods.control}
             rules={{ required: 'Please enter a reference.' }}
             render={({ field, fieldState: { error } }) => (
-              <InputSelect
-                className="mb-3 w-full"
-                label="Reference"
-                options={referenceOptions}
-                value={field.value}
-                onChange={(value) => {
-                  const selected = value as string
-                  field.onChange(selected)
-                  if (!secretNameValue) {
-                    const inferredName = selected.split('/').pop()?.toUpperCase()
-                    if (inferredName) {
-                      methods.setValue('secretName', inferredName, { shouldValidate: true })
-                    }
-                  }
-                }}
-                onInputChange={(value) => setReferenceInput(value)}
-                isSearchable
-                isCreatable
-                isLoading={isFetchingProviderSecrets || referenceInput !== debouncedReferenceInput}
-                error={error?.message}
-              />
+              <>
+                {isProviderSecretsError ? (
+                  <InputText
+                    className="mb-3 w-full"
+                    name={field.name}
+                    label="Reference"
+                    value={field.value}
+                    onChange={(event) => field.onChange(event.target.value)}
+                    error={error?.message}
+                  />
+                ) : (
+                  <InputSelect
+                    className="mb-3 w-full"
+                    label="Reference"
+                    options={referenceOptions}
+                    value={field.value}
+                    onChange={(value) => {
+                      const selected = value as string
+                      field.onChange(selected)
+                      if (!secretNameValue) {
+                        const inferredName = selected.split('/').pop()?.toUpperCase()
+                        if (inferredName) {
+                          methods.setValue('secretName', inferredName, { shouldValidate: true })
+                        }
+                      }
+                    }}
+                    onInputChange={(value) => setReferenceInput(value)}
+                    isSearchable
+                    isCreatable
+                    isLoading={isFetchingProviderSecrets || referenceInput !== debouncedReferenceInput}
+                    error={error?.message}
+                  />
+                )}
+              </>
             )}
           />
 

--- a/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
@@ -4,7 +4,8 @@ import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import { getSecretManagerProvider } from '@qovery/domains/clusters/data-access'
 import { useSecretManagerProviderSecrets } from '@qovery/domains/clusters/feature'
-import { Icon, InputSelect, InputText, InputTextArea, ModalCrud, useModal } from '@qovery/shared/ui'
+import { type VariableScope } from '@qovery/domains/variables/data-access'
+import { Checkbox, Icon, InputSelect, InputText, InputTextArea, ModalCrud, useModal } from '@qovery/shared/ui'
 import { useDebounce } from '@qovery/shared/util-hooks'
 
 export type SecretSourceOption = {
@@ -48,6 +49,7 @@ interface AddSecretModalProps {
   isFile?: boolean
   mode?: 'create' | 'edit'
   initialSecret?: AddSecretModalInitialSecret
+  scope?: VariableScope
   onClose: () => void
   onSubmit: (secret: AddSecretModalSubmitData) => void | Promise<void>
 }
@@ -58,6 +60,7 @@ type AddSecretFormValues = {
   path: string
   secretName: string
   description: string
+  acknowledgeEnvironmentSecretCost: boolean
 }
 
 export function AddSecretModal({
@@ -66,6 +69,7 @@ export function AddSecretModal({
   isFile = false,
   mode = 'create',
   initialSecret,
+  scope,
   onClose,
   onSubmit,
 }: AddSecretModalProps) {
@@ -78,6 +82,7 @@ export function AddSecretModal({
       path: initialSecret?.filePath ?? '',
       secretName: initialSecret?.name ?? '',
       description: initialSecret?.description ?? '',
+      acknowledgeEnvironmentSecretCost: false,
     },
     mode: 'onChange',
   })
@@ -85,6 +90,7 @@ export function AddSecretModal({
   const [referenceInput, setReferenceInput] = useState('')
   const debouncedReferenceInput = useDebounce(referenceInput, 300)
   const isDirty = methods.formState.isDirty
+  const shouldDisplayEnvironmentAcknowledgement = scope === 'ENVIRONMENT' && mode === 'create'
 
   const secretNameValue = methods.watch('secretName')
   const selectedSourceId = methods.watch('source')
@@ -292,6 +298,47 @@ export function AddSecretModal({
               />
             )}
           />
+
+          {shouldDisplayEnvironmentAcknowledgement && (
+            <div className="mb-3 rounded border border-warning-subtle bg-surface-warning-subtle p-4 text-sm text-neutral">
+              <div className="mb-3 flex flex-row gap-3">
+                <Icon iconName="triangle-exclamation" iconStyle="regular" className="mt-1 text-warning" />
+                <div>
+                  <p className="font-medium">Be careful when defining an external secret at environment level:</p>
+                  <ul className="list-disc pl-3">
+                    <li>The secret value will be fetched individually for each service running in the environment.</li>
+                    <li>
+                      With many services, this multiplies the number of secret fetches and can significantly increase
+                      your cloud costs.
+                    </li>
+                  </ul>
+                  <p className="mt-3">
+                    Prefer service-level secrets when only a subset of services need access to the value.
+                  </p>
+                </div>
+              </div>
+
+              <Controller
+                name="acknowledgeEnvironmentSecretCost"
+                control={methods.control}
+                rules={{ validate: (value) => value || 'Please acknowledge the environment-level secret impact.' }}
+                render={({ field }) => (
+                  <div className="flex flex-row gap-3">
+                    <Checkbox
+                      name={field.name}
+                      id="acknowledge_environment_secret_cost"
+                      className="mt-0.5 shrink-0"
+                      checked={field.value}
+                      onCheckedChange={(checked) => field.onChange(checked === true)}
+                    />
+                    <label htmlFor="acknowledge_environment_secret_cost" className="font-medium">
+                      I understand the secret can be fetched once per service and may increase cloud costs
+                    </label>
+                  </div>
+                )}
+              />
+            </div>
+          )}
         </>
       </ModalCrud>
     </FormProvider>

--- a/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
@@ -221,8 +221,11 @@ export function AddSecretModal({
                     className="mb-3 w-full"
                     name={field.name}
                     label="Reference"
-                    value={field.value}
-                    onChange={(event) => field.onChange(event.target.value)}
+                    value={field.value || referenceInput}
+                    onChange={(event) => {
+                      field.onChange(event.target.value)
+                      setReferenceInput(event.target.value)
+                    }}
                     error={error?.message}
                   />
                 ) : (

--- a/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.spec.tsx
@@ -290,8 +290,11 @@ describe('ExternalSecretsTab', () => {
     await userEvent.click(screen.getByRole('button', { name: /add secret/i }))
 
     const modalContent = openModal.mock.calls[0][0].content as ReactElement<{
+      scope?: string
       onSubmit: (secret: AddSecretModalSubmitData) => Promise<void>
     }>
+
+    expect(modalContent.props.scope).toBe('APPLICATION')
 
     await modalContent.props.onSubmit({
       name: 'MY_EXTERNAL_SECRET',
@@ -313,6 +316,42 @@ describe('ExternalSecretsTab', () => {
       },
     })
     expect(onCreateSecret).toHaveBeenCalled()
+  })
+
+  it('should pass the scope when creating an environment-scoped external secret', async () => {
+    const openModal = jest.fn()
+    useModalMock.mockReturnValue({
+      openModal,
+      closeModal: jest.fn(),
+    })
+    useVariablesMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as ReturnType<typeof useVariables>)
+    useVariablesSecretManagersMock.mockReturnValue({
+      secretManagers: [
+        {
+          id: 'sm-1',
+          name: 'Prod secret manager',
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+          endpoint: { mode: 'AWS_SECRET_MANAGER' },
+          authentication: { mode: 'STS' },
+        },
+      ],
+      hasClusterSecretManagerConfigured: true,
+      clusterId: 'cluster-id',
+    })
+
+    const { userEvent } = renderWithProviders(<ExternalSecretsTab scope="ENVIRONMENT" parentId="environment-id" />)
+
+    await userEvent.click(screen.getByRole('button', { name: /add secret/i }))
+
+    const modalContent = openModal.mock.calls[0][0].content as ReactElement<{
+      scope?: string
+    }>
+
+    expect(modalContent.props.scope).toBe('ENVIRONMENT')
   })
 
   it('should call delete callback after deleting an external secret', async () => {

--- a/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
@@ -202,6 +202,7 @@ export function ExternalSecretsTab({
             secretSources={secretSources}
             defaultSource={secretSources[0]}
             isFile={isFile}
+            scope={scope}
             onClose={closeModal}
             onSubmit={handleCreateSecret}
           />
@@ -212,7 +213,7 @@ export function ExternalSecretsTab({
         },
       })
     },
-    [closeModal, handleCreateSecret, openModal, secretSources]
+    [closeModal, handleCreateSecret, openModal, scope, secretSources]
   )
 
   const handleOpenEditSecret = useCallback(

--- a/libs/shared/ui/src/lib/components/modal/modal.tsx
+++ b/libs/shared/ui/src/lib/components/modal/modal.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { type ReactElement, type ReactNode, cloneElement, useContext, useEffect, useState } from 'react'
 import { Icon } from '../icon/icon'
 import useModalAlert from '../modal-alert/use-modal-alert/use-modal-alert'
+import { isToastInteraction } from '../toast/toast'
 import { ModalContext } from './modal-root'
 
 export interface ModalProps {
@@ -30,12 +31,6 @@ export interface ModalProps {
 
 export interface ModalContentProps {
   setOpen?: (open: boolean) => void
-}
-
-const isToastInteraction = (event: Event | React.MouseEvent) => {
-  const target = event.target
-
-  return target instanceof HTMLElement && Boolean(target.closest('[data-sonner-toaster], .z-toast'))
 }
 
 export const Modal = (props: ModalProps) => {

--- a/libs/shared/ui/src/lib/components/modal/modal.tsx
+++ b/libs/shared/ui/src/lib/components/modal/modal.tsx
@@ -32,6 +32,12 @@ export interface ModalContentProps {
   setOpen?: (open: boolean) => void
 }
 
+const isToastInteraction = (event: Event | React.MouseEvent) => {
+  const target = event.target
+
+  return target instanceof HTMLElement && Boolean(target.closest('[data-sonner-toaster], .z-toast'))
+}
+
 export const Modal = (props: ModalProps) => {
   const {
     children,
@@ -81,6 +87,12 @@ export const Modal = (props: ModalProps) => {
   ])
 
   const handleOutsideClick = (event: React.MouseEvent) => {
+    if (isToastInteraction(event)) {
+      event.preventDefault()
+      event.stopPropagation()
+      return
+    }
+
     if (alertClickOutside) {
       event.preventDefault()
       setModalAlertOpen(true)
@@ -127,6 +139,15 @@ export const Modal = (props: ModalProps) => {
         <Dialog.Content
           onPointerDownOutside={(event) => {
             event.preventDefault()
+            if (isToastInteraction(event.detail.originalEvent)) {
+              event.stopPropagation()
+            }
+          }}
+          onInteractOutside={(event) => {
+            if (isToastInteraction(event.detail.originalEvent)) {
+              event.preventDefault()
+              event.stopPropagation()
+            }
           }}
           style={
             fullScreen

--- a/libs/shared/ui/src/lib/components/toast/toast.spec.tsx
+++ b/libs/shared/ui/src/lib/components/toast/toast.spec.tsx
@@ -20,6 +20,15 @@ describe('Toast', () => {
     expect(baseElement).toBeTruthy()
   })
 
+  it('should expose the toast interaction root class', async () => {
+    const { baseElement } = renderWithProviders(<ToastBehavior />)
+
+    toast('success', 'my-title')
+
+    await screen.findByText('my-title')
+    expect(baseElement.querySelector('.toast-interaction-root')).toBeInTheDocument()
+  })
+
   it('should render a title and a description', async () => {
     renderWithProviders(<ToastBehavior />)
 

--- a/libs/shared/ui/src/lib/components/toast/toast.tsx
+++ b/libs/shared/ui/src/lib/components/toast/toast.tsx
@@ -1,3 +1,4 @@
+import { type MouseEvent } from 'react'
 import { Toaster, toast as sonnerToast } from 'sonner'
 import { twMerge } from '@qovery/shared/util-js'
 import { type ToastStatus } from '../../utils/toast'
@@ -25,6 +26,14 @@ export interface CustomToastProps {
   action?: ToastActionProps
 }
 
+const toastInteractionClassName = 'toast-interaction-root'
+
+export const isToastInteraction = (event: Event | MouseEvent) => {
+  const target = event.target
+
+  return target instanceof HTMLElement && Boolean(target.closest(`.${toastInteractionClassName}`))
+}
+
 const statusIcon: Record<
   ToastStatus,
   { iconName: 'circle-check' | 'circle-xmark' | 'triangle-exclamation'; className: string }
@@ -41,7 +50,12 @@ export function CustomToast({ id, status, title, description, action }: CustomTo
   }
 
   return (
-    <div className="relative w-full rounded-lg border border-neutral bg-surface-neutral p-3 font-sans shadow-sm">
+    <div
+      className={twMerge(
+        toastInteractionClassName,
+        'relative w-full rounded-lg border border-neutral bg-surface-neutral p-3 font-sans shadow-sm'
+      )}
+    >
       <Button
         type="button"
         size="xs"

--- a/libs/shared/ui/src/lib/components/toast/toast.tsx
+++ b/libs/shared/ui/src/lib/components/toast/toast.tsx
@@ -75,7 +75,7 @@ export function CustomToast({ id, status, title, description, action }: CustomTo
 }
 
 export function ToastBehavior() {
-  return <Toaster position="top-right" className="!font-sans" gap={8} />
+  return <Toaster position="top-right" className="!font-sans z-toast" gap={8} />
 }
 
 export default ToastBehavior

--- a/libs/shared/ui/src/lib/components/toast/toast.tsx
+++ b/libs/shared/ui/src/lib/components/toast/toast.tsx
@@ -75,7 +75,7 @@ export function CustomToast({ id, status, title, description, action }: CustomTo
 }
 
 export function ToastBehavior() {
-  return <Toaster position="top-right" className="!font-sans z-toast" gap={8} />
+  return <Toaster position="top-right" className="z-toast !font-sans" gap={8} />
 }
 
 export default ToastBehavior


### PR DESCRIPTION
## Summary

**Issue**: This PR introduces a few UI improvements for the Secret Manager feature.

Changes:
- Adds an acknowledgment checkbox when creating an external secret at the environment level, warning the users about the high costs it implies.
- In the "Add secret" modal, we are fetching the API to retrieve the list of references. This API endpoint can sometimes fail with a 4xx error if the IAM permissions are not correctly set. The fix is to disable the auto-retry strategy and turn the InputSelect into a simple InputText. That way users will still be able to manually type the value they want.
- When an error is returned by "Add secret" modal's POST request, the toast was not clickable because clicking outside the modal was considered as an attempt to dismiss it. A new `isToastInteraction` helper has been added to detect whether the toast has been clicked or not.

## Screenshots / Recordings

<img width="584" height="837" alt="SCR-20260609-nqfg" src="https://github.com/user-attachments/assets/0393d2de-291c-4e38-9c0d-d6e08ab9a640" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
