### PR TITLE
feat(shell): add ephemeral pod support to cloud shell

### DIFF
--- a/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`ServiceTerminal should match snapshot 1`] = `
               class="relative z-10"
             >
               <button
-                class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
+                class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
               >
                 pod-1
                 <span>
@@ -35,7 +35,7 @@ exports[`ServiceTerminal should match snapshot 1`] = `
                 </span>
               </button>
               <div
-                class="relative"
+                class="hidden relative"
               >
                 <i
                   aria-hidden="true"
@@ -52,7 +52,7 @@ exports[`ServiceTerminal should match snapshot 1`] = `
                   id="downshift-:r6:-input"
                   placeholder="Select a pod"
                   role="combobox"
-                  value=""
+                  value="pod-1"
                 />
               </div>
               <div

--- a/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
@@ -94,32 +94,27 @@ exports[`ServiceTerminal should match snapshot 1`] = `
             </div>
           </div>
           <button
-            class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 px-1.5 gap-x-1 rounded bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
-            data-state="closed"
+            class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm px-1.5 gap-x-1 rounded bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral h-8"
+          >
+            Launch ephemeral pod
+          </button>
+        </div>
+        <div
+          class="flex items-center gap-3"
+        >
+          <a
+            class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
+            href="https://www.qovery.com/docs/cli/overview"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             <i
               aria-hidden="true"
-              class="fa-solid fa-flask "
+              class="fa-regular fa-book "
             />
-            Switch to ephemeral pod
-            <i
-              aria-hidden="true"
-              class="fa-regular fa-circle-info "
-            />
-          </button>
+            CLI docs
+          </a>
         </div>
-        <a
-          class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
-          href="https://www.qovery.com/docs/cli/overview"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <i
-            aria-hidden="true"
-            class="fa-regular fa-book "
-          />
-          CLI docs
-        </a>
       </div>
       <div
         class="flex h-full flex-1 flex-col bg-background px-3 pt-5"

--- a/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
@@ -24,71 +24,55 @@ exports[`ServiceTerminal should match snapshot 1`] = `
               class="relative z-10"
             >
               <button
-                class="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
-                type="button"
+                class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
               >
-                <span
-                  class="max-w-32 truncate"
-                >
-                  pod-1...pod-1
-                </span>
-                <i
-                  aria-hidden="true"
-                  class="fa-regular fa-angle-down text-[10px] text-neutral-subtle transition-transform"
-                />
-              </button>
-              <div
-                class="absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
-              >
-                <div
-                  class="relative border-b border-neutral p-2"
-                >
+                pod-1
+                <span>
                   <i
                     aria-hidden="true"
-                    class="fa-regular fa-magnifying-glass absolute left-4 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+                    class="fa-regular fa-xmark text-sm"
                   />
-                  <input
-                    aria-activedescendant=""
-                    aria-autocomplete="list"
-                    aria-controls="downshift-:r6:-menu"
-                    aria-expanded="false"
-                    aria-labelledby="downshift-:r6:-label"
-                    autocomplete="off"
-                    class="h-7 w-full rounded border border-neutral bg-surface-neutral pl-6 pr-2 text-xs text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none"
-                    id="downshift-:r6:-input"
-                    placeholder="Search…"
-                    role="combobox"
-                    value="pod-1"
-                  />
-                </div>
+                </span>
+              </button>
+              <div
+                class="relative"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fa-regular fa-magnifying-glass absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="downshift-:r6:-menu"
+                  aria-expanded="false"
+                  aria-labelledby="downshift-:r6:-label"
+                  autocomplete="off"
+                  class="h-8 w-56 rounded border border-neutral bg-surface-neutral pl-7 pr-2 text-xs text-neutral placeholder:text-sm placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color]"
+                  id="downshift-:r6:-input"
+                  placeholder="Select a pod"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+              <div
+                class="mt-1 max-h-40 w-full min-w-56 overflow-y-auto rounded-md border border-neutral bg-surface-neutral p-2 shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
+              >
                 <ul
                   aria-labelledby="downshift-:r6:-label"
-                  class="m-0 max-h-40 list-none overflow-y-auto p-2"
+                  class="m-0 list-none p-0"
                   id="downshift-:r6:-menu"
                   role="listbox"
                 >
-                  <li
-                    aria-disabled="false"
-                    aria-selected="false"
-                    class="flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle"
-                    id="downshift-:r6:-item-0"
-                    role="option"
+                  <p
+                    class="flex w-full flex-col items-center py-2 text-center text-xs text-neutral-subtle"
                   >
-                    pod-1...pod-1
                     <i
                       aria-hidden="true"
-                      class="fa-regular fa-check text-brand"
+                      class="fa-regular fa-wave-pulse mb-1"
                     />
-                  </li>
-                  <li
-                    aria-disabled="false"
-                    aria-selected="false"
-                    class="flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle"
-                    id="downshift-:r6:-item-1"
-                    role="option"
-                  >
-                    pod-2...pod-2
-                  </li>
+                    No results found
+                  </p>
                 </ul>
               </div>
             </div>

--- a/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
@@ -99,22 +99,18 @@ exports[`ServiceTerminal should match snapshot 1`] = `
             Launch ephemeral pod
           </button>
         </div>
-        <div
-          class="flex items-center gap-3"
+        <a
+          class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
+          href="https://www.qovery.com/docs/cli/overview"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          <a
-            class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
-            href="https://www.qovery.com/docs/cli/overview"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <i
-              aria-hidden="true"
-              class="fa-regular fa-book "
-            />
-            CLI docs
-          </a>
-        </div>
+          <i
+            aria-hidden="true"
+            class="fa-regular fa-book "
+          />
+          CLI docs
+        </a>
       </div>
       <div
         class="flex h-full flex-1 flex-col bg-background px-3 pt-5"

--- a/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-terminal/__snapshots__/service-terminal.spec.tsx.snap
@@ -7,78 +7,106 @@ exports[`ServiceTerminal should match snapshot 1`] = `
       class="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-none border-0 bg-background"
     >
       <div
-        class="flex h-14 justify-between border-b border-neutral p-3"
+        class="flex h-12 items-center justify-between gap-3 border-b border-neutral px-3"
       >
         <div
-          class="flex gap-2 [&_input]:w-72"
+          class="flex min-w-0 items-center gap-3 text-xs text-neutral-subtle"
         >
           <div
-            class="relative"
+            class="flex items-center gap-2"
           >
+            <span
+              class="shrink-0 text-neutral-subtle"
+            >
+              Connected to live pod:
+            </span>
             <div
               class="relative z-10"
             >
               <button
-                class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
+                class="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
+                type="button"
               >
-                <span>
-                  <i
-                    aria-hidden="true"
-                    class="fa-regular fa-xmark text-sm"
-                  />
+                <span
+                  class="max-w-32 truncate"
+                >
+                  pod-1...pod-1
                 </span>
-              </button>
-              <div
-                class="relative"
-              >
                 <i
                   aria-hidden="true"
-                  class="fa-regular fa-magnifying-glass absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+                  class="fa-regular fa-angle-down text-[10px] text-neutral-subtle transition-transform"
                 />
-                <input
-                  aria-activedescendant=""
-                  aria-autocomplete="list"
-                  aria-controls="downshift-:r6:-menu"
-                  aria-expanded="false"
-                  aria-labelledby="downshift-:r6:-label"
-                  autocomplete="off"
-                  class="h-8 w-56 rounded border border-neutral bg-surface-neutral pl-7 pr-2 text-xs text-neutral placeholder:text-sm placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color]"
-                  id="downshift-:r6:-input"
-                  placeholder="Select a pod to connect to"
-                  role="combobox"
-                  value=""
-                />
-              </div>
+              </button>
               <div
-                class="mt-1 max-h-40 w-full min-w-56 overflow-y-auto rounded-md border border-neutral bg-surface-neutral p-2 shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
+                class="absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
               >
+                <div
+                  class="relative border-b border-neutral p-2"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="fa-regular fa-magnifying-glass absolute left-4 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+                  />
+                  <input
+                    aria-activedescendant=""
+                    aria-autocomplete="list"
+                    aria-controls="downshift-:r6:-menu"
+                    aria-expanded="false"
+                    aria-labelledby="downshift-:r6:-label"
+                    autocomplete="off"
+                    class="h-7 w-full rounded border border-neutral bg-surface-neutral pl-6 pr-2 text-xs text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none"
+                    id="downshift-:r6:-input"
+                    placeholder="Search…"
+                    role="combobox"
+                    value="pod-1"
+                  />
+                </div>
                 <ul
                   aria-labelledby="downshift-:r6:-label"
-                  class="m-0 list-none p-0"
+                  class="m-0 max-h-40 list-none overflow-y-auto p-2"
                   id="downshift-:r6:-menu"
                   role="listbox"
                 >
-                  <p
-                    class="flex w-full flex-col items-center py-2 text-center text-xs text-neutral-subtle"
+                  <li
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle"
+                    id="downshift-:r6:-item-0"
+                    role="option"
                   >
+                    pod-1...pod-1
                     <i
                       aria-hidden="true"
-                      class="fa-regular fa-wave-pulse mb-1"
+                      class="fa-regular fa-check text-brand"
                     />
-                    No results found
-                  </p>
+                  </li>
+                  <li
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle"
+                    id="downshift-:r6:-item-1"
+                    role="option"
+                  >
+                    pod-2...pod-2
+                  </li>
                 </ul>
               </div>
             </div>
-            <div
-              class="pointer-events-none absolute right-2.5 top-1/2 z-20 -translate-y-1/2 text-xs text-neutral-subtle"
-            >
-              <i
-                aria-hidden="true"
-                class="fa-regular fa-angle-down "
-              />
-            </div>
           </div>
+          <button
+            class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-ssm h-6 px-1.5 gap-x-1 rounded bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
+            data-state="closed"
+          >
+            <i
+              aria-hidden="true"
+              class="fa-solid fa-flask "
+            />
+            Switch to ephemeral pod
+            <i
+              aria-hidden="true"
+              class="fa-regular fa-circle-info "
+            />
+          </button>
         </div>
         <a
           class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
@@ -100,12 +128,17 @@ exports[`ServiceTerminal should match snapshot 1`] = `
           class="relative min-h-0 flex-1"
         >
           <div
-            class="absolute inset-0 flex items-start justify-center border-neutral bg-background pt-3"
+            class="absolute inset-0 flex flex-col items-center gap-2 border-neutral bg-background pt-6"
           >
             <div
               class="aspect-square border-2  animate-spin rounded-full border-solid border-neutral border-r-neutral-strong w-4 "
               data-testid="spinner"
             />
+            <span
+              class="text-xs text-neutral-subtle"
+            >
+              Connecting…
+            </span>
           </div>
         </div>
       </div>

--- a/libs/domains/services/feature/src/lib/service-terminal/ephemeral-shell-modal/ephemeral-shell-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/ephemeral-shell-modal/ephemeral-shell-modal.tsx
@@ -1,0 +1,72 @@
+import { Controller, FormProvider, useForm } from 'react-hook-form'
+import { InputText, ModalCrud } from '@qovery/shared/ui'
+
+export interface EphemeralShellFormValues {
+  cpu: string
+  memory: string
+}
+
+export interface EphemeralShellModalProps {
+  onClose: () => void
+  onLaunch: (values: EphemeralShellFormValues) => void
+  defaultValues?: EphemeralShellFormValues
+}
+
+export function EphemeralShellModal({ onClose, onLaunch, defaultValues }: EphemeralShellModalProps) {
+  const methods = useForm<EphemeralShellFormValues>({
+    mode: 'onChange',
+    defaultValues: defaultValues ?? { cpu: '1', memory: '2048Mi' },
+  })
+
+  const onSubmit = methods.handleSubmit((values) => {
+    onLaunch(values)
+    onClose()
+  })
+
+  return (
+    <FormProvider {...methods}>
+      <ModalCrud
+        title="Launch ephemeral pod"
+        description="Spawns a one-shot clone pod for troubleshooting. It mirrors your service's image and configuration but runs in isolation — nothing you do affects the live pods. The pod is automatically terminated when the session ends."
+        onClose={onClose}
+        onSubmit={onSubmit}
+        submitLabel="Launch"
+      >
+        <div className="flex flex-col gap-4">
+          <Controller
+            name="cpu"
+            control={methods.control}
+            rules={{ required: 'CPU is required.' }}
+            render={({ field, fieldState: { error } }) => (
+              <InputText
+                label="vCPU (milli)"
+                name={field.name}
+                value={field.value}
+                onChange={field.onChange}
+                hint="Minimum value is 10 milli vCPU."
+                error={error?.message}
+              />
+            )}
+          />
+          <Controller
+            name="memory"
+            control={methods.control}
+            rules={{ required: 'Memory is required.' }}
+            render={({ field, fieldState: { error } }) => (
+              <InputText
+                label="Memory (MiB)"
+                name={field.name}
+                value={field.value}
+                onChange={field.onChange}
+                hint="Minimum value is 1 MiB."
+                error={error?.message}
+              />
+            )}
+          />
+        </div>
+      </ModalCrud>
+    </FormProvider>
+  )
+}
+
+export default EphemeralShellModal

--- a/libs/domains/services/feature/src/lib/service-terminal/ephemeral-shell-modal/ephemeral-shell-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/ephemeral-shell-modal/ephemeral-shell-modal.tsx
@@ -27,7 +27,7 @@ export function EphemeralShellModal({ onClose, onLaunch, defaultValues }: Epheme
     <FormProvider {...methods}>
       <ModalCrud
         title="Launch ephemeral pod"
-        description="Spawns a one-shot clone pod for troubleshooting. It mirrors your service's image and configuration but runs in isolation — nothing you do affects the live pods. The pod is automatically terminated when the session ends."
+        description="Spawns a one-shot clone pod for troubleshooting. It mirrors your service's image and configuration but runs in isolation. Nothing you do affects the live pods. The pod is automatically terminated when the session ends."
         onClose={onClose}
         onSubmit={onSubmit}
         submitLabel="Launch"

--- a/libs/domains/services/feature/src/lib/service-terminal/input-search/__snapshots__/input-search.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-terminal/input-search/__snapshots__/input-search.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`InputSearch should match snapshot 1`] = `
       class="relative z-10"
     >
       <button
-        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
+        class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
       >
         my-value
         <span>
@@ -18,7 +18,7 @@ exports[`InputSearch should match snapshot 1`] = `
         </span>
       </button>
       <div
-        class="relative"
+        class="hidden relative"
       >
         <i
           aria-hidden="true"
@@ -35,7 +35,7 @@ exports[`InputSearch should match snapshot 1`] = `
           id="downshift-:r6:-input"
           placeholder="placeholder"
           role="combobox"
-          value=""
+          value="my-value"
         />
       </div>
       <div
@@ -70,7 +70,7 @@ exports[`InputSearch should match with snapshot 1`] = `
       class="relative z-10"
     >
       <button
-        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
+        class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral"
       >
         my-value
         <span>
@@ -81,7 +81,7 @@ exports[`InputSearch should match with snapshot 1`] = `
         </span>
       </button>
       <div
-        class="relative"
+        class="hidden relative"
       >
         <i
           aria-hidden="true"

--- a/libs/domains/services/feature/src/lib/service-terminal/input-search/__snapshots__/input-search.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-terminal/input-search/__snapshots__/input-search.spec.tsx.snap
@@ -7,62 +7,55 @@ exports[`InputSearch should match snapshot 1`] = `
       class="relative z-10"
     >
       <button
-        class="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
-        type="button"
+        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
       >
-        <span
-          class="max-w-32 truncate"
-        >
-          my-value
-        </span>
-        <i
-          aria-hidden="true"
-          class="fa-regular fa-angle-down text-[10px] text-neutral-subtle transition-transform"
-        />
-      </button>
-      <div
-        class="absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
-      >
-        <div
-          class="relative border-b border-neutral p-2"
-        >
+        my-value
+        <span>
           <i
             aria-hidden="true"
-            class="fa-regular fa-magnifying-glass absolute left-4 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+            class="fa-regular fa-xmark text-sm"
           />
-          <input
-            aria-activedescendant=""
-            aria-autocomplete="list"
-            aria-controls="downshift-:r6:-menu"
-            aria-expanded="false"
-            aria-labelledby="downshift-:r6:-label"
-            autocomplete="off"
-            class="h-7 w-full rounded border border-neutral bg-surface-neutral pl-6 pr-2 text-xs text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none"
-            id="downshift-:r6:-input"
-            placeholder="Search…"
-            role="combobox"
-            value="my-value"
-          />
-        </div>
+        </span>
+      </button>
+      <div
+        class="relative"
+      >
+        <i
+          aria-hidden="true"
+          class="fa-regular fa-magnifying-glass absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+        />
+        <input
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-controls="downshift-:r6:-menu"
+          aria-expanded="false"
+          aria-labelledby="downshift-:r6:-label"
+          autocomplete="off"
+          class="h-8 w-56 rounded border border-neutral bg-surface-neutral pl-7 pr-2 text-xs text-neutral placeholder:text-sm placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color]"
+          id="downshift-:r6:-input"
+          placeholder="placeholder"
+          role="combobox"
+          value=""
+        />
+      </div>
+      <div
+        class="mt-1 max-h-40 w-full min-w-56 overflow-y-auto rounded-md border border-neutral bg-surface-neutral p-2 shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
+      >
         <ul
           aria-labelledby="downshift-:r6:-label"
-          class="m-0 max-h-40 list-none overflow-y-auto p-2"
+          class="m-0 list-none p-0"
           id="downshift-:r6:-menu"
           role="listbox"
         >
-          <li
-            aria-disabled="false"
-            aria-selected="false"
-            class="flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle"
-            id="downshift-:r6:-item-0"
-            role="option"
+          <p
+            class="flex w-full flex-col items-center py-2 text-center text-xs text-neutral-subtle"
           >
-            my-value
             <i
               aria-hidden="true"
-              class="fa-regular fa-check text-brand"
+              class="fa-regular fa-wave-pulse mb-1"
             />
-          </li>
+            No results found
+          </p>
         </ul>
       </div>
     </div>
@@ -77,62 +70,55 @@ exports[`InputSearch should match with snapshot 1`] = `
       class="relative z-10"
     >
       <button
-        class="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
-        type="button"
+        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
       >
-        <span
-          class="max-w-32 truncate"
-        >
-          my-value
-        </span>
-        <i
-          aria-hidden="true"
-          class="fa-regular fa-angle-down text-[10px] text-neutral-subtle transition-transform rotate-180"
-        />
-      </button>
-      <div
-        class="absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)]"
-      >
-        <div
-          class="relative border-b border-neutral p-2"
-        >
+        my-value
+        <span>
           <i
             aria-hidden="true"
-            class="fa-regular fa-magnifying-glass absolute left-4 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+            class="fa-regular fa-xmark text-sm"
           />
-          <input
-            aria-activedescendant="downshift-:rd:-item-0"
-            aria-autocomplete="list"
-            aria-controls="downshift-:rd:-menu"
-            aria-expanded="true"
-            aria-labelledby="downshift-:rd:-label"
-            autocomplete="off"
-            class="h-7 w-full rounded border border-neutral bg-surface-neutral pl-6 pr-2 text-xs text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none"
-            id="downshift-:rd:-input"
-            placeholder="Search…"
-            role="combobox"
-            value="my-value"
-          />
-        </div>
+        </span>
+      </button>
+      <div
+        class="relative"
+      >
+        <i
+          aria-hidden="true"
+          class="fa-regular fa-magnifying-glass absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+        />
+        <input
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-controls="downshift-:rd:-menu"
+          aria-expanded="false"
+          aria-labelledby="downshift-:rd:-label"
+          autocomplete="off"
+          class="h-8 w-56 rounded border border-neutral bg-surface-neutral pl-7 pr-2 text-xs text-neutral placeholder:text-sm placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color]"
+          id="downshift-:rd:-input"
+          placeholder="placeholder"
+          role="combobox"
+          value=""
+        />
+      </div>
+      <div
+        class="mt-1 max-h-40 w-full min-w-56 overflow-y-auto rounded-md border border-neutral bg-surface-neutral p-2 shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
+      >
         <ul
           aria-labelledby="downshift-:rd:-label"
-          class="m-0 max-h-40 list-none overflow-y-auto p-2"
+          class="m-0 list-none p-0"
           id="downshift-:rd:-menu"
           role="listbox"
         >
-          <li
-            aria-disabled="false"
-            aria-selected="true"
-            class="flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle bg-surface-neutral-subtle"
-            id="downshift-:rd:-item-0"
-            role="option"
+          <p
+            class="flex w-full flex-col items-center py-2 text-center text-xs text-neutral-subtle"
           >
-            my-value
             <i
               aria-hidden="true"
-              class="fa-regular fa-check text-brand"
+              class="fa-regular fa-wave-pulse mb-1"
             />
-          </li>
+            No results found
+          </p>
         </ul>
       </div>
     </div>

--- a/libs/domains/services/feature/src/lib/service-terminal/input-search/__snapshots__/input-search.spec.tsx.snap
+++ b/libs/domains/services/feature/src/lib/service-terminal/input-search/__snapshots__/input-search.spec.tsx.snap
@@ -7,55 +7,62 @@ exports[`InputSearch should match snapshot 1`] = `
       class="relative z-10"
     >
       <button
-        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
+        class="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
+        type="button"
       >
-        my-value
-        <span>
-          <i
-            aria-hidden="true"
-            class="fa-regular fa-xmark text-sm"
-          />
+        <span
+          class="max-w-32 truncate"
+        >
+          my-value
         </span>
-      </button>
-      <div
-        class="relative"
-      >
         <i
           aria-hidden="true"
-          class="fa-regular fa-magnifying-glass absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+          class="fa-regular fa-angle-down text-[10px] text-neutral-subtle transition-transform"
         />
-        <input
-          aria-activedescendant=""
-          aria-autocomplete="list"
-          aria-controls="downshift-:r6:-menu"
-          aria-expanded="false"
-          aria-labelledby="downshift-:r6:-label"
-          autocomplete="off"
-          class="h-8 w-56 rounded border border-neutral bg-surface-neutral pl-7 pr-2 text-xs text-neutral placeholder:text-sm placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color]"
-          id="downshift-:r6:-input"
-          placeholder="placeholder"
-          role="combobox"
-          value=""
-        />
-      </div>
+      </button>
       <div
-        class="mt-1 max-h-40 w-full min-w-56 overflow-y-auto rounded-md border border-neutral bg-surface-neutral p-2 shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
+        class="absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
       >
+        <div
+          class="relative border-b border-neutral p-2"
+        >
+          <i
+            aria-hidden="true"
+            class="fa-regular fa-magnifying-glass absolute left-4 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+          />
+          <input
+            aria-activedescendant=""
+            aria-autocomplete="list"
+            aria-controls="downshift-:r6:-menu"
+            aria-expanded="false"
+            aria-labelledby="downshift-:r6:-label"
+            autocomplete="off"
+            class="h-7 w-full rounded border border-neutral bg-surface-neutral pl-6 pr-2 text-xs text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none"
+            id="downshift-:r6:-input"
+            placeholder="Search…"
+            role="combobox"
+            value="my-value"
+          />
+        </div>
         <ul
           aria-labelledby="downshift-:r6:-label"
-          class="m-0 list-none p-0"
+          class="m-0 max-h-40 list-none overflow-y-auto p-2"
           id="downshift-:r6:-menu"
           role="listbox"
         >
-          <p
-            class="flex w-full flex-col items-center py-2 text-center text-xs text-neutral-subtle"
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle"
+            id="downshift-:r6:-item-0"
+            role="option"
           >
+            my-value
             <i
               aria-hidden="true"
-              class="fa-regular fa-wave-pulse mb-1"
+              class="fa-regular fa-check text-brand"
             />
-            No results found
-          </p>
+          </li>
         </ul>
       </div>
     </div>
@@ -70,55 +77,62 @@ exports[`InputSearch should match with snapshot 1`] = `
       class="relative z-10"
     >
       <button
-        class="items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-neutral-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-neutral-component hover:bg-surface-neutral-componentHover text-neutral hidden"
+        class="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
+        type="button"
       >
-        my-value
-        <span>
-          <i
-            aria-hidden="true"
-            class="fa-regular fa-xmark text-sm"
-          />
+        <span
+          class="max-w-32 truncate"
+        >
+          my-value
         </span>
-      </button>
-      <div
-        class="relative"
-      >
         <i
           aria-hidden="true"
-          class="fa-regular fa-magnifying-glass absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+          class="fa-regular fa-angle-down text-[10px] text-neutral-subtle transition-transform rotate-180"
         />
-        <input
-          aria-activedescendant=""
-          aria-autocomplete="list"
-          aria-controls="downshift-:rd:-menu"
-          aria-expanded="false"
-          aria-labelledby="downshift-:rd:-label"
-          autocomplete="off"
-          class="h-8 w-56 rounded border border-neutral bg-surface-neutral pl-7 pr-2 text-xs text-neutral placeholder:text-sm placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color]"
-          id="downshift-:rd:-input"
-          placeholder="placeholder"
-          role="combobox"
-          value=""
-        />
-      </div>
+      </button>
       <div
-        class="mt-1 max-h-40 w-full min-w-56 overflow-y-auto rounded-md border border-neutral bg-surface-neutral p-2 shadow-[0_0_32px_rgba(0,0,0,0.08)] hidden"
+        class="absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)]"
       >
+        <div
+          class="relative border-b border-neutral p-2"
+        >
+          <i
+            aria-hidden="true"
+            class="fa-regular fa-magnifying-glass absolute left-4 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+          />
+          <input
+            aria-activedescendant="downshift-:rd:-item-0"
+            aria-autocomplete="list"
+            aria-controls="downshift-:rd:-menu"
+            aria-expanded="true"
+            aria-labelledby="downshift-:rd:-label"
+            autocomplete="off"
+            class="h-7 w-full rounded border border-neutral bg-surface-neutral pl-6 pr-2 text-xs text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none"
+            id="downshift-:rd:-input"
+            placeholder="Search…"
+            role="combobox"
+            value="my-value"
+          />
+        </div>
         <ul
           aria-labelledby="downshift-:rd:-label"
-          class="m-0 list-none p-0"
+          class="m-0 max-h-40 list-none overflow-y-auto p-2"
           id="downshift-:rd:-menu"
           role="listbox"
         >
-          <p
-            class="flex w-full flex-col items-center py-2 text-center text-xs text-neutral-subtle"
+          <li
+            aria-disabled="false"
+            aria-selected="true"
+            class="flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle bg-surface-neutral-subtle"
+            id="downshift-:rd:-item-0"
+            role="option"
           >
+            my-value
             <i
               aria-hidden="true"
-              class="fa-regular fa-wave-pulse mb-1"
+              class="fa-regular fa-check text-brand"
             />
-            No results found
-          </p>
+          </li>
         </ul>
       </div>
     </div>

--- a/libs/domains/services/feature/src/lib/service-terminal/input-search/input-search.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/input-search/input-search.tsx
@@ -7,12 +7,11 @@ export interface InputSearchProps {
   data: string[]
   onChange: (value?: string) => void
   placeholder: string
-  label: string
   value?: string
   trimLabel?: boolean
 }
 
-export function InputSearch({ data, value, onChange, placeholder, label, trimLabel }: InputSearchProps) {
+export function InputSearch({ data, value, onChange, placeholder, trimLabel }: InputSearchProps) {
   const [items, setItems] = useState(data)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -39,13 +38,11 @@ export function InputSearch({ data, value, onChange, placeholder, label, trimLab
 
   return (
     <div className="relative z-10">
-      {/* Trigger button — always visible, shows label + current value */}
       <button
         type="button"
         className="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
         onClick={() => (isOpen ? closeMenu() : openMenu())}
       >
-        {label && <span className="font-medium text-neutral-subtle">{label}</span>}
         <span className="max-w-32 truncate">
           {displayValue ?? <span className="text-neutral-subtle">{placeholder}</span>}
         </span>
@@ -55,7 +52,6 @@ export function InputSearch({ data, value, onChange, placeholder, label, trimLab
         />
       </button>
 
-      {/* Dropdown */}
       <div
         className={clsx(
           'absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)]',

--- a/libs/domains/services/feature/src/lib/service-terminal/input-search/input-search.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/input-search/input-search.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useCombobox } from 'downshift'
-import { useEffect, useRef, useState } from 'react'
-import { Icon } from '@qovery/shared/ui'
+import { useRef, useState } from 'react'
+import { Button, Icon } from '@qovery/shared/ui'
 
 export interface InputSearchProps {
   data: string[]
@@ -15,73 +15,73 @@ export function InputSearch({ data, value, onChange, placeholder, trimLabel }: I
   const [items, setItems] = useState(data)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const { isOpen, getMenuProps, getInputProps, getItemProps, selectedItem, highlightedIndex, openMenu, closeMenu } =
-    useCombobox({
-      selectedItem: value ?? null,
-      onInputValueChange({ inputValue }) {
-        setItems(data.filter((item) => item.toLowerCase().includes(inputValue.toLowerCase())))
-      },
-      onSelectedItemChange({ selectedItem }) {
-        onChange(selectedItem ?? undefined)
-        closeMenu()
-      },
-      items,
-    })
-
-  // Reset filtered list when dropdown closes
-  useEffect(() => {
-    if (!isOpen) setItems(data)
-  }, [isOpen, data])
-
-  const displayValue =
-    trimLabel && selectedItem ? `${selectedItem.substring(0, 10)}...${selectedItem.slice(-10)}` : selectedItem
+  // https://github.com/radix-ui/primitives/issues/1342
+  // We are waiting for radix combobox primitives
+  // So we are using Downshift
+  const { isOpen, getMenuProps, getInputProps, getItemProps, selectedItem, highlightedIndex, reset } = useCombobox({
+    onInputValueChange({ inputValue }) {
+      setItems(data.filter((item) => item.toLowerCase().includes(inputValue.toLowerCase())))
+    },
+    onSelectedItemChange({ selectedItem }) {
+      onChange(selectedItem)
+    },
+    items,
+  })
 
   return (
+    // XTerm using some z-index and absolute positioning that's why we need z-index here
     <div className="relative z-10">
-      <button
-        type="button"
-        className="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
-        onClick={() => (isOpen ? closeMenu() : openMenu())}
+      <Button
+        color="neutral"
+        variant="surface"
+        size="md"
+        className={!selectedItem ? 'hidden' : ''}
+        onClick={() => {
+          reset()
+          onChange(undefined)
+          // Timeout is necessary to allow focused input
+          setTimeout(() => inputRef.current?.focus(), 50)
+        }}
       >
-        <span className="max-w-32 truncate">
-          {displayValue ?? <span className="text-neutral-subtle">{placeholder}</span>}
+        {value}
+        <span>
+          <Icon iconName="xmark" className="text-sm" />
         </span>
+      </Button>
+      <div className={clsx({ hidden: selectedItem }, 'relative')}>
         <Icon
-          iconName="angle-down"
-          className={clsx('text-[10px] text-neutral-subtle transition-transform', { 'rotate-180': isOpen })}
+          iconName="magnifying-glass"
+          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
         />
-      </button>
-
+        <input
+          placeholder={placeholder}
+          className="h-8 w-56 rounded border border-neutral bg-surface-neutral pl-7 pr-2 text-xs text-neutral placeholder:text-sm placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color]"
+          {...getInputProps({ ref: inputRef })}
+        />
+      </div>
       <div
         className={clsx(
-          'absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)]',
-          { hidden: !isOpen }
+          'mt-1 max-h-40 w-full min-w-56 overflow-y-auto rounded-md border border-neutral bg-surface-neutral p-2 shadow-[0_0_32px_rgba(0,0,0,0.08)]',
+          {
+            hidden: !isOpen,
+          }
         )}
       >
-        <div className="relative border-b border-neutral p-2">
-          <Icon
-            iconName="magnifying-glass"
-            className="absolute left-4 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
-          />
-          <input
-            placeholder="Search…"
-            className="h-7 w-full rounded border border-neutral bg-surface-neutral pl-6 pr-2 text-xs text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none"
-            {...getInputProps({ ref: inputRef })}
-          />
-        </div>
-        <ul className="m-0 max-h-40 list-none overflow-y-auto p-2" {...getMenuProps()}>
-          {items.length > 0 ? (
+        <ul className="m-0 list-none p-0" {...getMenuProps()}>
+          {isOpen && items.length > 0 ? (
             items.map((v, index) => (
               <li
                 key={v}
                 className={clsx(
                   'flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle',
-                  { 'bg-surface-neutral-subtle': highlightedIndex === index }
+                  {
+                    'bg-surface-neutral-subtle': highlightedIndex === index,
+                  }
                 )}
                 {...getItemProps({ item: v, index })}
               >
                 {trimLabel ? `${v.substring(0, 10)}...${v.slice(-10)}` : v}
-                {v === selectedItem && <Icon iconName="check" className="text-brand" />}
+                {v === selectedItem && <Icon iconName="check" />}
               </li>
             ))
           ) : (

--- a/libs/domains/services/feature/src/lib/service-terminal/input-search/input-search.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/input-search/input-search.tsx
@@ -1,87 +1,91 @@
 import clsx from 'clsx'
 import { useCombobox } from 'downshift'
-import { useRef, useState } from 'react'
-import { Button, Icon } from '@qovery/shared/ui'
+import { useEffect, useRef, useState } from 'react'
+import { Icon } from '@qovery/shared/ui'
 
 export interface InputSearchProps {
   data: string[]
   onChange: (value?: string) => void
   placeholder: string
+  label: string
   value?: string
   trimLabel?: boolean
 }
 
-export function InputSearch({ data, value, onChange, placeholder, trimLabel }: InputSearchProps) {
+export function InputSearch({ data, value, onChange, placeholder, label, trimLabel }: InputSearchProps) {
   const [items, setItems] = useState(data)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  // https://github.com/radix-ui/primitives/issues/1342
-  // We are waiting for radix combobox primitives
-  // So we are using Downshift
-  const { isOpen, getMenuProps, getInputProps, getItemProps, selectedItem, highlightedIndex, reset } = useCombobox({
-    onInputValueChange({ inputValue }) {
-      setItems(data.filter((item) => item.toLowerCase().includes(inputValue.toLowerCase())))
-    },
-    onSelectedItemChange({ selectedItem }) {
-      onChange(selectedItem)
-    },
-    items,
-  })
+  const { isOpen, getMenuProps, getInputProps, getItemProps, selectedItem, highlightedIndex, openMenu, closeMenu } =
+    useCombobox({
+      selectedItem: value ?? null,
+      onInputValueChange({ inputValue }) {
+        setItems(data.filter((item) => item.toLowerCase().includes(inputValue.toLowerCase())))
+      },
+      onSelectedItemChange({ selectedItem }) {
+        onChange(selectedItem ?? undefined)
+        closeMenu()
+      },
+      items,
+    })
+
+  // Reset filtered list when dropdown closes
+  useEffect(() => {
+    if (!isOpen) setItems(data)
+  }, [isOpen, data])
+
+  const displayValue =
+    trimLabel && selectedItem ? `${selectedItem.substring(0, 10)}...${selectedItem.slice(-10)}` : selectedItem
 
   return (
-    // XTerm using some z-index and absolute positioning that's why we need z-index here
     <div className="relative z-10">
-      <Button
-        color="neutral"
-        variant="surface"
-        size="md"
-        className={!selectedItem ? 'hidden' : ''}
-        onClick={() => {
-          reset()
-          onChange(undefined)
-          // Timeout is necessary to allow focused input
-          setTimeout(() => inputRef.current?.focus(), 50)
-        }}
+      {/* Trigger button — always visible, shows label + current value */}
+      <button
+        type="button"
+        className="flex h-8 items-center gap-1.5 rounded border border-neutral bg-surface-neutral px-2.5 text-xs text-neutral hover:border-neutral-strong focus:outline-none"
+        onClick={() => (isOpen ? closeMenu() : openMenu())}
       >
-        {value}
-        <span>
-          <Icon iconName="xmark" className="text-sm" />
+        {label && <span className="font-medium text-neutral-subtle">{label}</span>}
+        <span className="max-w-32 truncate">
+          {displayValue ?? <span className="text-neutral-subtle">{placeholder}</span>}
         </span>
-      </Button>
-      <div className={clsx({ hidden: selectedItem }, 'relative')}>
         <Icon
-          iconName="magnifying-glass"
-          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+          iconName="angle-down"
+          className={clsx('text-[10px] text-neutral-subtle transition-transform', { 'rotate-180': isOpen })}
         />
-        <input
-          placeholder={placeholder}
-          className="h-8 w-56 rounded border border-neutral bg-surface-neutral pl-7 pr-2 text-xs text-neutral placeholder:text-sm placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none focus:transition-[border-color]"
-          {...getInputProps({ ref: inputRef })}
-        />
-      </div>
+      </button>
+
+      {/* Dropdown */}
       <div
         className={clsx(
-          'mt-1 max-h-40 w-full min-w-56 overflow-y-auto rounded-md border border-neutral bg-surface-neutral p-2 shadow-[0_0_32px_rgba(0,0,0,0.08)]',
-          {
-            hidden: !isOpen,
-          }
+          'absolute left-0 top-full mt-1 w-64 overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-[0_0_32px_rgba(0,0,0,0.08)]',
+          { hidden: !isOpen }
         )}
       >
-        <ul className="m-0 list-none p-0" {...getMenuProps()}>
-          {isOpen && items.length > 0 ? (
+        <div className="relative border-b border-neutral p-2">
+          <Icon
+            iconName="magnifying-glass"
+            className="absolute left-4 top-1/2 -translate-y-1/2 text-xs text-neutral-subtle"
+          />
+          <input
+            placeholder="Search…"
+            className="h-7 w-full rounded border border-neutral bg-surface-neutral pl-6 pr-2 text-xs text-neutral placeholder:text-neutral-subtle focus:border-brand-strong focus:outline-none"
+            {...getInputProps({ ref: inputRef })}
+          />
+        </div>
+        <ul className="m-0 max-h-40 list-none overflow-y-auto p-2" {...getMenuProps()}>
+          {items.length > 0 ? (
             items.map((v, index) => (
               <li
                 key={v}
                 className={clsx(
                   'flex h-9 w-full items-center justify-between rounded px-2 text-xs text-neutral transition-colors hover:bg-surface-neutral-subtle',
-                  {
-                    'bg-surface-neutral-subtle': highlightedIndex === index,
-                  }
+                  { 'bg-surface-neutral-subtle': highlightedIndex === index }
                 )}
                 {...getItemProps({ item: v, index })}
               >
                 {trimLabel ? `${v.substring(0, 10)}...${v.slice(-10)}` : v}
-                {v === selectedItem && <Icon iconName="check" />}
+                {v === selectedItem && <Icon iconName="check" className="text-brand" />}
               </li>
             ))
           ) : (

--- a/libs/domains/services/feature/src/lib/service-terminal/input-search/input-search.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/input-search/input-search.tsx
@@ -19,6 +19,7 @@ export function InputSearch({ data, value, onChange, placeholder, trimLabel }: I
   // We are waiting for radix combobox primitives
   // So we are using Downshift
   const { isOpen, getMenuProps, getInputProps, getItemProps, selectedItem, highlightedIndex, reset } = useCombobox({
+    defaultSelectedItem: value ?? null,
     onInputValueChange({ inputValue }) {
       setItems(data.filter((item) => item.toLowerCase().includes(inputValue.toLowerCase())))
     },

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.spec.tsx
@@ -192,7 +192,7 @@ describe('ServiceTerminal', () => {
 
   it('should pre-select the first pod on load', () => {
     renderWithProviders(<ServiceTerminal {...props} />)
-    expect(screen.getByRole('button', { name: /pod-1/ })).toBeInTheDocument()
+    expect(screen.getByText(/pod-1/)).toBeInTheDocument()
   })
 
   it('should use /shell/exec endpoint by default', () => {
@@ -204,8 +204,8 @@ describe('ServiceTerminal', () => {
     const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
     const initialRequestId = getLatestWsSubscriptionSearchParams()['external_request_id']
 
-    await userEvent.click(screen.getByRole('button', { name: /pod-1/ }))
-    await userEvent.click(screen.getByRole('option', { name: /pod-2/ }))
+    await userEvent.click(screen.getByPlaceholderText('Select a pod'))
+    await userEvent.click(screen.getByText(/pod-2/))
 
     await waitFor(() => {
       expect(getLatestWsSubscriptionSearchParams()).toEqual(expect.objectContaining({ pod_name: 'pod-2' }))
@@ -221,8 +221,8 @@ describe('ServiceTerminal', () => {
       getLatestWsSubscriptionConfig().onOpen?.({} as QueryClient, createWebSocketEvent('open', initialWebsocket))
     })
 
-    await userEvent.click(screen.getByRole('button', { name: /pod-1/ }))
-    await userEvent.click(screen.getByRole('option', { name: /pod-2/ }))
+    await userEvent.click(screen.getByPlaceholderText('Select a pod'))
+    await userEvent.click(screen.getByText(/pod-2/))
 
     act(() => {
       getLatestWsSubscriptionConfig().onClose?.(

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.spec.tsx
@@ -4,6 +4,7 @@ import { useReactQueryWsSubscription } from '@qovery/state/util-queries'
 import { ServiceTerminal, type ServiceTerminalProps } from './service-terminal'
 
 const mockUseRunningStatus = jest.fn()
+const mockUseService = jest.fn()
 
 jest.mock('color', () => ({
   __esModule: true,
@@ -39,6 +40,7 @@ jest.mock('@qovery/state/util-queries', () => ({
 
 jest.mock('../..', () => ({
   useRunningStatus: (...args: unknown[]) => mockUseRunningStatus(...args),
+  useService: (...args: unknown[]) => mockUseService(...args),
 }))
 
 const props: ServiceTerminalProps = {
@@ -104,6 +106,9 @@ describe('ServiceTerminal', () => {
         state: 'STOPPED',
       },
       isLoading: false,
+    })
+    mockUseService.mockReturnValue({
+      data: { cpu: 1000, memory: 512, serviceType: 'APPLICATION' },
     })
   })
 
@@ -185,33 +190,25 @@ describe('ServiceTerminal', () => {
     })
   })
 
-  it('should show pod and container placeholders', async () => {
-    const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
-
-    expect(screen.getByPlaceholderText('Select a pod to connect to')).toBeInTheDocument()
-
-    await userEvent.click(screen.getByPlaceholderText('Select a pod to connect to'))
-    const [firstPodOption] = screen.getAllByRole('option')
-    await userEvent.click(firstPodOption)
-
-    expect(screen.getByPlaceholderText('Select a container to connect to')).toBeInTheDocument()
+  it('should pre-select the first pod on load', () => {
+    renderWithProviders(<ServiceTerminal {...props} />)
+    expect(screen.getByRole('button', { name: /pod-1/ })).toBeInTheDocument()
   })
 
-  it('should start a fresh terminal session when selecting a pod', async () => {
+  it('should use /shell/exec endpoint by default', () => {
+    renderWithProviders(<ServiceTerminal {...props} />)
+    expect(getLatestWsSubscriptionConfig().url).toContain('/shell/exec')
+  })
+
+  it('should start a fresh terminal session and update pod when selecting a different pod', async () => {
     const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
     const initialRequestId = getLatestWsSubscriptionSearchParams()['external_request_id']
 
-    await userEvent.click(screen.getByPlaceholderText('Select a pod to connect to'))
-    const [firstPodOption] = screen.getAllByRole('option')
-    await userEvent.click(firstPodOption)
+    await userEvent.click(screen.getByRole('button', { name: /pod-1/ }))
+    await userEvent.click(screen.getByRole('option', { name: /pod-2/ }))
 
     await waitFor(() => {
-      expect(getLatestWsSubscriptionSearchParams()).toEqual(
-        expect.objectContaining({
-          pod_name: 'pod-1',
-          container_name: undefined,
-        })
-      )
+      expect(getLatestWsSubscriptionSearchParams()).toEqual(expect.objectContaining({ pod_name: 'pod-2' }))
       expect(getLatestWsSubscriptionSearchParams()['external_request_id']).not.toBe(initialRequestId)
     })
   })
@@ -224,9 +221,8 @@ describe('ServiceTerminal', () => {
       getLatestWsSubscriptionConfig().onOpen?.({} as QueryClient, createWebSocketEvent('open', initialWebsocket))
     })
 
-    await userEvent.click(screen.getByPlaceholderText('Select a pod to connect to'))
-    const [firstPodOption] = screen.getAllByRole('option')
-    await userEvent.click(firstPodOption)
+    await userEvent.click(screen.getByRole('button', { name: /pod-1/ }))
+    await userEvent.click(screen.getByRole('option', { name: /pod-2/ }))
 
     act(() => {
       getLatestWsSubscriptionConfig().onClose?.(
@@ -237,5 +233,66 @@ describe('ServiceTerminal', () => {
 
     expect(screen.queryByText('Unable to launch CLI')).not.toBeInTheDocument()
     expect(useReactQueryWsSubscriptionMock).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: true }))
+  })
+
+  describe('ephemeral pod', () => {
+    it('should show the Switch to ephemeral pod button for APPLICATION', () => {
+      renderWithProviders(<ServiceTerminal {...props} serviceType="APPLICATION" />)
+      expect(screen.getByRole('button', { name: /switch to ephemeral pod/i })).toBeInTheDocument()
+    })
+
+    it('should show the Switch to ephemeral pod button for CONTAINER', () => {
+      renderWithProviders(<ServiceTerminal {...props} serviceType="CONTAINER" />)
+      expect(screen.getByRole('button', { name: /switch to ephemeral pod/i })).toBeInTheDocument()
+    })
+
+    it('should not show the Switch to ephemeral pod button for unsupported service types', () => {
+      renderWithProviders(<ServiceTerminal {...props} serviceType="JOB" />)
+      expect(screen.queryByRole('button', { name: /switch to ephemeral pod/i })).not.toBeInTheDocument()
+    })
+
+    it('should open the ephemeral modal pre-filled with service resources', async () => {
+      const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
+      await userEvent.click(screen.getByRole('button', { name: /switch to ephemeral pod/i }))
+      expect(screen.getByLabelText(/vCPU/i)).toHaveValue('1000')
+      expect(screen.getByLabelText(/Memory/i)).toHaveValue('512')
+    })
+
+    it('should switch to /shell/ephemeral with correct params after launch', async () => {
+      const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /switch to ephemeral pod/i }))
+      await userEvent.click(screen.getByRole('button', { name: 'Launch' }))
+
+      await waitFor(() => {
+        expect(getLatestWsSubscriptionConfig().url).toContain('/shell/ephemeral')
+        expect(getLatestWsSubscriptionSearchParams()).toEqual(
+          expect.objectContaining({ mode: 'clone', cpu_override: '1000m', memory_override: '512Mi' })
+        )
+      })
+    })
+
+    it('should show ephemeral active badge and back button after launch', async () => {
+      const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /switch to ephemeral pod/i }))
+      await userEvent.click(screen.getByRole('button', { name: 'Launch' }))
+
+      expect(screen.getByText(/Ephemeral pod/)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /back to live pod/i })).toBeInTheDocument()
+    })
+
+    it('should return to /shell/exec after clicking Back to live pod', async () => {
+      const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /switch to ephemeral pod/i }))
+      await userEvent.click(screen.getByRole('button', { name: 'Launch' }))
+      await userEvent.click(screen.getByRole('button', { name: /back to live pod/i }))
+
+      await waitFor(() => {
+        expect(getLatestWsSubscriptionConfig().url).toContain('/shell/exec')
+        expect(screen.queryByRole('button', { name: /back to live pod/i })).not.toBeInTheDocument()
+      })
+    })
   })
 })

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.spec.tsx
@@ -236,24 +236,24 @@ describe('ServiceTerminal', () => {
   })
 
   describe('ephemeral pod', () => {
-    it('should show the Switch to ephemeral pod button for APPLICATION', () => {
+    it('should show the Launch ephemeral pod button for APPLICATION', () => {
       renderWithProviders(<ServiceTerminal {...props} serviceType="APPLICATION" />)
-      expect(screen.getByRole('button', { name: /switch to ephemeral pod/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /launch ephemeral pod/i })).toBeInTheDocument()
     })
 
-    it('should show the Switch to ephemeral pod button for CONTAINER', () => {
+    it('should show the Launch ephemeral pod button for CONTAINER', () => {
       renderWithProviders(<ServiceTerminal {...props} serviceType="CONTAINER" />)
-      expect(screen.getByRole('button', { name: /switch to ephemeral pod/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /launch ephemeral pod/i })).toBeInTheDocument()
     })
 
-    it('should not show the Switch to ephemeral pod button for unsupported service types', () => {
+    it('should not show the Launch ephemeral pod button for unsupported service types', () => {
       renderWithProviders(<ServiceTerminal {...props} serviceType="JOB" />)
-      expect(screen.queryByRole('button', { name: /switch to ephemeral pod/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /launch ephemeral pod/i })).not.toBeInTheDocument()
     })
 
     it('should open the ephemeral modal pre-filled with service resources', async () => {
       const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
-      await userEvent.click(screen.getByRole('button', { name: /switch to ephemeral pod/i }))
+      await userEvent.click(screen.getByRole('button', { name: /launch ephemeral pod/i }))
       expect(screen.getByLabelText(/vCPU/i)).toHaveValue('1000')
       expect(screen.getByLabelText(/Memory/i)).toHaveValue('512')
     })
@@ -261,7 +261,7 @@ describe('ServiceTerminal', () => {
     it('should switch to /shell/ephemeral with correct params after launch', async () => {
       const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
 
-      await userEvent.click(screen.getByRole('button', { name: /switch to ephemeral pod/i }))
+      await userEvent.click(screen.getByRole('button', { name: /launch ephemeral pod/i }))
       await userEvent.click(screen.getByRole('button', { name: 'Launch' }))
 
       await waitFor(() => {
@@ -275,7 +275,7 @@ describe('ServiceTerminal', () => {
     it('should show ephemeral active badge and back button after launch', async () => {
       const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
 
-      await userEvent.click(screen.getByRole('button', { name: /switch to ephemeral pod/i }))
+      await userEvent.click(screen.getByRole('button', { name: /launch ephemeral pod/i }))
       await userEvent.click(screen.getByRole('button', { name: 'Launch' }))
 
       expect(screen.getByText(/Ephemeral pod/)).toBeInTheDocument()
@@ -285,7 +285,7 @@ describe('ServiceTerminal', () => {
     it('should return to /shell/exec after clicking Back to live pod', async () => {
       const { userEvent } = renderWithProviders(<ServiceTerminal {...props} />)
 
-      await userEvent.click(screen.getByRole('button', { name: /switch to ephemeral pod/i }))
+      await userEvent.click(screen.getByRole('button', { name: /launch ephemeral pod/i }))
       await userEvent.click(screen.getByRole('button', { name: 'Launch' }))
       await userEvent.click(screen.getByRole('button', { name: /back to live pod/i }))
 

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -277,14 +277,16 @@ export function ServiceTerminal({
         <div className="flex min-w-0 items-center gap-3 text-xs text-neutral-subtle">
           {ephemeralConfig ? (
             <>
-              <Badge variant="surface" color="brand" size="sm" radius="rounded" className="gap-1">
-                <Icon iconName="flask" iconStyle="solid" className="text-xs text-brand" />
-                Ephemeral pod · {ephemeralConfig.cpu}m CPU / {ephemeralConfig.memory} MiB
-              </Badge>
-              <Button variant="surface" color="neutral" size="xs" onClick={() => resetTerminalSession(null)}>
-                <Icon iconName="arrow-left" className="text-xs" />
+              <Button variant="surface" color="neutral" size="md" onClick={() => resetTerminalSession(null)}>
+                <Icon iconName="arrow-left" />
                 Back to live pod
               </Button>
+              <Tooltip content={`${ephemeralConfig.cpu}m CPU / ${ephemeralConfig.memory} MiB`} side="bottom">
+                <Badge variant="surface" color="brand" size="sm" radius="rounded" className="gap-1">
+                  Ephemeral pod
+                  <Icon iconName="circle-info" iconStyle="regular" className="text-xs" />
+                </Badge>
+              </Tooltip>
             </>
           ) : (
             <>
@@ -302,32 +304,26 @@ export function ServiceTerminal({
                 )}
               </div>
               {supportsEphemeral && (
-                <Tooltip
-                  content="Spawns a one-shot clone pod for troubleshooting. It mirrors your service's image and configuration but runs in isolation — nothing you do affects the live pods. The pod is automatically terminated when the session ends."
-                  side="bottom"
-                  classNameContent="max-w-xs whitespace-normal"
-                >
-                  <Button variant="surface" color="neutral" size="xs" onClick={onOpenEphemeralModal}>
-                    <Icon iconName="flask" iconStyle="solid" />
-                    Switch to ephemeral pod
-                    <Icon iconName="circle-info" iconStyle="regular" />
-                  </Button>
-                </Tooltip>
+                <Button variant="surface" color="neutral" size="xs" className="h-8" onClick={onOpenEphemeralModal}>
+                  Launch ephemeral pod
+                </Button>
               )}
             </>
           )}
         </div>
 
-        <ExternalLink
-          as="button"
-          href="https://www.qovery.com/docs/cli/overview"
-          variant="surface"
-          color="neutral"
-          size="md"
-        >
-          <Icon iconName="book" />
-          CLI docs
-        </ExternalLink>
+        <div className="flex items-center gap-3">
+          <ExternalLink
+            as="button"
+            href="https://www.qovery.com/docs/cli/overview"
+            variant="surface"
+            color="neutral"
+            size="md"
+          >
+            <Icon iconName="book" />
+            CLI docs
+          </ExternalLink>
+        </div>
       </div>
       <div className="flex h-full flex-1 flex-col bg-background px-3 pt-5">
         <div className="relative min-h-0 flex-1">

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -294,7 +294,6 @@ export function ServiceTerminal({
                 <span className="shrink-0 text-neutral-subtle">Connected to live pod:</span>
                 {runningStatuses && runningStatuses.pods.length > 0 && (
                   <InputSearch
-                    label=""
                     value={selectedOrDefaultPodName}
                     onChange={onSelectedPodChange}
                     data={runningStatuses.pods.map((pod) => pod.name)}

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -198,12 +198,10 @@ export function ServiceTerminal({
 
   const ephemeralDefaultValues = useMemo((): EphemeralShellFormValues => {
     const cpuMillicores = match(service)
-      .with({ serviceType: 'APPLICATION' }, (s) => s.cpu)
-      .with({ serviceType: 'CONTAINER' }, (s) => s.cpu)
+      .with({ serviceType: 'APPLICATION' }, { serviceType: 'CONTAINER' }, (s) => s.cpu)
       .otherwise(() => undefined)
     const memoryMib = match(service)
-      .with({ serviceType: 'APPLICATION' }, (s) => s.memory)
-      .with({ serviceType: 'CONTAINER' }, (s) => s.memory)
+      .with({ serviceType: 'APPLICATION' }, { serviceType: 'CONTAINER' }, (s) => s.memory)
       .otherwise(() => undefined)
     const cpu = cpuMillicores != null && cpuMillicores > 0 ? String(cpuMillicores) : '1000'
     const memory = memoryMib != null && memoryMib > 0 ? String(memoryMib) : '2048'

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -198,11 +198,13 @@ export function ServiceTerminal({
 
   const ephemeralDefaultValues = useMemo((): EphemeralShellFormValues => {
     const cpuMillicores = match(service)
-      .with({ serviceType: 'TERRAFORM' }, (s) => s.job_resources?.cpu_milli)
-      .otherwise((s) => s?.cpu)
+      .with({ serviceType: 'APPLICATION' }, (s) => s.cpu)
+      .with({ serviceType: 'CONTAINER' }, (s) => s.cpu)
+      .otherwise(() => undefined)
     const memoryMib = match(service)
-      .with({ serviceType: 'TERRAFORM' }, (s) => s.job_resources?.ram_mib)
-      .otherwise((s) => s?.memory)
+      .with({ serviceType: 'APPLICATION' }, (s) => s.memory)
+      .with({ serviceType: 'CONTAINER' }, (s) => s.memory)
+      .otherwise(() => undefined)
     const cpu = cpuMillicores != null && cpuMillicores > 0 ? String(cpuMillicores) : '1000'
     const memory = memoryMib != null && memoryMib > 0 ? String(memoryMib) : '2048'
     return { cpu, memory }

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -8,11 +8,22 @@ import { XTerm } from 'react-xtermjs'
 import { match } from 'ts-pattern'
 import { v7 as uuidv7 } from 'uuid'
 import { type ServiceType } from '@qovery/domains/services/data-access'
-import { Button, EmptyState, ExternalLink, Icon, LoaderSpinner, toast } from '@qovery/shared/ui'
+import {
+  Badge,
+  Button,
+  EmptyState,
+  ExternalLink,
+  Icon,
+  LoaderSpinner,
+  Tooltip,
+  toast,
+  useModal,
+} from '@qovery/shared/ui'
 import { useTerminalReadiness } from '@qovery/shared/util-hooks'
 import { QOVERY_WS } from '@qovery/shared/util-node-env'
 import { useReactQueryWsSubscription } from '@qovery/state/util-queries'
-import { useRunningStatus } from '../..'
+import { useRunningStatus, useService } from '../..'
+import { type EphemeralShellFormValues, EphemeralShellModal } from './ephemeral-shell-modal/ephemeral-shell-modal'
 import { InputSearch } from './input-search/input-search'
 import { TerminalShellActionsAddon } from './terminal-shell-banner-addon'
 
@@ -39,6 +50,7 @@ export function ServiceTerminal({
   serviceType,
 }: ServiceTerminalProps) {
   const { data: runningStatuses } = useRunningStatus({ environmentId, serviceId })
+  const { data: service } = useService({ serviceId, serviceType })
   const hasWrittenShellBannerRef = useRef(false)
   const activeWebSocketRef = useRef<WebSocket | null>(null)
   const [requestId, setRequestId] = useState(() => uuidv7())
@@ -88,17 +100,24 @@ export function ServiceTerminal({
     [backgroundColor, foreground, selectionBackground, selectionForeground]
   )
 
+  const { openModal, closeModal } = useModal()
+  const [ephemeralConfig, setEphemeralConfig] = useState<EphemeralShellFormValues | null>(null)
+  const supportsEphemeral = serviceType === 'APPLICATION' || serviceType === 'CONTAINER'
+
   const [selectedPod, setSelectedPod] = useState<string | undefined>()
-  const [selectedContainer, setSelectedContainer] = useState<string | undefined>()
 
   const selectedOrDefaultPodName = selectedPod ?? runningStatuses?.pods[0]?.name
-  const selectedOrDefaultContainerName =
-    selectedContainer ?? runningStatuses?.pods.find((pod) => pod.name === selectedOrDefaultPodName)?.containers[0]?.name
-  const connectShellCommand = buildCommand(
-    `qovery shell https://console.qovery.com/organization/${organizationId}/project/${projectId}/environment/${environmentId}/service/${serviceId}`,
-    selectedOrDefaultPodName ? `--pod=${selectedOrDefaultPodName}` : undefined,
-    selectedOrDefaultContainerName ? `--container=${selectedOrDefaultContainerName}` : undefined
-  )
+  const connectShellCommand = ephemeralConfig
+    ? buildCommand(
+        `qovery shell --ephemeral --mode clone`,
+        `--cpu ${ephemeralConfig.cpu}m`,
+        `--memory ${ephemeralConfig.memory}Mi`,
+        `https://console.qovery.com/organization/${organizationId}/project/${projectId}/environment/${environmentId}/service/${serviceId}`
+      )
+    : buildCommand(
+        `qovery shell https://console.qovery.com/organization/${organizationId}/project/${projectId}/environment/${environmentId}/service/${serviceId}`,
+        selectedOrDefaultPodName ? `--pod=${selectedOrDefaultPodName}` : undefined
+      )
   const portForwardCommand = buildCommand(
     `qovery port-forward https://console.qovery.com/organization/${organizationId}/project/${projectId}/environment/${environmentId}/service/${serviceId} --port local-port:target-port`
   )
@@ -127,7 +146,8 @@ export function ServiceTerminal({
           getPortForwardCommand,
           getShellCommand,
           shouldWriteShellBanner,
-          requestId
+          requestId,
+          ephemeralConfig !== null
         ),
       ])
     },
@@ -152,15 +172,49 @@ export function ServiceTerminal({
     [detachWebSocket]
   )
 
-  const resetTerminalSession = useCallback(() => {
-    activeWebSocketRef.current = null
-    detachWebSocket()
-    hasWrittenShellBannerRef.current = false
-    setAddons([])
-    setTerminalLaunchError(null)
-    setRequestId(uuidv7())
-    resetTerminalReadiness()
-  }, [detachWebSocket, resetTerminalReadiness])
+  const resetTerminalSession = useCallback(
+    (nextEphemeralConfig?: EphemeralShellFormValues | null) => {
+      activeWebSocketRef.current = null
+      detachWebSocket()
+      hasWrittenShellBannerRef.current = false
+      setAddons([])
+      setTerminalLaunchError(null)
+      setRequestId(uuidv7())
+      resetTerminalReadiness()
+      if (nextEphemeralConfig !== undefined) {
+        setEphemeralConfig(nextEphemeralConfig)
+      }
+    },
+    [detachWebSocket, resetTerminalReadiness]
+  )
+
+  const onLaunchEphemeral = useCallback(
+    (values: EphemeralShellFormValues) => {
+      setSelectedPod(undefined)
+      resetTerminalSession(values)
+    },
+    [resetTerminalSession]
+  )
+
+  const ephemeralDefaultValues = useMemo((): EphemeralShellFormValues => {
+    const cpuMillicores = match(service)
+      .with({ serviceType: 'TERRAFORM' }, (s) => s.job_resources?.cpu_milli)
+      .otherwise((s) => s?.cpu)
+    const memoryMib = match(service)
+      .with({ serviceType: 'TERRAFORM' }, (s) => s.job_resources?.ram_mib)
+      .otherwise((s) => s?.memory)
+    const cpu = cpuMillicores != null && cpuMillicores > 0 ? String(cpuMillicores) : '1000'
+    const memory = memoryMib != null && memoryMib > 0 ? String(memoryMib) : '2048'
+    return { cpu, memory }
+  }, [service])
+
+  const onOpenEphemeralModal = useCallback(() => {
+    openModal({
+      content: (
+        <EphemeralShellModal onClose={closeModal} onLaunch={onLaunchEphemeral} defaultValues={ephemeralDefaultValues} />
+      ),
+    })
+  }, [closeModal, ephemeralDefaultValues, onLaunchEphemeral, openModal])
 
   const onRetryCliLaunch = useCallback(() => {
     resetTerminalSession()
@@ -170,15 +224,6 @@ export function ServiceTerminal({
     (pod?: string) => {
       resetTerminalSession()
       setSelectedPod(pod)
-      setSelectedContainer(undefined)
-    },
-    [resetTerminalSession]
-  )
-
-  const onSelectedContainerChange = useCallback(
-    (container?: string) => {
-      resetTerminalSession()
-      setSelectedContainer(container)
     },
     [resetTerminalSession]
   )
@@ -198,7 +243,7 @@ export function ServiceTerminal({
   const cols = Math.ceil(document.body.clientWidth / 8)
 
   useReactQueryWsSubscription({
-    url: QOVERY_WS + '/shell/exec',
+    url: QOVERY_WS + (ephemeralConfig ? '/shell/ephemeral' : '/shell/exec'),
     urlSearchParams: {
       organization: organizationId,
       cluster: clusterId,
@@ -206,8 +251,9 @@ export function ServiceTerminal({
       environment: environmentId,
       service: serviceId,
       service_type: serviceType,
-      pod_name: selectedPod,
-      container_name: selectedContainer,
+      ...(ephemeralConfig
+        ? { mode: 'clone', cpu_override: `${ephemeralConfig.cpu}m`, memory_override: `${ephemeralConfig.memory}Mi` }
+        : { pod_name: selectedPod }),
       tty_height: rows.toString(),
       tty_width: cols.toString(),
       external_request_id: requestId,
@@ -225,44 +271,51 @@ export function ServiceTerminal({
 
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-none border-0 bg-background">
-      <div className="flex h-14 justify-between border-b border-neutral p-3">
-        <div className="flex gap-2 [&_input]:w-72">
-          {runningStatuses && runningStatuses.pods.length > 0 && (
-            <div className="relative">
-              <InputSearch
-                value={selectedPod}
-                onChange={onSelectedPodChange}
-                data={runningStatuses.pods.map((pod) => pod.name)}
-                placeholder="Select a pod to connect to"
-                trimLabel
-              />
-              {!selectedPod && (
-                <div className="pointer-events-none absolute right-2.5 top-1/2 z-20 -translate-y-1/2 text-xs text-neutral-subtle">
-                  <Icon iconName="angle-down" />
-                </div>
+      <div className="flex h-12 items-center justify-between gap-3 border-b border-neutral px-3">
+        <div className="flex min-w-0 items-center gap-3 text-xs text-neutral-subtle">
+          {ephemeralConfig ? (
+            <>
+              <Badge variant="surface" color="brand" size="sm" radius="rounded" className="gap-1">
+                <Icon iconName="flask" iconStyle="solid" className="text-xs text-brand" />
+                Ephemeral pod · {ephemeralConfig.cpu}m CPU / {ephemeralConfig.memory} MiB
+              </Badge>
+              <Button variant="surface" color="neutral" size="xs" onClick={() => resetTerminalSession(null)}>
+                <Icon iconName="arrow-left" className="text-xs" />
+                Back to live pod
+              </Button>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <span className="shrink-0 text-neutral-subtle">Connected to live pod:</span>
+                {runningStatuses && runningStatuses.pods.length > 0 && (
+                  <InputSearch
+                    label=""
+                    value={selectedOrDefaultPodName}
+                    onChange={onSelectedPodChange}
+                    data={runningStatuses.pods.map((pod) => pod.name)}
+                    placeholder="Select a pod"
+                    trimLabel
+                  />
+                )}
+              </div>
+              {supportsEphemeral && (
+                <Tooltip
+                  content="Spawns a one-shot clone pod for troubleshooting. It mirrors your service's image and configuration but runs in isolation — nothing you do affects the live pods. The pod is automatically terminated when the session ends."
+                  side="bottom"
+                  classNameContent="max-w-xs whitespace-normal"
+                >
+                  <Button variant="surface" color="neutral" size="xs" onClick={onOpenEphemeralModal}>
+                    <Icon iconName="flask" iconStyle="solid" />
+                    Switch to ephemeral pod
+                    <Icon iconName="circle-info" iconStyle="regular" />
+                  </Button>
+                </Tooltip>
               )}
-            </div>
-          )}
-          {runningStatuses && selectedPod && (
-            <div className="relative">
-              <InputSearch
-                value={selectedContainer}
-                onChange={onSelectedContainerChange}
-                data={
-                  runningStatuses.pods
-                    .find((pod) => selectedPod === pod?.name)
-                    ?.containers.map((container) => container?.name) || []
-                }
-                placeholder="Select a container to connect to"
-              />
-              {!selectedContainer && (
-                <div className="pointer-events-none absolute right-2.5 top-1/2 z-20 -translate-y-1/2 text-xs text-neutral-subtle">
-                  <Icon iconName="angle-down" iconStyle="solid" />
-                </div>
-              )}
-            </div>
+            </>
           )}
         </div>
+
         <ExternalLink
           as="button"
           href="https://www.qovery.com/docs/cli/overview"
@@ -287,8 +340,15 @@ export function ServiceTerminal({
             <>
               {!isTerminalLoading && <MemoizedXTerm className="h-full" addons={addons} options={terminalOptions} />}
               {showLoader && (
-                <div className="absolute inset-0 flex items-start justify-center border-neutral bg-background pt-3">
+                <div className="absolute inset-0 flex flex-col items-center gap-2 border-neutral bg-background pt-6">
                   <LoaderSpinner />
+                  <span className="text-xs text-neutral-subtle">
+                    {ephemeralConfig
+                      ? 'Provisioning ephemeral pod…'
+                      : isTerminalLoading
+                        ? 'Connecting…'
+                        : 'Waiting for shell…'}
+                  </span>
                 </div>
               )}
             </>

--- a/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
+++ b/libs/domains/services/feature/src/lib/service-terminal/service-terminal.tsx
@@ -311,18 +311,16 @@ export function ServiceTerminal({
           )}
         </div>
 
-        <div className="flex items-center gap-3">
-          <ExternalLink
-            as="button"
-            href="https://www.qovery.com/docs/cli/overview"
-            variant="surface"
-            color="neutral"
-            size="md"
-          >
-            <Icon iconName="book" />
-            CLI docs
-          </ExternalLink>
-        </div>
+        <ExternalLink
+          as="button"
+          href="https://www.qovery.com/docs/cli/overview"
+          variant="surface"
+          color="neutral"
+          size="md"
+        >
+          <Icon iconName="book" />
+          CLI docs
+        </ExternalLink>
       </div>
       <div className="flex h-full flex-1 flex-col bg-background px-3 pt-5">
         <div className="relative min-h-0 flex-1">

--- a/libs/domains/services/feature/src/lib/service-terminal/terminal-shell-banner-addon.ts
+++ b/libs/domains/services/feature/src/lib/service-terminal/terminal-shell-banner-addon.ts
@@ -22,6 +22,7 @@ interface TerminalBannerSegment {
 export class TerminalShellActionsAddon implements ITerminalAddon {
   private static readonly COPY_COMMAND_LABEL = '[copy command]'
   private static readonly FIRST_COMMAND_TITLE = '1. Use $ qovery shell in your local terminal'
+  private static readonly FIRST_COMMAND_TITLE_EPHEMERAL = 'Use $ qovery shell --ephemeral in your local terminal'
   private static readonly SECOND_COMMAND_TITLE = '2. Use $ qovery port-forward in your local terminal'
   private static readonly LOOKBACK_LINE_COUNT = 6
 
@@ -38,7 +39,8 @@ export class TerminalShellActionsAddon implements ITerminalAddon {
     private readonly getPortForwardCommand: () => string,
     private readonly getShellCommand: () => string,
     private readonly shouldWriteBanner: boolean,
-    private readonly requestId: string
+    private readonly requestId: string,
+    private readonly isEphemeral: boolean = false
   ) {}
 
   private toAnsiColor(color: string): string {
@@ -168,21 +170,35 @@ export class TerminalShellActionsAddon implements ITerminalAddon {
     }
 
     const firstCommandLine: TerminalBannerSegment[] = [
-      { bold: true, color: this.colors.warning, text: TerminalShellActionsAddon.FIRST_COMMAND_TITLE },
+      {
+        bold: true,
+        color: this.colors.warning,
+        text: this.isEphemeral
+          ? TerminalShellActionsAddon.FIRST_COMMAND_TITLE_EPHEMERAL
+          : TerminalShellActionsAddon.FIRST_COMMAND_TITLE,
+      },
     ]
 
     const secondCommandLine: TerminalBannerSegment[] = [
       { bold: true, color: this.colors.warning, text: TerminalShellActionsAddon.SECOND_COMMAND_TITLE },
     ]
 
+    const firstCommandDescription = this.isEphemeral
+      ? 'Open an interactive shell inside an ephemeral container'
+      : 'Open an interactive shell inside a running container'
+
     const bannerLines: TerminalBannerSegment[][] = [
       firstCommandLine,
-      [{ color: this.colors.subtle, text: 'Open an interactive shell inside a running container' }],
+      [{ color: this.colors.subtle, text: firstCommandDescription }],
       [{ text: TerminalShellActionsAddon.COPY_COMMAND_LABEL }],
-      [{ text: '' }],
-      secondCommandLine,
-      [{ color: this.colors.subtle, text: 'Forward a pod port to localhost' }],
-      [{ text: TerminalShellActionsAddon.COPY_COMMAND_LABEL }],
+      ...(this.isEphemeral
+        ? []
+        : ([
+            [{ text: '' }],
+            secondCommandLine,
+            [{ color: this.colors.subtle, text: 'Forward a pod port to localhost' }],
+            [{ text: TerminalShellActionsAddon.COPY_COMMAND_LABEL }],
+          ] satisfies TerminalBannerSegment[][])),
       [{ text: '' }],
       [{ color: this.colors.subtle, text: `Request ID: ${this.requestId}` }],
     ]

--- a/libs/domains/services/feature/src/lib/service-terminal/terminal-shell-banner-addon.ts
+++ b/libs/domains/services/feature/src/lib/service-terminal/terminal-shell-banner-addon.ts
@@ -40,7 +40,7 @@ export class TerminalShellActionsAddon implements ITerminalAddon {
     private readonly getShellCommand: () => string,
     private readonly shouldWriteBanner: boolean,
     private readonly requestId: string,
-    private readonly isEphemeral: boolean = false
+    private readonly isEphemeral = false
   ) {}
 
   private toAnsiColor(color: string): string {

--- a/libs/domains/services/feature/src/lib/service-terminal/terminal-shell-banner-addon.ts
+++ b/libs/domains/services/feature/src/lib/service-terminal/terminal-shell-banner-addon.ts
@@ -153,7 +153,10 @@ export class TerminalShellActionsAddon implements ITerminalAddon {
       return () => this.copyCommandToClipboard(this.getPortForwardCommand())
     }
 
-    if (contextLines.includes(TerminalShellActionsAddon.FIRST_COMMAND_TITLE)) {
+    if (
+      contextLines.includes(TerminalShellActionsAddon.FIRST_COMMAND_TITLE) ||
+      contextLines.includes(TerminalShellActionsAddon.FIRST_COMMAND_TITLE_EPHEMERAL)
+    ) {
       return () => this.copyCommandToClipboard(this.getShellCommand())
     }
 


### PR DESCRIPTION
## Summary

- Adds a **Switch to ephemeral pod** button to the Cloud Shell toolbar (APPLICATION and CONTAINER service types only), mirroring `qovery shell --ephemeral --mode clone` CLI behaviour
- Opens a modal pre-filled with the service's configured CPU (milli) and Memory (MiB) — launches a one-shot clone pod via the `/shell/ephemeral` WebSocket endpoint
- Active ephemeral state shows a badge with resource info and a **Back to live pod** button
- Terminal banner adapts in ephemeral mode: hides the port-forward section and updates the shell command title/description
- pre-filled pod switch with current pod connected to
- updated initial message in the shell, no port-forward for ephemeral pods

<img width="970" height="523" alt="image" src="https://github.com/user-attachments/assets/27d7b5fe-2e7e-49a2-b788-90277f38da94" />



Video here:
https://www.loom.com/share/2019a108ee8643ec8b99ef940db7705e
