### PR TITLE
fix(buttons): add missing gap

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-actions/__snapshots__/cluster-actions.spec.tsx.snap
+++ b/libs/domains/clusters/feature/src/lib/cluster-actions/__snapshots__/cluster-actions.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`ClusterActions should match manage deployment snapshot 1`] = `
       type="button"
     >
       <div
-        class="flex h-full w-full items-center justify-center"
+        class="flex h-full w-full items-center justify-center gap-x-1.5"
         data-state="closed"
       >
         <i
@@ -143,7 +143,7 @@ exports[`ClusterActions should match other actions snapshot 1`] = `
       type="button"
     >
       <div
-        class="flex h-full w-full items-center justify-center"
+        class="flex h-full w-full items-center justify-center gap-x-1.5"
         data-state="closed"
       >
         <i
@@ -308,7 +308,7 @@ exports[`ClusterActions should match outdated snapshot 1`] = `
       type="button"
     >
       <div
-        class="flex h-full w-full items-center justify-center"
+        class="flex h-full w-full items-center justify-center gap-x-1.5"
         data-state="closed"
       >
         <i

--- a/libs/domains/clusters/feature/src/lib/cluster-actions/cluster-actions.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-actions/cluster-actions.tsx
@@ -242,7 +242,7 @@ function MenuManageDeployment({
           iconOnly={!hasTextActionButton}
         >
           <Tooltip content="Manage Deployment">
-            <div className="flex h-full w-full items-center justify-center">
+            <div className="flex h-full w-full items-center justify-center gap-x-1.5">
               <Icon iconName="rocket" />
               {hasTextActionButton && (
                 <>

--- a/libs/domains/clusters/feature/src/lib/cluster-card/__snapshots__/cluster-card.spec.tsx.snap
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/__snapshots__/cluster-card.spec.tsx.snap
@@ -147,7 +147,7 @@ exports[`ClusterCard should match snapshot 1`] = `
               type="button"
             >
               <div
-                class="flex h-full w-full items-center justify-center"
+                class="flex h-full w-full items-center justify-center gap-x-1.5"
                 data-state="closed"
               >
                 <i

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -105,11 +105,9 @@ export function HeaderLogs({
                         align="start"
                       >
                         <Button variant="outline" color="neutral" size="sm" className="relative">
-                          <div className="flex items-center">
-                            <Icon iconName="link" iconStyle="regular" />
-                            {pluralize(filteredLinks.length, 'Link', 'Links')}
-                            <Icon iconName="angle-down" />
-                          </div>
+                          <Icon iconName="link" iconStyle="regular" />
+                          {pluralize(filteredLinks.length, 'Link', 'Links')}
+                          <Icon iconName="angle-down" />
                         </Button>
                       </ServiceLinksPopover>
                     )}
@@ -132,14 +130,6 @@ export function HeaderLogs({
                       <Icon iconName="code" iconStyle="regular" className="text-sm text-neutral-subtle" />
                       <span className="flex items-center gap-0.5 truncate">
                         <span className="font-normal text-neutral">{trimId(executionId ?? '')}</span>
-                        {executionId && (
-                          <CopyToClipboardButtonIcon
-                            content={executionId}
-                            tooltipContent="Copy execution id"
-                            className="opacity-0 transition-opacity group-hover:opacity-100"
-                            iconClassName="text-xs"
-                          />
-                        )}
                       </span>
                     </span>
                   </Tooltip>
@@ -155,14 +145,6 @@ export function HeaderLogs({
                 <Tooltip side="bottom" content={<span>Execution id: {environmentStatus?.last_deployment_id}</span>}>
                   <span className="group flex items-center gap-1">
                     <Icon className="text-base text-neutral-subtle" iconName="circle-info" iconStyle="regular" />
-                    {environmentStatus?.last_deployment_id && (
-                      <CopyToClipboardButtonIcon
-                        content={environmentStatus.last_deployment_id}
-                        tooltipContent="Copy execution id"
-                        className="ml-0.5 opacity-0 transition-opacity group-hover:opacity-100"
-                        iconClassName="text-xs"
-                      />
-                    )}
                   </span>
                 </Tooltip>
                 {!isNotDeployedOrStopped && !isManagedDatabase && filteredLinks.length > 0 && (
@@ -176,11 +158,9 @@ export function HeaderLogs({
                         align="start"
                       >
                         <Button variant="outline" color="neutral" size="sm" className="relative">
-                          <div className="flex items-center">
-                            <Icon iconName="link" iconStyle="regular" />
-                            {pluralize(filteredLinks.length, 'Link', 'Links')}
-                            <Icon iconName="angle-down" />
-                          </div>
+                          <Icon iconName="link" iconStyle="regular" />
+                          {pluralize(filteredLinks.length, 'Link', 'Links')}
+                          <Icon iconName="angle-down" />
                         </Button>
                       </ServiceLinksPopover>
                     )}


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Fixed gap for dropdown button and removed visual bug with copy icon

## Screenshots / Recordings

| Before | After |
| --- | --- |
| <img width="96" height="41" alt="Screenshot 2026-06-16 at 10 25 52" src="https://github.com/user-attachments/assets/1e379b8e-1dfc-47b1-9b1e-8bf17c8e6971" /><br/><img width="126" height="61" alt="Screenshot 2026-06-16 at 10 26 17" src="https://github.com/user-attachments/assets/d9ad9af1-a7df-456b-b9c7-b736cc48efa7" /> | <img width="114" height="47" alt="Screenshot 2026-06-16 at 10 25 02" src="https://github.com/user-attachments/assets/4abf8832-2141-4838-b4b5-a3fbe8523b64" /><br/><img width="132" height="74" alt="Screenshot 2026-06-16 at 10 27 03" src="https://github.com/user-attachments/assets/26397553-f2f6-471c-b5de-0664a2ebc6fb" /> |


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
