### PR TITLE
fix(services): clarify skipped service status

### DIFF
--- a/libs/domains/services/feature/src/lib/hooks/use-service-deployment-and-running-statuses/service-status-utils.spec.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-service-deployment-and-running-statuses/service-status-utils.spec.ts
@@ -1,0 +1,66 @@
+import { type Status } from 'qovery-typescript-axios'
+import { type AnyService } from '@qovery/domains/services/data-access'
+import { getServiceListStatus, getServiceRunningStatus } from './service-status-utils'
+
+const managedDatabase = {
+  id: 'database-id',
+  service_type: 'DATABASE',
+  serviceType: 'DATABASE',
+  mode: 'MANAGED',
+} as AnyService
+
+const createDeploymentStatus = (overrides: Partial<Status> = {}) =>
+  ({
+    id: 'database-id',
+    state: 'READY',
+    service_deployment_status: 'UP_TO_DATE',
+    is_part_last_deployment: false,
+    status_details: {
+      action: 'DEPLOY',
+      status: 'SUCCESS',
+      sub_action: 'NONE',
+    },
+    deployment_request_id: null,
+    deployment_requests_count: 0,
+    ...overrides,
+  }) as Status
+
+describe('service status utils', () => {
+  it('keeps skipped managed databases with previous deployment metadata displayed as running', () => {
+    const runningStatus = getServiceRunningStatus({
+      service: managedDatabase,
+      deploymentStatus: createDeploymentStatus({
+        last_deployment_date: '2026-05-25T07:00:00Z',
+        execution_id: 'execution-id',
+      }),
+    })
+
+    expect(runningStatus.state).toBe('RUNNING')
+    expect(runningStatus.stateLabel).toBe('Running')
+  })
+
+  it('keeps never deployed managed databases unknown when deployment state is ready', () => {
+    const runningStatus = getServiceRunningStatus({
+      service: managedDatabase,
+      deploymentStatus: createDeploymentStatus(),
+    })
+
+    expect(runningStatus.state).toBe('UNKNOWN')
+    expect(runningStatus.stateLabel).toBe('Unknown')
+  })
+
+  it('keeps the running status as the service list status when the service is skipped', () => {
+    const status = getServiceListStatus({
+      ...managedDatabase,
+      deploymentStatus: createDeploymentStatus({
+        state: 'READY',
+        last_deployment_date: '2026-05-25T07:00:00Z',
+      }),
+      runningStatus: {
+        state: 'RUNNING',
+      },
+    })
+
+    expect(status).toBe('RUNNING')
+  })
+})

--- a/libs/domains/services/feature/src/lib/hooks/use-service-deployment-and-running-statuses/service-status-utils.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-service-deployment-and-running-statuses/service-status-utils.ts
@@ -1,0 +1,79 @@
+import { type Status } from 'qovery-typescript-axios'
+import { type ServiceStateDto } from 'qovery-ws-typescript-axios'
+import { P, match } from 'ts-pattern'
+import { type AnyService, isManagedDatabase } from '@qovery/domains/services/data-access'
+import { type ServiceRunningStatus } from '@qovery/shared/interfaces'
+import { upperCaseFirstLetter } from '@qovery/shared/util-js'
+
+type ServiceListStatus = Status['state'] | ServiceRunningStatus['state'] | 'SKIPPED'
+type ServiceWithStatuses = AnyService & {
+  deploymentStatus?: Pick<Status, 'state'> | null
+  runningStatus?: { state?: ServiceRunningStatus['state'] } | null
+}
+
+export function formatDeploymentStatusLabel(deploymentStatus?: Status | null) {
+  return upperCaseFirstLetter(
+    (deploymentStatus?.state === 'READY' ? 'NEVER_DEPLOYED' : deploymentStatus?.state)?.replace('_', ' ') ?? 'STOPPED'
+  )
+}
+
+export function formatRunningStatusLabel(state?: ServiceStateDto) {
+  return upperCaseFirstLetter(state?.replace('_', ' ') ?? 'STOPPED')
+}
+
+function hasPreviousDeployment(deploymentStatus?: Status | null) {
+  return Boolean(deploymentStatus?.last_deployment_date || deploymentStatus?.execution_id)
+}
+
+export function getServiceListStatus(service: ServiceWithStatuses): ServiceListStatus {
+  return (
+    service.runningStatus?.state ??
+    match(service)
+      .with({ serviceType: 'DATABASE', mode: 'MANAGED' }, () => service.deploymentStatus?.state)
+      .otherwise(() => service.runningStatus?.state)
+  )
+}
+
+export function getManagedDatabaseRunningStatus(deploymentStatus?: Status | null): ServiceRunningStatus {
+  return {
+    triggered_action: undefined,
+    ...deploymentStatus,
+    state: match(deploymentStatus?.state)
+      .with('DEPLOYED', () => 'RUNNING' as const)
+      .with('READY', () => (hasPreviousDeployment(deploymentStatus) ? ('RUNNING' as const) : ('UNKNOWN' as const)))
+      .with('STOPPED', () => 'STOPPED' as const)
+      .otherwise(() => 'UNKNOWN' as const),
+    stateLabel: match(deploymentStatus?.state)
+      .with('DEPLOYED', () => 'Running')
+      .with('READY', () => (hasPreviousDeployment(deploymentStatus) ? 'Running' : 'Unknown'))
+      .with('STOPPED', () => 'Stopped')
+      .otherwise(() => 'Unknown'),
+  }
+}
+
+export function getServiceRunningStatus({
+  service,
+  runningStatus,
+  deploymentStatus,
+}: {
+  service?: AnyService
+  runningStatus?: { triggered_action?: ServiceRunningStatus['triggered_action']; state: ServiceStateDto } | null
+  deploymentStatus?: Status | null
+}): ServiceRunningStatus {
+  const runningStatusLabel = formatRunningStatusLabel(runningStatus?.state)
+  const isManagedDb = isManagedDatabase(service)
+
+  return match({ runningStatus, isManagedDb })
+    .with({ runningStatus: P.any, isManagedDb: true }, () => getManagedDatabaseRunningStatus(deploymentStatus))
+    .with({ runningStatus: P.nullish, isManagedDb: false }, () => ({
+      state: undefined,
+      stateLabel: undefined,
+      triggered_action: undefined,
+    }))
+    .with({ runningStatus: P.not(P.nullish) }, ({ runningStatus }) => ({
+      triggered_action: undefined,
+      ...runningStatus,
+      stateLabel: runningStatusLabel,
+    }))
+    .exhaustive()
+}

--- a/libs/domains/services/feature/src/lib/hooks/use-service-deployment-and-running-statuses/use-service-deployment-and-running-statuses.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-service-deployment-and-running-statuses/use-service-deployment-and-running-statuses.ts
@@ -1,9 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
-import { P, match } from 'ts-pattern'
-import { type AnyService, isManagedDatabase } from '@qovery/domains/services/data-access'
-import { type ServiceRunningStatus, type ServiceStatuses } from '@qovery/shared/interfaces'
-import { upperCaseFirstLetter } from '@qovery/shared/util-js'
+import { type AnyService } from '@qovery/domains/services/data-access'
+import { type ServiceStatuses } from '@qovery/shared/interfaces'
 import { queries } from '@qovery/state/util-queries'
+import { formatDeploymentStatusLabel, getServiceRunningStatus } from './service-status-utils'
 
 export interface UseDeploymentFullStatusProps {
   environmentId?: string
@@ -21,33 +20,8 @@ export function useServiceDeploymentAndRunningStatuses({ environmentId = '', ser
     ...queries.services.deploymentStatus(environmentId, serviceId),
   })
 
-  const deploymentStatusLabel = upperCaseFirstLetter(
-    (deploymentStatus?.state === 'READY' ? 'NEVER_DEPLOYED' : deploymentStatus?.state)?.replace('_', ' ') ?? 'STOPPED'
-  )
-  const runningStatusLabel = upperCaseFirstLetter(runningStatus?.state.replace('_', ' ') ?? 'STOPPED')
-  const isManagedDb = isManagedDatabase(service)
-  const runningStatusOverride: ServiceRunningStatus = match({ runningStatus, isManagedDb })
-    .with({ runningStatus: P.any, isManagedDb: true }, () => ({
-      triggered_action: undefined,
-      ...deploymentStatus,
-      state: match(deploymentStatus?.state)
-        .with('DEPLOYED', () => 'RUNNING' as const)
-        .otherwise(() => 'UNKNOWN' as const),
-      stateLabel: match(deploymentStatus?.state)
-        .with('DEPLOYED', () => 'Running')
-        .otherwise(() => 'Unknown'),
-    }))
-    .with({ runningStatus: P.nullish, isManagedDb: false }, () => ({
-      state: undefined,
-      stateLabel: undefined,
-      triggered_action: undefined,
-    }))
-    .with({ runningStatus: P.not(P.nullish) }, ({ runningStatus }) => ({
-      triggered_action: undefined, // will be unpacked from runningStatus if present
-      ...runningStatus,
-      stateLabel: runningStatusLabel,
-    }))
-    .exhaustive()
+  const deploymentStatusLabel = formatDeploymentStatusLabel(deploymentStatus)
+  const runningStatusOverride = getServiceRunningStatus({ service, runningStatus, deploymentStatus })
 
   const data: ServiceStatuses = {
     runningStatus: runningStatusOverride,

--- a/libs/domains/services/feature/src/lib/hooks/use-services/use-services.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-services/use-services.ts
@@ -1,9 +1,10 @@
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import { P, match } from 'ts-pattern'
-import { isManagedDatabase } from '@qovery/domains/services/data-access'
-import { upperCaseFirstLetter } from '@qovery/shared/util-js'
 import { queries } from '@qovery/state/util-queries'
+import {
+  formatDeploymentStatusLabel,
+  getServiceRunningStatus,
+} from '../use-service-deployment-and-running-statuses/service-status-utils'
 
 export interface UseServicesProps {
   environmentId?: string
@@ -37,35 +38,8 @@ export function useServices({ environmentId, suspense = false }: UseServicesProp
       const runningStatus = runningStatusResults[index].data
       const deploymentStatus = deploymentStatusResults[index].data
 
-      const runningStatusLabel = upperCaseFirstLetter(runningStatus?.state.replace('_', ' ') ?? 'STOPPED')
-      const deploymentStatusLabel = upperCaseFirstLetter(
-        (deploymentStatus?.state === 'READY' ? 'NEVER_DEPLOYED' : deploymentStatus?.state)?.replace('_', ' ') ??
-          'STOPPED'
-      )
-      const isManagedDb = isManagedDatabase(service)
-
-      const runningStatusOverride = match({ runningStatus, isManagedDb })
-        .with({ runningStatus: P.any, isManagedDb: true }, () => ({
-          triggered_action: undefined,
-          ...deploymentStatus,
-          state: match(deploymentStatus?.state)
-            .with('DEPLOYED', () => 'RUNNING' as const)
-            .otherwise(() => 'UNKNOWN' as const),
-          stateLabel: match(deploymentStatus?.state)
-            .with('DEPLOYED', () => 'Running')
-            .otherwise(() => 'Unknown'),
-        }))
-        .with({ runningStatus: P.nullish, isManagedDb: false }, () => ({
-          state: undefined,
-          stateLabel: undefined,
-          triggered_action: undefined,
-        }))
-        .with({ runningStatus: P.not(P.nullish) }, ({ runningStatus }) => ({
-          triggered_action: undefined, // will be unpacked from runningStatus if present
-          ...runningStatus,
-          stateLabel: runningStatusLabel,
-        }))
-        .exhaustive()
+      const deploymentStatusLabel = formatDeploymentStatusLabel(deploymentStatus)
+      const runningStatusOverride = getServiceRunningStatus({ service, runningStatus, deploymentStatus })
 
       return {
         ...service,

--- a/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.spec.tsx
@@ -78,4 +78,49 @@ describe('ServiceLastDeploymentCell', () => {
     expect(screen.queryByText('Launch diagnostic')).not.toBeInTheDocument()
     expect(screen.getByText('Deploy').previousElementSibling).toHaveClass('text-neutral-subtle')
   })
+
+  it('keeps the last operation visible when a ready service has previous deployment metadata', () => {
+    mockUseServiceDeploymentAndRunningStatuses.mockReturnValue({
+      data: {
+        deploymentStatus: {
+          execution_id: 'execution-id',
+          last_deployment_date: '2026-05-25T07:00:00Z',
+          state: 'READY',
+          status_details: {
+            action: 'DEPLOY',
+            status: 'SUCCESS',
+            sub_action: 'NONE',
+          },
+        },
+      },
+    })
+
+    renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} />)
+
+    expect(screen.queryByText('No operations yet')).not.toBeInTheDocument()
+    expect(screen.getByText('Deploy')).toBeInTheDocument()
+  })
+
+  it('shows skipped as last operation for skipped services without service deployment date', () => {
+    mockUseServiceDeploymentAndRunningStatuses.mockReturnValue({
+      data: {
+        deploymentStatus: {
+          execution_id: 'execution-id',
+          last_deployment_date: '2026-05-25T07:00:00Z',
+          state: 'READY',
+          status_details: {
+            action: 'DEPLOY',
+            status: 'SUCCESS',
+            sub_action: 'NONE',
+          },
+        },
+      },
+    })
+
+    renderWithProviders(<ServiceLastDeploymentCell environment={environment} service={service} isSkipped />)
+
+    expect(screen.getByText('Skipped')).toBeInTheDocument()
+    expect(screen.queryByText(/ago/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Deploy')).not.toBeInTheDocument()
+  })
 })

--- a/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list-cells/service-last-deployment-cell.tsx
@@ -9,15 +9,17 @@ import { useServiceDeploymentAndRunningStatuses } from '../../hooks/use-service-
 type ServiceLastDeploymentCellProps = {
   service: AnyService
   environment: Environment
+  isSkipped?: boolean
 }
 
-export function ServiceLastDeploymentCell({ service, environment }: ServiceLastDeploymentCellProps) {
+export function ServiceLastDeploymentCell({ service, environment, isSkipped = false }: ServiceLastDeploymentCellProps) {
   const {
     data: { deploymentStatus },
   } = useServiceDeploymentAndRunningStatuses({ environmentId: environment.id, service })
   const subAction = deploymentStatus?.status_details?.sub_action
   const triggerAction = subAction !== 'NONE' ? subAction : deploymentStatus?.status_details?.action
   const hasDeploymentError = deploymentStatus?.status_details?.status === 'ERROR'
+  const hasPreviousDeployment = Boolean(deploymentStatus?.last_deployment_date || deploymentStatus?.execution_id)
 
   const WrappingLink = useCallback(
     ({ children }: PropsWithChildren) => {
@@ -44,7 +46,17 @@ export function ServiceLastDeploymentCell({ service, environment }: ServiceLastD
     [environment, service, deploymentStatus?.execution_id]
   )
 
-  return deploymentStatus?.state === 'READY' ? (
+  if (isSkipped) {
+    return (
+      <div className="flex w-full items-center justify-between gap-4">
+        <div className="group flex items-center gap-2">
+          <DeploymentAction status="SKIPPED" iconClassName="text-neutral-subtle" />
+        </div>
+      </div>
+    )
+  }
+
+  return deploymentStatus?.state === 'READY' && !hasPreviousDeployment ? (
     <span className="text-sm font-normal text-neutral-subtle">No operations yet</span>
   ) : (
     <div className="flex w-full items-center justify-between gap-4">

--- a/libs/domains/services/feature/src/lib/service-list/service-list.tsx
+++ b/libs/domains/services/feature/src/lib/service-list/service-list.tsx
@@ -31,6 +31,7 @@ import {
 } from '@qovery/shared/ui'
 import { pluralize, twMerge } from '@qovery/shared/util-js'
 import { useListDeploymentStages } from '../hooks/use-list-deployment-stages/use-list-deployment-stages'
+import { getServiceListStatus } from '../hooks/use-service-deployment-and-running-statuses/service-status-utils'
 import { useServices } from '../hooks/use-services/use-services'
 import { ServiceActions } from '../service-actions/service-actions'
 import { ServiceListActionBar } from './service-list-action-bar'
@@ -126,14 +127,15 @@ export function ServiceList({ className, containerClassName, environment, ...pro
 
   const actualServices = useMemo(() => {
     return serviceList.map((service) => {
+      const isSkipped = skippedServicesMap.get(service.id) || false
+
       return {
         ...service,
-        status: match(service)
-          .with({ serviceType: 'DATABASE', mode: 'MANAGED' }, () => service.deploymentStatus?.state)
-          .otherwise(() => service.runningStatus?.state),
+        isSkipped,
+        status: getServiceListStatus(service),
       }
     })
-  }, [serviceList])
+  }, [serviceList, skippedServicesMap])
 
   const sortedServices = useMemo(() => {
     return [...actualServices].sort((a, b) => {
@@ -235,11 +237,7 @@ export function ServiceList({ className, containerClassName, environment, ...pro
         enableColumnFilter: false,
         enableSorting: false,
         cell: (info) => {
-          const serviceStatus = match(info.row.original)
-            .with({ serviceType: 'DATABASE', mode: 'MANAGED' }, () => info.row.original.deploymentStatus?.state)
-            .otherwise(() => info.row.original.runningStatus?.state)
-
-          return <StatusChip status={serviceStatus} />
+          return <StatusChip status={info.row.original.status} />
         },
       }),
       columnHelper.display({
@@ -247,7 +245,13 @@ export function ServiceList({ className, containerClassName, environment, ...pro
         header: 'Last operation',
         enableColumnFilter: false,
         enableSorting: false,
-        cell: (info) => <ServiceLastDeploymentCell service={info.row.original} environment={environment} />,
+        cell: (info) => (
+          <ServiceLastDeploymentCell
+            service={info.row.original}
+            environment={environment}
+            isSkipped={info.row.original.isSkipped}
+          />
+        ),
       }),
       columnHelper.accessor('version', {
         header: 'Target version',
@@ -283,7 +287,7 @@ export function ServiceList({ className, containerClassName, environment, ...pro
       rowSelection,
     },
     enableRowSelection: (row) => {
-      return !skippedServicesMap.get(row.original.id)
+      return !row.original.isSkipped
     },
     onSortingChange: setSorting,
     onRowSelectionChange: setRowSelection,

--- a/libs/shared/ui/src/lib/components/deployment-action/deployment-action.tsx
+++ b/libs/shared/ui/src/lib/components/deployment-action/deployment-action.tsx
@@ -2,14 +2,23 @@ import {
   type DeploymentHistoryTriggerAction,
   ServiceActionStatusEnum,
   type ServiceSubActionEnum,
+  type StageStatusEnum,
   StateEnum,
+  type StepMetricStatusEnum,
 } from 'qovery-typescript-axios'
 import { match } from 'ts-pattern'
 import { twMerge } from '@qovery/shared/util-js'
 import Icon from '../icon/icon'
 
 export const getDeploymentAction = (
-  status: StateEnum | ServiceActionStatusEnum | DeploymentHistoryTriggerAction | ServiceSubActionEnum | undefined
+  status:
+    | StateEnum
+    | ServiceActionStatusEnum
+    | DeploymentHistoryTriggerAction
+    | ServiceSubActionEnum
+    | StageStatusEnum
+    | StepMetricStatusEnum
+    | undefined
 ) => {
   return match(status)
     .with(
@@ -88,6 +97,18 @@ export const getDeploymentAction = (
       status: 'Stop',
       icon: <Icon iconStyle="regular" iconName="circle-stop" />,
     }))
+    .with('SKIP', 'SKIPPED', () => ({
+      status: 'Skipped',
+      icon: <Icon iconStyle="regular" iconName="ban" />,
+    }))
+    .with('DONE', () => ({
+      status: 'Done',
+      icon: <Icon iconStyle="regular" iconName="circle-check" />,
+    }))
+    .with('CANCEL', () => ({
+      status: 'Cancel',
+      icon: <Icon iconStyle="regular" iconName="ban" />,
+    }))
     .with('UNKNOWN', 'NONE', 'DEPLOY', 'DEPLOY_DRY_RUN', 'TERRAFORM_PLAN_ONLY', 'TERRAFORM_PLAN_AND_APPLY', () => ({
       status: 'Deploy',
       icon: <Icon iconStyle="regular" iconName="rocket" />,
@@ -117,7 +138,14 @@ export const DeploymentAction = ({
   iconClassName,
   textClassName,
 }: {
-  status: StateEnum | ServiceActionStatusEnum | DeploymentHistoryTriggerAction | ServiceSubActionEnum | undefined
+  status:
+    | StateEnum
+    | ServiceActionStatusEnum
+    | DeploymentHistoryTriggerAction
+    | ServiceSubActionEnum
+    | StageStatusEnum
+    | StepMetricStatusEnum
+    | undefined
   className?: string
   iconClassName?: string
   textClassName?: string


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

https://qovery.slack.com/archives/C0A4CDDJBRQ/p1782372560955019

- Keep the service list status icon aligned with the actual running status used on the service overview
- Show `Skipped` in the **Last operation** column when a service is excluded from the deployment pipeline
- Centralize service status normalization shared by the service list and single-service status hook

[Test URL](http://localhost:4200/organization/3d542888-3d2c-474a-b1ad-712556db66da/project/b93c05d2-cc3f-4775-878b-5a14f59f50e6/environment/8a11a46f-8ed8-48d7-98a2-b7a352b75e07/overview)
## Screenshots / Recordings

| Before | After |
| --- | --- |
| ![Screenshot 2026-06-25 at 14 56 16](https://github.com/user-attachments/assets/307d2eca-5a5a-4960-99b3-3597cab77f79) | ![Screenshot 2026-06-25 at 14 57 31](https://github.com/user-attachments/assets/ac17234f-8c40-4729-8c74-ea2f7ef6d763) |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
