### PR TITLE
feat(qov-1844): Hide future gke kms key feature

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-features/step-features.tsx
@@ -225,8 +225,8 @@ function StepFeaturesForm({
                   const natGatewayFeature = features.find(({ id }) => id === 'NAT_GATEWAY')
                   const hasMergedStaticIpNatGateway = Boolean(staticIpFeature && natGatewayFeature)
                   const remainingFeatures = hasMergedStaticIpNatGateway
-                    ? features.filter(({ id }) => id !== 'STATIC_IP' && id !== 'NAT_GATEWAY')
-                    : features
+                    ? features.filter(({ id }) => id !== 'STATIC_IP' && id !== 'NAT_GATEWAY' && id !== 'GKE_KMS_KEY')
+                    : features.filter(({ id }) => id !== 'GKE_KMS_KEY')
 
                   return (
                     <>

--- a/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-network-settings/cluster-network-settings.tsx
@@ -512,6 +512,7 @@ export function ClusterNetworkSettings({ organizationId, clusterId }: ClusterNet
   const gcpDisplayFeatures = configuredFeatures.filter(({ id }) => {
     if (id === 'STATIC_IP') return false
     if (id === 'NAT_GATEWAY' && hasGcpStaticIpFeature) return false
+    if (id === 'GKE_KMS_KEY') return false
     return true
   })
   const displayConfiguredFeatures = isGcpCluster ? gcpDisplayFeatures : configuredFeatures


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: QOV-1844

If we add a new cluster feature, it will be shown by default in the Network configuration page (both at creation & existing cluster pages).
This change explicitely hides the feature that will be added soon on api side.
I'm preparing another PR to properly integrate this feature

<img width="955" height="840" alt="image" src="https://github.com/user-attachments/assets/e63b5641-cc1b-45bf-9aa3-7e3b0611234f" />

