### PR TITLE
feat(analytics): add PostHog tracking for Secret Manager adoption   flow

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
@@ -198,6 +198,7 @@ function RouteComponent() {
                           posthog.capture('cluster-secret-manager-add-clicked', {
                             cluster_id: clusterId,
                             organization_id: organizationId,
+                            source: 'settings',
                           })
                         }
                       }}

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useParams } from '@tanstack/react-router'
+import posthog from 'posthog-js'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { type SecretManagerAccess } from 'qovery-typescript-axios'
 import { useMemo, useState } from 'react'
@@ -193,7 +194,19 @@ function RouteComponent() {
                   <div className="flex flex-col items-start gap-3">
                     <DropdownMenu.Root>
                       <DropdownMenu.Trigger asChild>
-                        <Button color="neutral" variant="solid" size="md" className="gap-2" type="button">
+                        <Button
+                          color="neutral"
+                          variant="solid"
+                          size="md"
+                          className="gap-2"
+                          type="button"
+                          onClick={() =>
+                            posthog.capture('cluster-secret-manager-add-clicked', {
+                              cluster_id: clusterId,
+                              organization_id: organizationId,
+                            })
+                          }
+                        >
                           <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
                           Add secret manager
                           <Icon iconName="chevron-down" className="text-[10px]" />
@@ -205,7 +218,14 @@ function RouteComponent() {
                             key={option.value}
                             color="neutral"
                             icon={<Icon name={option.icon} width={16} height={16} />}
-                            onSelect={() => openSecretManagerModal(option)}
+                            onSelect={() => {
+                              posthog.capture('cluster-secret-manager-type-selected', {
+                                cluster_id: clusterId,
+                                organization_id: organizationId,
+                                secret_manager_type: option.value,
+                              })
+                              openSecretManagerModal(option)
+                            }}
                           >
                             {option.label}
                           </DropdownMenu.Item>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
@@ -192,7 +192,16 @@ function RouteComponent() {
                     </p>
                   </div>
                   <div className="flex flex-col items-start gap-3">
-                    <DropdownMenu.Root>
+                    <DropdownMenu.Root
+                      onOpenChange={(open) => {
+                        if (open) {
+                          posthog.capture('cluster-secret-manager-add-clicked', {
+                            cluster_id: clusterId,
+                            organization_id: organizationId,
+                          })
+                        }
+                      }}
+                    >
                       <DropdownMenu.Trigger asChild>
                         <Button
                           color="neutral"
@@ -200,12 +209,6 @@ function RouteComponent() {
                           size="md"
                           className="gap-2"
                           type="button"
-                          onClick={() =>
-                            posthog.capture('cluster-secret-manager-add-clicked', {
-                              cluster_id: clusterId,
-                              organization_id: organizationId,
-                            })
-                          }
                         >
                           <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
                           Add secret manager

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
@@ -204,13 +204,7 @@ function RouteComponent() {
                       }}
                     >
                       <DropdownMenu.Trigger asChild>
-                        <Button
-                          color="neutral"
-                          variant="solid"
-                          size="md"
-                          className="gap-2"
-                          type="button"
-                        >
+                        <Button color="neutral" variant="solid" size="md" className="gap-2" type="button">
                           <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
                           Add secret manager
                           <Icon iconName="chevron-down" className="text-[10px]" />

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
+import posthog from 'posthog-js'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
+import { useEffect } from 'react'
 import { getServiceVariableScope, useRedeployServiceAction, useService } from '@qovery/domains/services/feature'
 import { ExternalSecretsTab, SecretManagerFeatureFlagEntryPoint } from '@qovery/domains/variables/feature'
 import { toast } from '@qovery/shared/ui'
@@ -12,9 +14,19 @@ export const Route = createFileRoute(
 })
 
 function RouteComponent() {
-  const { environmentId, serviceId } = Route.useParams()
+  const { organizationId, projectId, environmentId, serviceId } = Route.useParams()
   const secretManagerEnabled = useFeatureFlagEnabled('secret-manager')
   useDocumentTitle('External secrets - Service')
+
+  useEffect(() => {
+    posthog.capture('external-secrets-tab-accessed', {
+      scope: 'service',
+      organization_id: organizationId,
+      project_id: projectId,
+      environment_id: environmentId,
+      service_id: serviceId,
+    })
+  }, [organizationId, projectId, environmentId, serviceId])
 
   if (!secretManagerEnabled) {
     return <SecretManagerFeatureFlagEntryPoint />

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
+import posthog from 'posthog-js'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
+import { useEffect } from 'react'
 import { useDeployEnvironment } from '@qovery/domains/environments/feature'
 import { ExternalSecretsTab, SecretManagerFeatureFlagEntryPoint } from '@qovery/domains/variables/feature'
 import { ENVIRONMENT_LOGS_URL, ENVIRONMENT_STAGES_URL } from '@qovery/shared/routes'
@@ -16,6 +18,15 @@ function RouteComponent() {
   const { organizationId, projectId, environmentId } = Route.useParams()
   const secretManagerEnabled = useFeatureFlagEnabled('secret-manager')
   useDocumentTitle('External secrets - Environment')
+
+  useEffect(() => {
+    posthog.capture('external-secrets-tab-accessed', {
+      scope: 'environment',
+      organization_id: organizationId,
+      project_id: projectId,
+      environment_id: environmentId,
+    })
+  }, [organizationId, projectId, environmentId])
 
   const { mutate: deployEnvironment } = useDeployEnvironment({
     projectId,

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -1,3 +1,4 @@
+import posthog from 'posthog-js'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { type Cluster, type SecretManagerAccess } from 'qovery-typescript-axios'
 import { type FormEventHandler, useEffect, useMemo } from 'react'
@@ -145,7 +146,18 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                 <div className="flex flex-col items-start gap-3">
                   <DropdownMenu.Root>
                     <DropdownMenu.Trigger asChild>
-                      <Button color="neutral" variant="solid" size="md" className="gap-2" type="button">
+                      <Button
+                        color="neutral"
+                        variant="solid"
+                        size="md"
+                        className="gap-2"
+                        type="button"
+                        onClick={() =>
+                          posthog.capture('cluster-secret-manager-add-clicked', {
+                            organization_id: organizationId,
+                          })
+                        }
+                      >
                         <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
                         Add secret manager
                         <Icon iconName="chevron-down" className="text-[10px]" />
@@ -157,7 +169,13 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                           key={option.value}
                           color="neutral"
                           icon={<Icon name={option.icon} width={16} height={16} />}
-                          onSelect={() => openSecretManagerModal(option)}
+                          onSelect={() => {
+                            posthog.capture('cluster-secret-manager-type-selected', {
+                              organization_id: organizationId,
+                              secret_manager_type: option.value,
+                            })
+                            openSecretManagerModal(option)
+                          }}
                         >
                           {option.label}
                         </DropdownMenu.Item>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -144,7 +144,15 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                   </p>
                 </div>
                 <div className="flex flex-col items-start gap-3">
-                  <DropdownMenu.Root>
+                  <DropdownMenu.Root
+                    onOpenChange={(open) => {
+                      if (open) {
+                        posthog.capture('cluster-secret-manager-add-clicked', {
+                          organization_id: organizationId,
+                        })
+                      }
+                    }}
+                  >
                     <DropdownMenu.Trigger asChild>
                       <Button
                         color="neutral"
@@ -152,11 +160,6 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                         size="md"
                         className="gap-2"
                         type="button"
-                        onClick={() =>
-                          posthog.capture('cluster-secret-manager-add-clicked', {
-                            organization_id: organizationId,
-                          })
-                        }
                       >
                         <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
                         Add secret manager

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -155,13 +155,7 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                     }}
                   >
                     <DropdownMenu.Trigger asChild>
-                      <Button
-                        color="neutral"
-                        variant="solid"
-                        size="md"
-                        className="gap-2"
-                        type="button"
-                      >
+                      <Button color="neutral" variant="solid" size="md" className="gap-2" type="button">
                         <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
                         Add secret manager
                         <Icon iconName="chevron-down" className="text-[10px]" />

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -149,6 +149,7 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                       if (open) {
                         posthog.capture('cluster-secret-manager-add-clicked', {
                           organization_id: organizationId,
+                          source: 'creation-flow',
                         })
                       }
                     }}

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal.tsx
@@ -103,12 +103,25 @@ export function SecretManagerIntegrationModal({
   }
 
   const handleSubmit = methods.handleSubmit(async (data) => {
-    await onSubmit(getSubmitPayload(data))
-    posthog.capture('cluster-secret-manager-form-submitted', {
-      is_edit: mode === 'edit',
-      secret_manager_type: option.value,
-    })
-    onClose()
+    const integration_mode = isManualOnlyGcpIntegration || isManualOnlyAwsIntegration ? 'manual' : activeTab
+    try {
+      await onSubmit(getSubmitPayload(data))
+      posthog.capture('cluster-secret-manager-form-submitted', {
+        is_edit: mode === 'edit',
+        secret_manager_type: option.value,
+        integration_mode,
+        success: true,
+      })
+      onClose()
+    } catch (error) {
+      posthog.capture('cluster-secret-manager-form-submitted', {
+        is_edit: mode === 'edit',
+        secret_manager_type: option.value,
+        integration_mode,
+        success: false,
+      })
+      throw error
+    }
   })
 
   const manualSections = isGcpManualTabOnGcpSecretManager ? (

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal.tsx
@@ -1,3 +1,4 @@
+import posthog from 'posthog-js'
 import { type Cluster, type ClusterRegion, type SecretManagerAccess } from 'qovery-typescript-axios'
 import { type ReactNode, useCallback, useMemo, useState } from 'react'
 import { FormProvider, type UseFormReturn, useForm } from 'react-hook-form'
@@ -103,6 +104,10 @@ export function SecretManagerIntegrationModal({
 
   const handleSubmit = methods.handleSubmit(async (data) => {
     await onSubmit(getSubmitPayload(data))
+    posthog.capture('cluster-secret-manager-form-submitted', {
+      is_edit: mode === 'edit',
+      secret_manager_type: option.value,
+    })
     onClose()
   })
 

--- a/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
@@ -1,3 +1,4 @@
+import posthog from 'posthog-js'
 import { type SecretManagerAccess } from 'qovery-typescript-axios'
 import { useEffect, useMemo, useState } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
@@ -155,8 +156,18 @@ export function AddSecretModal({
         reference: finalReference,
         secretManagerAccessId: selectedSource.value,
       })
+      posthog.capture('external-secret-form-success', {
+        mode,
+        scope,
+        is_file: isFile,
+      })
       onClose()
     } catch (error) {
+      posthog.capture('external-secret-form-error', {
+        mode,
+        scope,
+        is_file: isFile,
+      })
       console.error(error)
     }
   })

--- a/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/add-secret-modal/add-secret-modal.tsx
@@ -156,17 +156,19 @@ export function AddSecretModal({
         reference: finalReference,
         secretManagerAccessId: selectedSource.value,
       })
-      posthog.capture('external-secret-form-success', {
+      posthog.capture('external-secret-form-submitted', {
         mode,
         scope,
         is_file: isFile,
+        success: true,
       })
       onClose()
     } catch (error) {
-      posthog.capture('external-secret-form-error', {
+      posthog.capture('external-secret-form-submitted', {
         mode,
         scope,
         is_file: isFile,
+        success: false,
       })
       console.error(error)
     }

--- a/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
@@ -1,5 +1,4 @@
 import { Link, useParams } from '@tanstack/react-router'
-import posthog from 'posthog-js'
 import {
   type ColumnFiltersState,
   type RowSelectionState,
@@ -13,6 +12,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
+import posthog from 'posthog-js'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { match } from 'ts-pattern'
 import { getSecretManagerProvider } from '@qovery/domains/clusters/data-access'

--- a/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
+++ b/libs/domains/variables/feature/src/lib/external-secrets/external-secrets-tab.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from '@tanstack/react-router'
+import posthog from 'posthog-js'
 import {
   type ColumnFiltersState,
   type RowSelectionState,
@@ -196,6 +197,10 @@ export function ExternalSecretsTab({
 
   const handleOpenAddSecret = useCallback(
     (isFile: boolean) => {
+      posthog.capture('external-secret-add-clicked', {
+        scope,
+        is_file: isFile,
+      })
       openModal({
         content: (
           <AddSecretModal


### PR DESCRIPTION
## Summary

**Issue**: [QOV-2022](https://qovery.atlassian.net/browse/QOV-2022)

## Summary

  - Add custom PostHog events covering the full Secret Manager
  adoption flow,
    from the cluster Add-ons page down to external secret creation at
  service
    and environment level
  - Fix `cluster-secret-manager-add-clicked` to use `onOpenChange` on
  the
    `DropdownMenu.Root` instead of `onClick` on the trigger (Radix
  intercepts
    `pointerdown` before `click` fires)
  - Add a `source` property (`settings` | `creation-flow`) to
  distinguish
    whether the user adds a secret manager from an existing cluster
  or during
    cluster creation

  ## Events added

|Event | Trigger |Key properties |
|---|---|---|
  | cluster-secret-manager-add-clicked | Opens the "Add secret manager" dropdown | source, cluster_id, organization_id |
  | cluster-secret-manager-type-selected | Selects a provider in the dropdown | secret_manager_type, organization_id |
  | cluster-secret-manager-form-submitted | Submits the integration form | secret_manager_type, integration_mode, is_edit, success |
  | external-secrets-tab-accessed | Navigates to the External Secrets tab | scope, organization_id, project_id, environment_id, service_id |
  | external-secret-add-clicked | Opens the Add secret modal | scope, is_file |
  | external-secret-form-submitted | Submits the Add/Edit secret form | mode, scope, is_file, success |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code


[QOV-2022]: https://qovery.atlassian.net/browse/QOV-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ