### PR TITLE
feat(devops-copilot): send message ID and thread ID to PostHog

### DIFF
--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
@@ -13,13 +13,15 @@ interface AssistantMessageProps {
   plan: PlanStep[]
   showPlans: Record<string, boolean>
   setShowPlans: (fn: (prev: Record<string, boolean>) => Record<string, boolean>) => void
+  threadId?: string
 }
 
-function VoteButtons({ messageId }: { messageId: string }) {
+function VoteButtons({ messageId, threadId }: { messageId: string; threadId?: string }) {
   const { respond, response, triggerRef } = useThumbSurvey({
     surveyId: POSTHOG_SURVEY_ID,
     properties: {
-      $ai_trace_id: messageId,
+      $ai_trace_id: threadId ?? messageId,
+      $ai_message_id: messageId,
     },
   })
 
@@ -49,7 +51,7 @@ function VoteButtons({ messageId }: { messageId: string }) {
   )
 }
 
-export function AssistantMessage({ message, plan, showPlans, setShowPlans }: AssistantMessageProps) {
+export function AssistantMessage({ message, plan, showPlans, setShowPlans, threadId }: AssistantMessageProps) {
   const messagePlans = plan.filter((p) => p.messageId === message.id)
   const hasPlan = messagePlans.length > 0
   const isPlanVisible = showPlans[message.id]
@@ -87,7 +89,7 @@ export function AssistantMessage({ message, plan, showPlans, setShowPlans }: Ass
         </div>
       )}
       {renderedMarkdown}
-      <VoteButtons messageId={message.id} />
+      <VoteButtons messageId={message.id} threadId={threadId} />
     </div>
   )
 }

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/message-list/message-list.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/message-list/message-list.tsx
@@ -82,6 +82,7 @@ export function MessageList({
               plan={plan}
               showPlans={showPlans}
               setShowPlans={setShowPlans}
+              threadId={threadId}
             />
           ))
           .exhaustive()


### PR DESCRIPTION
## Summary

Send the messageID and threadID to PostHog during votes and messages so that the link can be made in PostHog

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
