### PR TITLE
feat(qov-1844): Display gke kms key at cluster creation summary

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.spec.tsx
@@ -29,6 +29,8 @@ const defaultProps: StepSummaryPresentationProps = {
     region: 'us-east-1',
     installation_type: 'MANAGED',
     production: false,
+    credentials: '',
+    credentials_name: '',
   },
   resourcesData: {
     ...defaultResourcesData,
@@ -43,6 +45,8 @@ const defaultProps: StepSummaryPresentationProps = {
     cpu: 2,
     ram_in_gb: 4,
     architecture: 'x86_64',
+    bandwidth_in_gbps: '',
+    bandwidth_guarantee: '',
   },
 }
 
@@ -173,6 +177,41 @@ describe('StepSummaryPresentation', () => {
     )
 
     expect(screen.getByText('static_ips_enabled=true, static_ips_count=2')).toBeInTheDocument()
+  })
+
+  it('should display GKE KMS Key when cloud provider is GCP and a key is provided', () => {
+    renderWithProviders(
+      <StepSummaryPresentation
+        {...defaultProps}
+        generalData={{
+          ...defaultProps.generalData,
+          cloud_provider: CloudProviderEnum.GCP,
+          gke_kms_key: {
+            value: 'projects/my-project/locations/us-east1/keyRings/my-ring/cryptoKeys/my-key',
+            enabled: false,
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('GKE KMS Key:')).toBeInTheDocument()
+    expect(
+      screen.getByText('projects/my-project/locations/us-east1/keyRings/my-ring/cryptoKeys/my-key')
+    ).toBeInTheDocument()
+  })
+
+  it('should not display GKE KMS Key when cloud provider is GCP but no key is provided', () => {
+    renderWithProviders(
+      <StepSummaryPresentation
+        {...defaultProps}
+        generalData={{
+          ...defaultProps.generalData,
+          cloud_provider: CloudProviderEnum.GCP,
+        }}
+      />
+    )
+
+    expect(screen.queryByText('GKE KMS Key:')).not.toBeInTheDocument()
   })
 
   it('should render GCP existing VPC private nodes in summary', () => {

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-summary/step-summary-presentation.tsx
@@ -202,6 +202,12 @@ export function StepSummaryPresentation(props: StepSummaryPresentationProps) {
                   </li>
                 </>
               )}
+              {props.generalData.cloud_provider === 'GCP' && props.generalData.gke_kms_key?.value && (
+                <li>
+                  <strong className="font-medium">GKE KMS Key: </strong>
+                  {props.generalData.gke_kms_key.value}
+                </li>
+              )}
             </ul>
           </div>
 


### PR DESCRIPTION

## Summary

**Issue**: https://qovery.atlassian.net/browse/QOV-1844
The purpose is to display the gke kms key when set in the cluster creation summary

<img width="696" height="862" alt="image" src="https://github.com/user-attachments/assets/e7cbaa4e-284c-40ff-aeb4-f5bc28fff46f" />
