### PR TITLE
fix(cluster): remove Free label and add Beta tooltip on add-ons

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
@@ -14,7 +14,7 @@ import {
   useEditCluster,
 } from '@qovery/domains/clusters/feature'
 import { SettingsHeading } from '@qovery/shared/console-shared'
-import { Badge, Button, DropdownMenu, Icon, Section, useModal, useModalConfirmation } from '@qovery/shared/ui'
+import { Badge, Button, DropdownMenu, Icon, Section, Tooltip, useModal, useModalConfirmation } from '@qovery/shared/ui'
 import { useDocumentTitle, useSupportChat } from '@qovery/shared/util-hooks'
 
 const SECRET_MANAGER_EARLY_ACCESS_FORM_SLUG = 'request-access-secrets-manager'
@@ -167,7 +167,6 @@ function RouteComponent() {
               <AddonToggleCard
                 title="KEDA autoscaler"
                 description="Qovery KEDA autoscaler allows you to add event-based autoscaling on all the services running on this cluster."
-                badge={{ label: 'Free', color: 'green' }}
                 activated={cluster?.keda?.enabled ?? false}
                 onToggle={handleToggleKeda}
                 loading={isKedaUpdating}
@@ -180,12 +179,11 @@ function RouteComponent() {
                   <div className="flex flex-col gap-1">
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-medium text-neutral">Secret manager integration</span>
-                      <Badge size="sm" radius="full" variant="surface" color="green" className="text-[13px]">
-                        Free
-                      </Badge>
-                      <Badge size="sm" radius="full" variant="surface" color="purple" className="text-[13px]">
-                        Beta
-                      </Badge>
+                      <Tooltip content="This feature is in beta. Behaviour and accessibility may change when released in GA.">
+                        <Badge size="sm" radius="full" variant="surface" color="purple" className="text-[13px]">
+                          Beta
+                        </Badge>
+                      </Tooltip>
                     </div>
                     <p className="text-sm text-neutral-subtle">
                       Link any secret manager on your cluster to add external secrets variables to all the services
@@ -233,12 +231,11 @@ function RouteComponent() {
                   <div className="flex flex-col gap-1">
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-medium text-neutral">Secret manager integration</span>
-                      <Badge size="sm" radius="full" variant="surface" color="green" className="text-[13px]">
-                        Free
-                      </Badge>
-                      <Badge size="sm" radius="full" variant="surface" color="purple" className="text-[13px]">
-                        Beta
-                      </Badge>
+                      <Tooltip content="This feature is in beta. Behaviour and accessibility may change when released in GA.">
+                        <Badge size="sm" radius="full" variant="surface" color="purple" className="text-[13px]">
+                          Beta
+                        </Badge>
+                      </Tooltip>
                     </div>
                     <p className="text-sm text-neutral-subtle">
                       Connect your external secret manager to Qovery and expose secrets as variables across the services

--- a/libs/domains/clusters/feature/src/lib/cluster-addons/addon-toggle-card.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-addons/addon-toggle-card.tsx
@@ -3,7 +3,7 @@ import { Badge, Button, Icon } from '@qovery/shared/ui'
 export interface AddonToggleCardProps {
   title: string
   description: string
-  badge: { label: string; color: 'yellow' | 'green' }
+  badge?: { label: string; color: 'yellow' | 'green' }
   activated: boolean
   onToggle: () => void
   activateLabel?: string
@@ -24,9 +24,11 @@ export function AddonToggleCard({
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-neutral">{title}</span>
-          <Badge size="sm" radius="full" variant="surface" color={badge.color} className="text-[13px]">
-            {badge.label}
-          </Badge>
+          {badge && (
+            <Badge size="sm" radius="full" variant="surface" color={badge.color} className="text-[13px]">
+              {badge.label}
+            </Badge>
+          )}
         </div>
         <p className="text-sm text-neutral-subtle">{description}</p>
       </div>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.spec.tsx
@@ -1,3 +1,4 @@
+import { Provider as TooltipProvider } from '@radix-ui/react-tooltip'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { CloudProviderEnum, type SecretManagerAccess } from 'qovery-typescript-axios'
 import { type PropsWithChildren } from 'react'
@@ -59,7 +60,9 @@ const mockContextValue: ClusterContainerCreateContextInterface = {
 function getWrapper(contextValue: ClusterContainerCreateContextInterface = mockContextValue) {
   return function Wrapper({ children }: PropsWithChildren) {
     return (
-      <ClusterContainerCreateContext.Provider value={contextValue}>{children}</ClusterContainerCreateContext.Provider>
+      <TooltipProvider>
+        <ClusterContainerCreateContext.Provider value={contextValue}>{children}</ClusterContainerCreateContext.Provider>
+      </TooltipProvider>
     )
   }
 }

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -2,7 +2,18 @@ import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { type Cluster, type SecretManagerAccess } from 'qovery-typescript-axios'
 import { type FormEventHandler, useEffect, useMemo } from 'react'
 import { isSameSecretManagerAccess } from '@qovery/domains/clusters/data-access'
-import { Badge, Button, DropdownMenu, FunnelFlowBody, Heading, Icon, Link, Section, useModal } from '@qovery/shared/ui'
+import {
+  Badge,
+  Button,
+  DropdownMenu,
+  FunnelFlowBody,
+  Heading,
+  Icon,
+  Link,
+  Section,
+  Tooltip,
+  useModal,
+} from '@qovery/shared/ui'
 import {
   AddonToggleCard,
   SECRET_MANAGER_OPTIONS,
@@ -107,7 +118,6 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
             <AddonToggleCard
               title="KEDA autoscaler"
               description="Qovery KEDA autoscaler allows you to add event-based autoscaling on all your services running on this cluster."
-              badge={{ label: 'Free', color: 'green' }}
               activated={addonsData.kedaActivated}
               onToggle={() =>
                 setAddonsData((addonsData) => ({ ...addonsData, kedaActivated: !addonsData.kedaActivated }))
@@ -121,12 +131,11 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                 <div className="flex flex-col gap-1">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-neutral">Secret manager integration</span>
-                    <Badge size="sm" radius="full" variant="surface" color="green" className="text-ssm">
-                      Free
-                    </Badge>
-                    <Badge size="sm" radius="full" variant="surface" color="purple" className="text-ssm">
-                      Beta
-                    </Badge>
+                    <Tooltip content="This feature is in beta. Behaviour and accessibility may change when released in GA.">
+                      <Badge size="sm" radius="full" variant="surface" color="purple" className="text-ssm">
+                        Beta
+                      </Badge>
+                    </Tooltip>
                   </div>
                   <p className="text-sm text-neutral-subtle">
                     Link any secret manager on your cluster to add external secrets variables to all the services


### PR DESCRIPTION
## Summary

- Remove the "Free" green badge from KEDA autoscaler and secret manager integration add-ons in both the cluster settings page and cluster creation flow
- Make the `badge` prop optional on `AddonToggleCard` with a null-guard in the render
- Add a tooltip on the "Beta" badge for secret manager integration: *"This feature is in beta. Behaviour and accessibility may change when released in GA."*
- Fix test setup in `step-addons.spec.tsx` to include `TooltipProvider` in the wrapper (required by Radix `Tooltip`)

<img width="857" height="524" alt="image" src="https://github.com/user-attachments/assets/eaaaf46c-d221-4127-a6e3-47ebbbefe1e7" />

