### PR TITLE
feat(devops-copilot): remove read-write feature-flag & move the toggl…

### DIFF
--- a/libs/shared/devops-copilot/feature/src/lib/ai-copilot-settings/section-ai-copilot-configuration/section-ai-copilot-configuration.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/ai-copilot-settings/section-ai-copilot-configuration/section-ai-copilot-configuration.tsx
@@ -1,4 +1,3 @@
-import { useFeatureFlagVariantKey } from 'posthog-js/react'
 import { type Organization } from 'qovery-typescript-axios'
 import { useState } from 'react'
 import {
@@ -65,15 +64,11 @@ export function SectionAICopilotConfiguration({
 }: SectionAICopilotConfigurationProps) {
   const { openModal, closeModal } = useModal()
   const [selectedMode, setSelectedMode] = useState<'read-only' | 'read-write' | null>(null)
-  const hasReadWriteAccess = useFeatureFlagVariantKey('copilot-read-write-access')
   const mode = selectedMode ?? currentMode
   const hasUnsavedChanges = selectedMode !== null && selectedMode !== currentMode
 
   const handleSaveMode = () => {
     if (selectedMode) {
-      if (selectedMode === 'read-write' && !hasReadWriteAccess) {
-        return
-      }
       onModeChange(selectedMode)
       setSelectedMode(null)
     }
@@ -170,24 +165,20 @@ export function SectionAICopilotConfiguration({
             </div>
 
             <div className="space-y-4">
-              {hasReadWriteAccess && (
-                <>
-                  <div className="space-y-1">
-                    <label className="text-sm font-medium text-neutral">Access Mode</label>
-                    <p className="text-xs text-neutral-subtle">
-                      Choose the level of access the AI Copilot will have on your organization
-                    </p>
-                  </div>
-                  <InputSelect
-                    value={mode}
-                    onChange={(value) => setSelectedMode(value as 'read-write' | 'read-only')}
-                    options={modeOptions}
-                    portal
-                    label="Right access"
-                    disabled={isUpdating}
-                  />
-                </>
-              )}
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-neutral">Access Mode</label>
+                <p className="text-xs text-neutral-subtle">
+                  Choose the level of access the AI Copilot will have on your organization
+                </p>
+              </div>
+              <InputSelect
+                value={mode}
+                onChange={(value) => setSelectedMode(value as 'read-write' | 'read-only')}
+                options={modeOptions}
+                portal
+                label="Right access"
+                disabled={isUpdating}
+              />
 
               {hasUnsavedChanges && (
                 <div className="flex items-center gap-3">

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-panel.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/devops-copilot-panel.tsx
@@ -367,10 +367,7 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
               threadId={threadId}
               threads={threads}
               currentThreadHistoryTitle={currentThreadHistoryTitle}
-              userAccess={readOnlyData?.user_access}
-              isReadOnly={isReadOnly}
               setIsReadOnly={setIsReadOnly}
-              threadLength={thread.length}
               expand={expand}
               setExpand={setExpand}
               handleOnClose={handleOnClose}
@@ -509,7 +506,13 @@ export function DevopsCopilotPanel({ onClose, style }: DevopsCopilotPanelProps) 
                       }}
                     />
                   </div>
-                  <StatusFooter isReadOnly={isReadOnly} status={appStatus?.status} />
+                  <StatusFooter
+                    isReadOnly={isReadOnly}
+                    status={appStatus?.status}
+                    setIsReadOnly={setIsReadOnly}
+                    userAccess={readOnlyData?.user_access}
+                    threadLength={thread.length}
+                  />
                 </div>
               </div>
             ) : (

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/header/header.spec.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/header/header.spec.tsx
@@ -60,10 +60,7 @@ describe('Header', () => {
     threadId: undefined,
     threads: [],
     currentThreadHistoryTitle: 'New conversation',
-    userAccess: undefined,
-    isReadOnly: true,
     setIsReadOnly: mockSetIsReadOnly,
-    threadLength: 0,
     expand: false,
     setExpand: mockSetExpand,
     handleOnClose: mockHandleOnClose,
@@ -98,24 +95,6 @@ describe('Header', () => {
     })
 
     expect(screen.getByText('My Custom Thread')).toBeInTheDocument()
-  })
-
-  it('shows and toggles read-only mode when allowed', async () => {
-    const { userEvent } = renderHeader({ userAccess: { read_only: false }, isReadOnly: true })
-
-    expect(screen.getByText('Read-only')).toBeInTheDocument()
-
-    const buttons = screen.getAllByRole('button')
-    await userEvent.click(buttons[0])
-
-    expect(mockSetIsReadOnly).toHaveBeenCalledWith(false)
-  })
-
-  it('hides the read-only toggle once the thread has messages', () => {
-    renderHeader({ userAccess: { read_only: false }, threadLength: 2 })
-
-    expect(screen.queryByText('Read-only')).not.toBeInTheDocument()
-    expect(screen.queryByText('Read-write')).not.toBeInTheDocument()
   })
 
   it('resets the conversation when clicking new chat', async () => {

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/header/header.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/header/header.tsx
@@ -1,5 +1,4 @@
 import * as Dialog from '@radix-ui/react-dialog'
-import clsx from 'clsx'
 import { type MutableRefObject } from 'react'
 import { Badge, Button, DropdownMenu, Icon, Tooltip } from '@qovery/shared/ui'
 import { QOVERY_FEEDBACK_URL, QOVERY_FORUM_URL } from '@qovery/shared/util-const'
@@ -9,10 +8,7 @@ interface HeaderProps {
   threadId?: string
   threads: Array<{ id: string; title: string }>
   currentThreadHistoryTitle: string
-  userAccess?: { read_only?: boolean }
-  isReadOnly: boolean
   setIsReadOnly: (value: boolean) => void
-  threadLength: number
   expand: boolean
   setExpand: (value: boolean) => void
   handleOnClose: () => void
@@ -27,10 +23,7 @@ export function Header({
   threadId,
   threads,
   currentThreadHistoryTitle,
-  userAccess,
-  isReadOnly,
   setIsReadOnly,
-  threadLength,
   expand,
   setExpand,
   handleOnClose,
@@ -58,37 +51,6 @@ export function Header({
             Beta
           </Badge>
         </Tooltip>
-        {userAccess?.read_only === false && threadLength === 0 && (
-          <>
-            <div className="mx-1 h-5 w-[1px] bg-surface-neutral-component"></div>
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-neutral-subtle">{isReadOnly ? 'Read-only' : 'Read-write'}</span>
-              <Tooltip content={isReadOnly ? 'Enable read-write mode' : 'Disable read-write mode'} delayDuration={400}>
-                <button
-                  type="button"
-                  onClick={() => setIsReadOnly(!isReadOnly)}
-                  className={clsx(
-                    'relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand',
-                    {
-                      'bg-surface-warning-solid': !isReadOnly,
-                      'bg-surface-neutral-componentActive': isReadOnly,
-                    }
-                  )}
-                >
-                  <span
-                    className={clsx(
-                      'inline-block h-3.5 w-3.5 transform rounded-full bg-surface-neutralInvert transition-transform',
-                      {
-                        'translate-x-[18px]': !isReadOnly,
-                        'translate-x-0.5': isReadOnly,
-                      }
-                    )}
-                  />
-                </button>
-              </Tooltip>
-            </div>
-          </>
-        )}
       </div>
       <div className="flex items-center gap-1">
         <DropdownMenu.Root>

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.spec.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.spec.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event'
 import { render, screen } from '@qovery/shared/util-tests'
 import { StatusFooter } from './status-footer'
 
@@ -16,14 +17,8 @@ describe('StatusFooter', () => {
   }
 
   describe('rendering', () => {
-    it('should render read-only mode text when isReadOnly is true', () => {
+    it('should always render read-write mode text', () => {
       render(<StatusFooter {...defaultProps} />)
-
-      expect(screen.getByText('Read-only mode')).toBeInTheDocument()
-    })
-
-    it('should render read-write mode text when isReadOnly is false', () => {
-      render(<StatusFooter {...defaultProps} isReadOnly={false} />)
 
       expect(screen.getByText('Read-write mode')).toBeInTheDocument()
     })
@@ -73,7 +68,8 @@ describe('StatusFooter', () => {
 
     it('should call setIsReadOnly when toggle is clicked', async () => {
       const mockSetIsReadOnly = jest.fn()
-      const { userEvent } = render(
+      const user = userEvent.setup()
+      render(
         <StatusFooter
           {...defaultProps}
           isReadOnly={true}
@@ -84,7 +80,7 @@ describe('StatusFooter', () => {
       )
 
       const buttons = screen.getAllByRole('button')
-      await userEvent.click(buttons[0])
+      await user.click(buttons[1])
 
       expect(mockSetIsReadOnly).toHaveBeenCalledWith(false)
     })
@@ -158,10 +154,10 @@ describe('StatusFooter', () => {
   })
 
   describe('combined states', () => {
-    it('should render both read-only mode and operational status', () => {
+    it('should render both read-write mode and operational status', () => {
       render(<StatusFooter {...defaultProps} isReadOnly={true} status="OPERATIONAL" />)
 
-      expect(screen.getByText('Read-only mode')).toBeInTheDocument()
+      expect(screen.getByText('Read-write mode')).toBeInTheDocument()
       expect(screen.getByText('All systems operational')).toBeInTheDocument()
     })
 

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.spec.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.spec.tsx
@@ -41,6 +41,53 @@ describe('StatusFooter', () => {
       const tooltipButton = screen.getByRole('button')
       expect(tooltipButton).toBeInTheDocument()
     })
+
+    it('should render toggle switch when user can toggle and thread is empty', () => {
+      const setIsReadOnly = jest.fn()
+      render(
+        <StatusFooter
+          {...defaultProps}
+          setIsReadOnly={setIsReadOnly}
+          userAccess={{ read_only: false }}
+          threadLength={0}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+      expect(buttons.length).toBeGreaterThan(0)
+    })
+
+    it('should not render toggle switch when thread has messages', () => {
+      const setIsReadOnly = jest.fn()
+      render(
+        <StatusFooter
+          {...defaultProps}
+          setIsReadOnly={setIsReadOnly}
+          userAccess={{ read_only: false }}
+          threadLength={2}
+        />
+      )
+
+      expect(screen.getByTestId('icon-circle-info')).toBeInTheDocument()
+    })
+
+    it('should call setIsReadOnly when toggle is clicked', async () => {
+      const mockSetIsReadOnly = jest.fn()
+      const { userEvent } = render(
+        <StatusFooter
+          {...defaultProps}
+          isReadOnly={true}
+          setIsReadOnly={mockSetIsReadOnly}
+          userAccess={{ read_only: false }}
+          threadLength={0}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+      await userEvent.click(buttons[0])
+
+      expect(mockSetIsReadOnly).toHaveBeenCalledWith(false)
+    })
   })
 
   describe('app status', () => {

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.spec.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.spec.tsx
@@ -1,5 +1,4 @@
-import userEvent from '@testing-library/user-event'
-import { render, screen } from '@qovery/shared/util-tests'
+import { fireEvent, render, screen } from '@qovery/shared/util-tests'
 import { StatusFooter } from './status-footer'
 
 jest.mock('@qovery/shared/ui', () => ({
@@ -66,9 +65,8 @@ describe('StatusFooter', () => {
       expect(screen.getByTestId('icon-circle-info')).toBeInTheDocument()
     })
 
-    it('should call setIsReadOnly when toggle is clicked', async () => {
+    it('should call setIsReadOnly when toggle is clicked', () => {
       const mockSetIsReadOnly = jest.fn()
-      const user = userEvent.setup()
       render(
         <StatusFooter
           {...defaultProps}
@@ -80,7 +78,7 @@ describe('StatusFooter', () => {
       )
 
       const buttons = screen.getAllByRole('button')
-      await user.click(buttons[1])
+      fireEvent.click(buttons[1])
 
       expect(mockSetIsReadOnly).toHaveBeenCalledWith(false)
     })

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { match } from 'ts-pattern'
 import { Icon, Tooltip } from '@qovery/shared/ui'
 import { QOVERY_STATUS_URL } from '@qovery/shared/util-const'
@@ -6,9 +7,12 @@ import { DotStatus } from '../../dot-status/dot-status'
 export interface StatusFooterProps {
   isReadOnly: boolean
   status?: 'OPERATIONAL' | 'MAJOROUTAGE' | 'MINOROUTAGE' | 'PARTIALOUTAGE'
+  setIsReadOnly?: (value: boolean) => void
+  userAccess?: { read_only?: boolean }
+  threadLength?: number
 }
 
-export function StatusFooter({ isReadOnly, status }: StatusFooterProps) {
+export function StatusFooter({ isReadOnly, status, setIsReadOnly, userAccess, threadLength }: StatusFooterProps) {
   const statusText = status
     ? match(status)
         .with('OPERATIONAL', () => 'All systems operational')
@@ -27,10 +31,11 @@ export function StatusFooter({ isReadOnly, status }: StatusFooterProps) {
         .exhaustive()
     : null
 
+  const canToggle = userAccess?.read_only === false && threadLength === 0 && setIsReadOnly
+
   return (
-    <div className="flex w-full items-center justify-between">
+    <div className="flex w-full items-center justify-between pt-1">
       <div className="inline-flex items-center gap-2 text-xs text-neutral-subtle">
-        <span>{isReadOnly ? 'Read-only mode' : 'Read-write mode'}</span>
         <Tooltip
           content={isReadOnly ? "Your Copilot can't make any changes" : 'It can perform actions'}
           classNameContent="z-10"
@@ -39,6 +44,32 @@ export function StatusFooter({ isReadOnly, status }: StatusFooterProps) {
             <Icon iconName="circle-info" className="text-neutral-subtle" />
           </button>
         </Tooltip>
+        <span>Read-write mode</span>
+        {canToggle && (
+          <Tooltip content={isReadOnly ? 'Enable read-write mode' : 'Disable read-write mode'} delayDuration={400}>
+            <button
+              type="button"
+              onClick={() => setIsReadOnly!(!isReadOnly)}
+              className={clsx(
+                'relative inline-flex h-4 w-7 flex-shrink-0 items-center rounded-full transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand',
+                {
+                  'bg-surface-warning-solid': !isReadOnly,
+                  'bg-surface-neutral-componentActive': isReadOnly,
+                }
+              )}
+            >
+              <span
+                className={clsx(
+                  'inline-block h-2.5 w-2.5 transform rounded-full bg-surface-neutralInvert transition-transform',
+                  {
+                    'translate-x-[14px]': !isReadOnly,
+                    'translate-x-0.5': isReadOnly,
+                  }
+                )}
+              />
+            </button>
+          </Tooltip>
+        )}
       </div>
       {statusText && statusColor ? (
         <a

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/status-footer/status-footer.tsx
@@ -31,7 +31,7 @@ export function StatusFooter({ isReadOnly, status, setIsReadOnly, userAccess, th
         .exhaustive()
     : null
 
-  const canToggle = userAccess?.read_only === false && threadLength === 0 && setIsReadOnly
+  const canToggle = userAccess?.read_only === false && threadLength === 0 && !!setIsReadOnly
 
   return (
     <div className="flex w-full items-center justify-between pt-1">
@@ -49,7 +49,7 @@ export function StatusFooter({ isReadOnly, status, setIsReadOnly, userAccess, th
           <Tooltip content={isReadOnly ? 'Enable read-write mode' : 'Disable read-write mode'} delayDuration={400}>
             <button
               type="button"
-              onClick={() => setIsReadOnly!(!isReadOnly)}
+              onClick={() => setIsReadOnly?.(!isReadOnly)}
               className={clsx(
                 'relative inline-flex h-4 w-7 flex-shrink-0 items-center rounded-full transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand',
                 {


### PR DESCRIPTION
## Summary

Remove the read-write feature flag as we can release the feature to everyone and move the toggle in the bottom.

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="545" height="672" alt="image" src="https://github.com/user-attachments/assets/83ef61c7-7afa-49f9-b11e-e66cb9b9b2e5" /> | <img width="671" height="751" alt="image" src="https://github.com/user-attachments/assets/f601b77b-c590-4429-9ca2-4c97d2f54987" /> |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
