### PR TITLE
fix(external-secret): Handle FILE_EXTERNAL_SECRET

### DIFF
--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -600,6 +600,7 @@ export function CreateUpdateVariableModal(props: CreateUpdateVariableModalProps)
           { mode: 'CREATE', type: 'FILE' },
           { mode: 'CREATE', type: 'BUILT_IN' },
           { mode: 'CREATE', type: 'EXTERNAL_SECRET' },
+          { mode: 'CREATE', type: 'FILE_EXTERNAL_SECRET' },
           () => {
             return Promise.resolve()
           }

--- a/libs/domains/variables/util/src/lib/is-external-secret-variable/is-external-secret-variable.ts
+++ b/libs/domains/variables/util/src/lib/is-external-secret-variable/is-external-secret-variable.ts
@@ -1,5 +1,5 @@
 import { type VariableResponse } from 'qovery-typescript-axios'
 
 export function isExternalSecretVariable(variable: VariableResponse): boolean {
-  return variable.variable_type === 'EXTERNAL_SECRET'
+  return variable.variable_type === 'EXTERNAL_SECRET' || variable.variable_type === 'FILE_EXTERNAL_SECRET'
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mermaid": "11.6.0",
     "monaco-editor": "0.53.0",
     "posthog-js": "1.345.1",
-    "qovery-typescript-axios": "1.1.902",
+    "qovery-typescript-axios": "1.1.909",
     "react": "18.3.1",
     "react-country-flag": "3.0.2",
     "react-datepicker": "4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6342,7 +6342,7 @@ __metadata:
     prettier: 3.2.5
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
-    qovery-typescript-axios: 1.1.902
+    qovery-typescript-axios: 1.1.909
     qovery-ws-typescript-axios: 0.1.586
     react: 18.3.1
     react-country-flag: 3.0.2
@@ -25836,12 +25836,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:1.1.902":
-  version: 1.1.902
-  resolution: "qovery-typescript-axios@npm:1.1.902"
+"qovery-typescript-axios@npm:1.1.909":
+  version: 1.1.909
+  resolution: "qovery-typescript-axios@npm:1.1.909"
   dependencies:
     axios: 1.15.2
-  checksum: 637171e52f62862d748d66d494034617afe8f083aaac43cb56d1e7bd9944ed19bd572c46dfde094b03155a0123939dcd98463d33cefc3bd5c4cee7c117c139a3
+  checksum: 91234b867f2b005b31637d3b0c212b6ef952caa8cd10cffb13c62db06ff59e36cdc6a1c4c820c0d10fce2dde4a006dfac74e8eca8d48b5e7211a5e7bccde250b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Today we handle correctly an external secret, but not a file external secret. Type was missing in the openapi.


## Screenshots / Recordings
<img width="1268" height="943" alt="image" src="https://github.com/user-attachments/assets/92f43b60-59bc-41ee-b8e6-077b2adf1b2d" />
