### PR TITLE
fix(invite): redirection bug when user tries to accept invite

### DIFF
--- a/apps/console/src/routes/login/auth0-callback.tsx
+++ b/apps/console/src/routes/login/auth0-callback.tsx
@@ -17,6 +17,11 @@ type Auth0CallbackSearch = {
   error_description?: string
 }
 
+function isAcceptInvitationReturnTo(returnTo: string) {
+  const pathname = returnTo.split(/[?#]/)[0]?.replace(/\/$/, '')
+  return pathname === '/accept-invitation'
+}
+
 export const Route = createFileRoute('/login/auth0-callback')({
   component: RouteComponent,
   validateSearch: (search: Record<string, unknown>): Auth0CallbackSearch => ({
@@ -52,11 +57,16 @@ function useRedirectIfLogged(connection?: string) {
         return
       }
 
+      const returnTo = consumePendingReturnTo()
+      if (returnTo && isAcceptInvitationReturnTo(returnTo)) {
+        navigate({ href: returnTo })
+        return
+      }
+
       // User has at least 1 organization attached
       if (organizations.length > 0) {
-        const returnTo = consumePendingReturnTo()
         if (returnTo) {
-          navigate({ to: returnTo })
+          navigate({ href: returnTo })
         } else {
           navigate({ to: '/organization/$organizationId/overview', params: { organizationId: organizations[0]?.id } })
         }

--- a/apps/console/src/routes/login/auth0-callback.tsx
+++ b/apps/console/src/routes/login/auth0-callback.tsx
@@ -66,7 +66,7 @@ function useRedirectIfLogged(connection?: string) {
       // User has at least 1 organization attached
       if (organizations.length > 0) {
         if (returnTo) {
-          navigate({ href: returnTo })
+          navigate({ to: returnTo })
         } else {
           navigate({ to: '/organization/$organizationId/overview', params: { organizationId: organizations[0]?.id } })
         }


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1781627198721579)

**This PR fixes first-time invitees being redirected to onboarding instead of the invitation acceptance page.**

Changes:
- Prioritize Auth0 `returnTo` URLs targeting `/accept-invitation` before checking whether the user belongs to any organization.
- Preserve invitation query params by navigating with `href` instead of `to`.

## Screenshot

### Before

https://qovery.slack.com/archives/C0A4CDDJBRQ/p1781700333716899?thread_ts=1781627198.721579&cid=C0A4CDDJBRQ

### After

https://qovery.slack.com/archives/C0A4CDDJBRQ/p1781700345952609?thread_ts=1781627198.721579&cid=C0A4CDDJBRQ

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
