### PR TITLE
chore(feature-flags): remove stale gates

### DIFF
--- a/apps/console/src/app/components/header/header.tsx
+++ b/apps/console/src/app/components/header/header.tsx
@@ -1,6 +1,5 @@
 import { Link, useParams } from '@tanstack/react-router'
 import posthog from 'posthog-js'
-import { useFeatureFlagVariantKey } from 'posthog-js/react'
 import { Suspense, useCallback } from 'react'
 import { AssistantTrigger } from '@qovery/shared/assistant/feature'
 import { DevopsCopilotButton } from '@qovery/shared/devops-copilot/feature'
@@ -24,7 +23,6 @@ export function Separator() {
 
 export function Header() {
   const { organizationId = '' } = useParams({ strict: false })
-  const isDevopsCopilotEnabled = useFeatureFlagVariantKey('devops-copilot')
   const handleFeedbackClick = useCallback(() => {
     posthog.capture('feedback_button_clicked_new_navigation')
   }, [])
@@ -51,7 +49,7 @@ export function Header() {
                 Feedback
               </Button>
               <AssistantTrigger />
-              {isDevopsCopilotEnabled && <DevopsCopilotButton />}
+              <DevopsCopilotButton />
               <UserMenu />
             </div>
           </div>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/settings/argocd-integration.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/settings/argocd-integration.tsx
@@ -1,5 +1,4 @@
-import { Navigate, createFileRoute, useParams } from '@tanstack/react-router'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
+import { createFileRoute } from '@tanstack/react-router'
 import { SettingsArgoCdIntegration } from '@qovery/domains/organizations/feature'
 
 export const Route = createFileRoute('/_authenticated/organization/$organizationId/settings/argocd-integration')({
@@ -7,16 +6,5 @@ export const Route = createFileRoute('/_authenticated/organization/$organization
 })
 
 function RouteComponent() {
-  const { organizationId = '' } = useParams({ strict: false })
-  const isArgoCdEnabled = useFeatureFlagEnabled('argocd')
-
-  if (!organizationId || typeof isArgoCdEnabled === 'undefined') {
-    return null
-  }
-
-  if (isArgoCdEnabled === false) {
-    return <Navigate to="/organization/$organizationId/settings/general" params={{ organizationId }} replace />
-  }
-
   return <SettingsArgoCdIntegration />
 }

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/settings/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/settings/route.tsx
@@ -1,5 +1,4 @@
 import { Outlet, createFileRoute, useParams, useRouterState } from '@tanstack/react-router'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { useUserRole } from '@qovery/shared/iam/feature'
 import { Sidebar } from '@qovery/shared/ui'
 
@@ -13,7 +12,6 @@ function RouteComponent() {
     location: { pathname },
   } = useRouterState()
   const { roles } = useUserRole()
-  const isArgoCdEnabled = useFeatureFlagEnabled('argocd')
 
   const isOrganizationAdmin = roles.some((role) => role.includes(`organization:${organizationId}:admin`))
 
@@ -115,7 +113,7 @@ function RouteComponent() {
     teamLink,
     billingPlansLink,
     labelsAnnotationsLink,
-    ...(isArgoCdEnabled ? [argoCdIntegrationLink] : []),
+    argoCdIntegrationLink,
     containerRegistriesLink,
     helmRepositoriesLink,
     cloudCredentialsLink,

--- a/libs/shared/devops-copilot/feature/src/lib/ai-copilot-settings/ai-copilot-settings.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/ai-copilot-settings/ai-copilot-settings.tsx
@@ -1,4 +1,3 @@
-import { useFeatureFlagVariantKey } from 'posthog-js/react'
 import { type Organization } from 'qovery-typescript-axios'
 import { useAuth } from '@qovery/shared/auth'
 import { SettingsHeading } from '@qovery/shared/console-shared'
@@ -19,7 +18,6 @@ export interface AICopilotSettingsProps {
 
 export function AICopilotSettings(props: AICopilotSettingsProps) {
   const { organization } = props
-  const isDevopsCopilotPanelFeatureFlag = useFeatureFlagVariantKey('devops-copilot')
 
   const { data: userAccount } = useUserAccount()
   const { user: authUser } = useAuth()
@@ -48,10 +46,6 @@ export function AICopilotSettings(props: AICopilotSettingsProps) {
 
   const handleToggleCopilot = (enabled: boolean) => {
     updateConfigMutation.mutate({ enabled, readOnly: true, userEmail })
-  }
-
-  if (!isDevopsCopilotPanelFeatureFlag) {
-    return null
   }
 
   return (


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Clean up stale feature flags:
- remove `argocd` gate from organization settings
- remove `devops-copilot` gate from header and AI Copilot settings

Once, it's release need to remove it in [PostHog](https://us.posthog.com/project/3828/feature_flags?tab=overview)

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
