### PR TITLE
fix(services): searching among services to create led to 404

### DIFF
--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -108,4 +108,23 @@ describe('ServiceNew', () => {
       ).toBeInTheDocument()
     })
   })
+
+  it('should keep default service links valid when rendered from search results', async () => {
+    const { container, userEvent } = renderWithProviders(
+      <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
+    )
+
+    await userEvent.type(screen.getByPlaceholderText('Search…'), 'application')
+
+    expect(
+      container.querySelector(
+        'a[href="/organization/org-1/project/project-1/environment/env-1/service/create/application"]'
+      )
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        'a[href="/organization/org-1/project/project-1/environment/env-1/organization/org-1/project/project-1/environment/env-1/service/create/application"]'
+      )
+    ).not.toBeInTheDocument()
+  })
 })

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -403,8 +403,8 @@ function CardService({
     )
   }
 
-  const pathSuffix = link ?? (type && slug ? servicePathSuffix(type, slug, 'current') : undefined)
-  const to = pathSuffix ? getServicesPath(organizationId, projectId, environmentId, pathSuffix) : undefined
+  const pathSuffix = type && slug ? servicePathSuffix(type, slug, 'current') : undefined
+  const to = link ?? (pathSuffix ? getServicesPath(organizationId, projectId, environmentId, pathSuffix) : undefined)
 
   if (!to) return null
 


### PR DESCRIPTION
## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1781097950460149)

Quick PR fixing a bug where users were landing on a 404 page when searching among available services in the template list and clicking on the matching item (for example Application or Helm)

## Screenshots / Recordings

### Before

https://github.com/user-attachments/assets/b1a5face-9631-4c43-866d-9d67ca4f8ffa

### After

https://github.com/user-attachments/assets/a3b908b5-4dda-4bf9-9f7e-fbdbbf1dca9d


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
