### PR TITLE
feat(QOV-1999): GKE allow private nodes for user provided VPC

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/gcp-vpc-feature/gcp-vpc-feature.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/gcp-vpc-feature/gcp-vpc-feature.spec.tsx
@@ -8,6 +8,8 @@ describe('GCPVpcFeature', () => {
 
     expect(screen.getByText('Deploy on an existing VPC')).toBeInTheDocument()
     expect(screen.getByLabelText('VPC Name')).toBeInTheDocument()
+    expect(screen.getByText('Private nodes')).toBeInTheDocument()
+    expect(screen.getByText('Make nodes private (no public IP), traffic will go through gateway.')).toBeInTheDocument()
     expect(screen.getByText('Set additional ranges')).toBeInTheDocument()
   })
 

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/gcp-vpc-feature/gcp-vpc-feature.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/gcp-vpc-feature/gcp-vpc-feature.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
-import { Button, ExternalLink, InputText } from '@qovery/shared/ui'
+import { Button, ExternalLink, InputText, InputToggle } from '@qovery/shared/ui'
 
 export function GCPVpcFeature() {
   const { control } = useFormContext()
@@ -53,6 +53,21 @@ export function GCPVpcFeature() {
               By default: the project id used is the one specified in the credentials file
             </p>
           </>
+        )}
+      />
+      <Controller
+        name="gcp_existing_vpc.private_nodes"
+        control={control}
+        render={({ field }) => (
+          <InputToggle
+            title="Private nodes"
+            description="Make nodes private (no public IP), traffic will go through gateway."
+            className="mb-4 ml-4 mt-1"
+            value={field.value ?? false}
+            onChange={field.onChange}
+            align="top"
+            small
+          />
         )}
       />
       {!openOptions && (

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.tsx
@@ -354,6 +354,7 @@ export function StepFeatures({ organizationId, onSubmit }: StepFeaturesProps) {
             gcp_existing_vpc: existingVpcData?.vpc_name
               ? {
                   vpc_name: existingVpcData?.vpc_name ?? '',
+                  private_nodes: existingVpcData?.private_nodes ?? false,
                   vpc_project_id: existingVpcData?.vpc_project_id,
                   subnetwork_name: existingVpcData?.subnetwork_name,
                   ip_range_services_name: existingVpcData?.ip_range_services_name,

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.spec.tsx
@@ -174,4 +174,27 @@ describe('StepSummaryPresentation', () => {
 
     expect(screen.getByText('static_ips_enabled=true, static_ips_count=2')).toBeInTheDocument()
   })
+
+  it('should render GCP existing VPC private nodes in summary', () => {
+    renderWithProviders(
+      <StepSummaryPresentation
+        {...defaultProps}
+        generalData={{
+          ...defaultProps.generalData,
+          cloud_provider: CloudProviderEnum.GCP,
+        }}
+        featuresData={{
+          vpc_mode: 'EXISTING_VPC',
+          gcp_existing_vpc: {
+            vpc_name: 'test-vpc',
+            private_nodes: true,
+          },
+          features: {},
+        }}
+      />
+    )
+
+    expect(screen.getByText('Private nodes:')).toBeInTheDocument()
+    expect(screen.getByText('true')).toBeInTheDocument()
+  })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
@@ -594,6 +594,10 @@ export function StepSummaryPresentation(props: StepSummaryPresentationProps) {
                       <strong className="font-medium">VPC name: </strong>
                       {props.featuresData.gcp_existing_vpc.vpc_name}
                     </li>
+                    <li>
+                      <strong className="font-medium">Private nodes: </strong>
+                      {props.featuresData.gcp_existing_vpc.private_nodes ? 'true' : 'false'}
+                    </li>
                     {props.featuresData.gcp_existing_vpc.vpc_project_id && (
                       <li>
                         <strong className="font-medium">VPC Project ID: </strong>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.spec.tsx
@@ -276,6 +276,59 @@ describe('StepSummary', () => {
     ])
   })
 
+  it('should send GCP private nodes in existing VPC payload on create', async () => {
+    mockContextValue.generalData = {
+      name: 'test-gcp-cluster',
+      description: 'description',
+      cloud_provider: CloudProviderEnum.GCP,
+      region: 'europe-west1',
+      installation_type: 'MANAGED',
+      production: false,
+      credentials: 'cred-id',
+      credentials_name: 'cred-name',
+    }
+    mockContextValue.featuresData = {
+      vpc_mode: 'EXISTING_VPC',
+      gcp_existing_vpc: {
+        vpc_name: 'test-vpc',
+        private_nodes: true,
+        vpc_project_id: 'test-project',
+        ip_range_services_name: 'services-range',
+        ip_range_pods_name: 'pods-range',
+        additional_ip_range_pods_names: 'pods-range-2,pods-range-3',
+        subnetwork_name: 'subnet-a',
+      },
+      features: {},
+    }
+
+    mockCreateCluster.mockResolvedValue({ id: 'cluster-123' })
+    mockEditCloudProviderInfo.mockResolvedValue({})
+
+    const { userEvent } = renderWithProviders(<StepSummary {...defaultProps} />, { wrapper: Wrapper })
+
+    await userEvent.click(screen.getByTestId('button-create'))
+
+    await waitFor(() => {
+      expect(mockCreateCluster).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: 'org-123',
+          clusterRequest: expect.objectContaining({
+            cloud_provider: 'GCP',
+            features: expect.arrayContaining([
+              expect.objectContaining({
+                id: 'EXISTING_VPC',
+                value: expect.objectContaining({
+                  vpc_name: 'test-vpc',
+                  private_nodes: true,
+                }),
+              }),
+            ]),
+          }),
+        })
+      )
+    })
+  })
+
   it('should emit default NAT_GATEWAY for GCP when only STATIC_IP is in form data', async () => {
     mockContextValue.generalData = {
       name: 'test-gcp-cluster',

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary.tsx
@@ -299,6 +299,7 @@ export function StepSummary({ organizationId }: StepSummaryProps) {
             id: 'EXISTING_VPC',
             value: {
               vpc_name: featuresData?.gcp_existing_vpc?.vpc_name ?? '',
+              private_nodes: featuresData?.gcp_existing_vpc?.private_nodes ?? false,
               vpc_project_id: featuresData?.gcp_existing_vpc?.vpc_project_id,
               ip_range_services_name: featuresData?.gcp_existing_vpc?.ip_range_services_name,
               ip_range_pods_name: featuresData?.gcp_existing_vpc?.ip_range_pods_name,

--- a/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.spec.tsx
@@ -301,6 +301,42 @@ describe('ClusterNetworkSettings', () => {
     expect(screen.queryByText('Static IP count')).not.toBeInTheDocument()
   })
 
+  it('should render GCP existing VPC private nodes', () => {
+    const gcpClusterWithExistingVpc: Cluster = {
+      ...mockCluster,
+      cloud_provider: 'GCP',
+      features: [
+        {
+          id: 'EXISTING_VPC',
+          value_object: {
+            type: 'GCP_USER_PROVIDED_NETWORK',
+            value: {
+              vpc_name: 'test-vpc',
+              private_nodes: true,
+            },
+          },
+        },
+      ],
+    } as Cluster
+
+    mockUseCluster.mockReturnValue({
+      data: gcpClusterWithExistingVpc,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCluster>)
+    mockUseClusterRoutingTable.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useClusterRoutingTable>)
+
+    renderWithProviders(
+      wrapWithReactHookForm(<ClusterNetworkSettings organizationId="org-id" clusterId="cluster-id" />)
+    )
+
+    expect(screen.getByText('Private nodes')).toBeInTheDocument()
+    expect(screen.getByText('Make nodes private (no public IP), traffic will go through gateway.')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('true')).toBeInTheDocument()
+  })
+
   it('should keep NAT_GATEWAY visible for GCP when STATIC_IP feature is missing', () => {
     const gcpClusterWithoutStaticIp: Cluster = {
       ...mockCluster,

--- a/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
@@ -161,6 +161,8 @@ function AWSExistingVPC({ feature }: { feature: ClusterFeatureAwsExistingVpc }) 
 }
 
 function GcpExistingVPC({ feature }: { feature: ClusterFeatureGcpExistingVpc }) {
+  const gcpFeature = feature as ClusterFeatureGcpExistingVpc & { private_nodes?: boolean | null }
+
   return (
     <div className="flex flex-col justify-between gap-4 rounded border border-neutral bg-surface-neutral-subtle p-4">
       <div>
@@ -173,6 +175,14 @@ function GcpExistingVPC({ feature }: { feature: ClusterFeatureGcpExistingVpc }) 
         </ExternalLink>
       </div>
       <InputText name="vpc_id" label="VPC Name" value={feature.vpc_name} disabled />
+      <InputToggle
+        title="Private nodes"
+        description="Make nodes private (no public IP), traffic will go through gateway."
+        value={gcpFeature.private_nodes ?? false}
+        align="top"
+        small
+        disabled
+      />
       {feature.vpc_project_id && (
         <InputText name="vpc_project_id" label="External project id" value={feature.vpc_project_id} disabled />
       )}

--- a/libs/shared/interfaces/src/lib/domain/cluster-creation-flow.interface.ts
+++ b/libs/shared/interfaces/src/lib/domain/cluster-creation-flow.interface.ts
@@ -85,6 +85,7 @@ export type ClusterFeaturesData = {
   }
   gcp_existing_vpc?: {
     vpc_name: string
+    private_nodes: boolean
     vpc_project_id?: string
     ip_range_services_name?: string
     ip_range_pods_name?: string

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mermaid": "11.6.0",
     "monaco-editor": "0.53.0",
     "posthog-js": "1.345.1",
-    "qovery-typescript-axios": "1.1.909",
+    "qovery-typescript-axios": "1.1.911",
     "react": "18.3.1",
     "react-country-flag": "3.0.2",
     "react-datepicker": "4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6342,7 +6342,7 @@ __metadata:
     prettier: 3.2.5
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
-    qovery-typescript-axios: 1.1.909
+    qovery-typescript-axios: 1.1.911
     qovery-ws-typescript-axios: 0.1.586
     react: 18.3.1
     react-country-flag: 3.0.2
@@ -25836,12 +25836,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:1.1.909":
-  version: 1.1.909
-  resolution: "qovery-typescript-axios@npm:1.1.909"
+"qovery-typescript-axios@npm:1.1.911":
+  version: 1.1.911
+  resolution: "qovery-typescript-axios@npm:1.1.911"
   dependencies:
     axios: 1.15.2
-  checksum: 91234b867f2b005b31637d3b0c212b6ef952caa8cd10cffb13c62db06ff59e36cdc6a1c4c820c0d10fce2dde4a006dfac74e8eca8d48b5e7211a5e7bccde250b
+  checksum: 8423357183d710334a77394aed83a79aaf981da7d2b9926d704f77be4657ca236744aee4d65ac5f9d9a521af68422f5decdcb1e9a453cf656af98c5a05249d77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ticket: QOV-1999

<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: QOV-1999

This PR allows users to activate private nodes on GKE for custom VPC.

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<img width="1358" height="948" alt="CleanShot 2026-06-15 at 15 21 41" src="https://github.com/user-attachments/assets/7549d11a-2f55-4b19-9f42-2dd9b13d371b" />
<img width="1105" height="571" alt="CleanShot 2026-06-15 at 15 20 40" src="https://github.com/user-attachments/assets/42360e57-c423-4741-a3f4-6e99a3d49e46" />




<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
