### PR TITLE
fix(shell): infinite loader

### DIFF
--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.spec.tsx
@@ -12,6 +12,27 @@ jest.mock('color', () => ({
   }),
 }))
 
+jest.mock('@xterm/addon-attach', () => ({
+  __esModule: true,
+  AttachAddon: jest.fn().mockImplementation(() => ({
+    activate: jest.fn(),
+    dispose: jest.fn(),
+  })),
+}))
+
+jest.mock('@xterm/addon-fit', () => ({
+  __esModule: true,
+  FitAddon: jest.fn().mockImplementation(() => ({
+    activate: jest.fn(),
+    dispose: jest.fn(),
+    fit: jest.fn(),
+  })),
+}))
+
+jest.mock('react-xtermjs', () => ({
+  XTerm: () => <div data-testid="xterm" />,
+}))
+
 jest.mock('@qovery/state/util-queries', () => ({
   useReactQueryWsSubscription: jest.fn(),
 }))
@@ -41,6 +62,36 @@ const getLatestWsSubscriptionConfig = (): Parameters<typeof useReactQueryWsSubsc
   return latestCall[0]
 }
 
+const getLatestWsSubscriptionSearchParams = (): Record<string, string | undefined> => {
+  const { urlSearchParams } = getLatestWsSubscriptionConfig()
+
+  if (!urlSearchParams || typeof urlSearchParams !== 'object' || urlSearchParams instanceof URLSearchParams) {
+    throw new Error('Expected websocket search params to be an object.')
+  }
+
+  return urlSearchParams as Record<string, string | undefined>
+}
+
+const createWebSocketEvent = (type: string, websocket: WebSocket): Event => {
+  const event = new Event(type)
+  Object.defineProperty(event, 'target', { value: websocket })
+  return event
+}
+
+const createWebSocketCloseEvent = (websocket: WebSocket, eventInit: CloseEventInit): CloseEvent => {
+  const event = new CloseEvent('close', eventInit)
+  Object.defineProperty(event, 'target', { value: websocket })
+  return event
+}
+
+const createMockWebSocket = (): WebSocket =>
+  ({
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    send: jest.fn(),
+    readyState: WebSocket.OPEN,
+  }) as unknown as WebSocket
+
 describe('ServiceTerminal', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -63,11 +114,16 @@ describe('ServiceTerminal', () => {
 
   it('should show a retry empty state and disable subscription on terminal launch error', () => {
     renderWithProviders(<ServiceTerminal {...props} />)
+    const websocket = createMockWebSocket()
+
+    act(() => {
+      getLatestWsSubscriptionConfig().onOpen?.({} as QueryClient, createWebSocketEvent('open', websocket))
+    })
 
     act(() => {
       getLatestWsSubscriptionConfig().onClose?.(
         {} as QueryClient,
-        new CloseEvent('close', { code: 1000, reason: 'No pod exists for this application.' })
+        createWebSocketCloseEvent(websocket, { code: 1000, reason: 'No pod exists for this application.' })
       )
     })
 
@@ -90,11 +146,16 @@ describe('ServiceTerminal', () => {
     })
 
     renderWithProviders(<ServiceTerminal {...props} />)
+    const websocket = createMockWebSocket()
+
+    act(() => {
+      getLatestWsSubscriptionConfig().onOpen?.({} as QueryClient, createWebSocketEvent('open', websocket))
+    })
 
     act(() => {
       getLatestWsSubscriptionConfig().onClose?.(
         {} as QueryClient,
-        new CloseEvent('close', { code: 1000, reason: 'No pod exists for this application.' })
+        createWebSocketCloseEvent(websocket, { code: 1000, reason: 'No pod exists for this application.' })
       )
     })
 
@@ -103,11 +164,16 @@ describe('ServiceTerminal', () => {
 
   it('should restart terminal launch flow when retrying from empty state', async () => {
     const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
+    const websocket = createMockWebSocket()
+
+    act(() => {
+      getLatestWsSubscriptionConfig().onOpen?.({} as QueryClient, createWebSocketEvent('open', websocket))
+    })
 
     act(() => {
       getLatestWsSubscriptionConfig().onClose?.(
         {} as QueryClient,
-        new CloseEvent('close', { code: 1000, reason: 'No pod exists for this application.' })
+        createWebSocketCloseEvent(websocket, { code: 1000, reason: 'No pod exists for this application.' })
       )
     })
 
@@ -129,5 +195,47 @@ describe('ServiceTerminal', () => {
     await userEvent.click(firstPodOption)
 
     expect(screen.getByPlaceholderText('Select a container to connect to')).toBeInTheDocument()
+  })
+
+  it('should start a fresh terminal session when selecting a pod', async () => {
+    const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
+    const initialRequestId = getLatestWsSubscriptionSearchParams()['external_request_id']
+
+    await userEvent.click(screen.getByPlaceholderText('Select a pod to connect to'))
+    const [firstPodOption] = screen.getAllByRole('option')
+    await userEvent.click(firstPodOption)
+
+    await waitFor(() => {
+      expect(getLatestWsSubscriptionSearchParams()).toEqual(
+        expect.objectContaining({
+          pod_name: 'pod-1',
+          container_name: undefined,
+        })
+      )
+      expect(getLatestWsSubscriptionSearchParams()['external_request_id']).not.toBe(initialRequestId)
+    })
+  })
+
+  it('should ignore a stale websocket close after selecting a pod', async () => {
+    const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
+    const initialWebsocket = createMockWebSocket()
+
+    act(() => {
+      getLatestWsSubscriptionConfig().onOpen?.({} as QueryClient, createWebSocketEvent('open', initialWebsocket))
+    })
+
+    await userEvent.click(screen.getByPlaceholderText('Select a pod to connect to'))
+    const [firstPodOption] = screen.getAllByRole('option')
+    await userEvent.click(firstPodOption)
+
+    act(() => {
+      getLatestWsSubscriptionConfig().onClose?.(
+        {} as QueryClient,
+        createWebSocketCloseEvent(initialWebsocket, { code: 1000, reason: 'Stale close from previous websocket.' })
+      )
+    })
+
+    expect(screen.queryByText('Unable to launch CLI')).not.toBeInTheDocument()
+    expect(useReactQueryWsSubscriptionMock).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: true }))
   })
 })

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -40,6 +40,7 @@ export function ServiceTerminal({
 }: ServiceTerminalProps) {
   const { data: runningStatuses } = useRunningStatus({ environmentId, serviceId })
   const hasWrittenShellBannerRef = useRef(false)
+  const activeWebSocketRef = useRef<WebSocket | null>(null)
   const [requestId, setRequestId] = useState(() => uuidv7())
 
   const [addons, setAddons] = useState<Array<ITerminalAddon>>([])
@@ -113,6 +114,7 @@ export function ServiceTerminal({
       const shouldWriteShellBanner = !hasWrittenShellBannerRef.current
 
       // As WS are open twice in dev mode / strict mode it doesn't happens in production
+      activeWebSocketRef.current = websocket
       attachWebSocket(websocket)
       setTerminalLaunchError(null)
       hasWrittenShellBannerRef.current = true
@@ -134,6 +136,11 @@ export function ServiceTerminal({
 
   const onCloseHandler = useCallback(
     (_: QueryClient, event: CloseEvent) => {
+      if (event.target !== activeWebSocketRef.current) {
+        return
+      }
+
+      activeWebSocketRef.current = null
       detachWebSocket()
       setAddons([])
 
@@ -145,7 +152,8 @@ export function ServiceTerminal({
     [detachWebSocket]
   )
 
-  const onRetryCliLaunch = useCallback(() => {
+  const resetTerminalSession = useCallback(() => {
+    activeWebSocketRef.current = null
     detachWebSocket()
     hasWrittenShellBannerRef.current = false
     setAddons([])
@@ -153,6 +161,27 @@ export function ServiceTerminal({
     setRequestId(uuidv7())
     resetTerminalReadiness()
   }, [detachWebSocket, resetTerminalReadiness])
+
+  const onRetryCliLaunch = useCallback(() => {
+    resetTerminalSession()
+  }, [resetTerminalSession])
+
+  const onSelectedPodChange = useCallback(
+    (pod?: string) => {
+      resetTerminalSession()
+      setSelectedPod(pod)
+      setSelectedContainer(undefined)
+    },
+    [resetTerminalSession]
+  )
+
+  const onSelectedContainerChange = useCallback(
+    (container?: string) => {
+      resetTerminalSession()
+      setSelectedContainer(container)
+    },
+    [resetTerminalSession]
+  )
   const terminalUnavailableDescription = useMemo(
     () =>
       match(runningStatuses?.state)
@@ -189,13 +218,8 @@ export function ServiceTerminal({
   })
 
   useEffect(() => {
-    hasWrittenShellBannerRef.current = false
-    resetTerminalReadiness()
-  }, [resetTerminalReadiness, selectedContainer, selectedPod])
-
-  useEffect(() => {
     if (fitAddon) {
-      setTimeout(() => fitAddon.fit(), 0)
+      setTimeout(() => fitAddon.fit?.(), 0)
     }
   }, [fitAddon])
 
@@ -207,7 +231,7 @@ export function ServiceTerminal({
             <div className="relative">
               <InputSearch
                 value={selectedPod}
-                onChange={setSelectedPod}
+                onChange={onSelectedPodChange}
                 data={runningStatuses.pods.map((pod) => pod.name)}
                 placeholder="Select a pod to connect to"
                 trimLabel
@@ -223,7 +247,7 @@ export function ServiceTerminal({
             <div className="relative">
               <InputSearch
                 value={selectedContainer}
-                onChange={setSelectedContainer}
+                onChange={onSelectedContainerChange}
                 data={
                   runningStatuses.pods
                     .find((pod) => selectedPod === pod?.name)


### PR DESCRIPTION
## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1781600443144339)

**On Chrome-based browsers, an infinite loader was displayed after selecting a pod from the dropdown**

### Tech explanation

The Chrome-specific failure is: when selecting a pod, the previous WebSocket closes after the new one has opened, and its stale onclose handler clears addons, which makes isTerminalLoading true forever. Firefox likely orders those events differently.
I updated `service-terminal.tsx` to track the active WebSocket and also ignore close events from stale sockets.

## Screenshots / Recordings

https://github.com/user-attachments/assets/f828e941-9fbb-43af-9fd3-65414c4e8d7e

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
