### PR TITLE
fix: update S3 cache rule for index.html

### DIFF
--- a/.github/workflows/test-build-and-deploy.yml
+++ b/.github/workflows/test-build-and-deploy.yml
@@ -173,7 +173,10 @@ jobs:
           AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/ s3://${{ secrets.s3-bucket-name }}/  --recursive --exclude "index.html"
       - name: Copy index.html to S3 last
         run: |
-          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/index.html s3://${{ secrets.s3-bucket-name }}/
+          # index.html must never be cached: it references content-hashed assets by name,
+          # and a stale version after a new deployment causes "Importing a module script failed"
+          # in Safari (which applies heuristic caching when Cache-Control is absent).
+          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/index.html s3://${{ secrets.s3-bucket-name }}/ --cache-control "no-store"
 
   staging-smoke-test:
     name: Staging smoke test


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1781097950460149)

### "Importing a module script failed" errors
We're having a lot of "Importing a module script failed" errors. The bug seems to happen a lot on Safari, which applies heuristic caching when Cache-Control is absent, but uses a different algorithm compared to Chrome-based browsers.

When neither `Cache-Control` nor `Expires` is present, an HTTP cache may assign a heuristic freshness lifetime. This is standardized in [RFC 9111 §4.2.2](https://www.rfc-editor.org/info/rfc9111/#section-4.2.2): 
> Since origin servers do not always provide explicit expiration times, a cache MAY assign a heuristic expiration time when an explicit time is not specified, employing algorithms that use other field values (such as the Last-Modified time) to estimate a plausible expiration time. This specification does not provide specific algorithms, but it does impose worst-case constraints on their results.

The fix is for `index.html` to not be cached, by adding a `Cache-Control: 'no-cache'` header.

### Sources

[Why you should use Cache-Control: no-store on index.html](https://mifi.no/blog/why-you-should-use-cache-control-no-store-on-indexhtml/)
[HTTP Heuristic Caching](https://paulcalvano.com/2018-03-14-http-heuristic-caching-missing-cache-control-and-expires-headers-explained/)


## Screenshots / Recordings

<img width="1048" height="750" alt="image" src="https://github.com/user-attachments/assets/96554c83-b004-40d9-86e3-4a33d3012962" />

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
