### PR TITLE
feat(devops-copilot): use tanstack router for internal links

### DIFF
--- a/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
@@ -1,10 +1,11 @@
+import { useNavigate } from '@tanstack/react-router'
 import { isValidElement } from 'react'
-import type { FC, HTMLAttributes, PropsWithChildren } from 'react'
+import type { AnchorHTMLAttributes, FC, HTMLAttributes, MouseEvent, PropsWithChildren, ReactNode } from 'react'
 import Markdown from 'react-markdown'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { materialDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import remarkGfm from 'remark-gfm'
-import { CopyToClipboardButtonIcon, ExternalLink, Link } from '@qovery/shared/ui'
+import { CopyToClipboardButtonIcon, ExternalLink } from '@qovery/shared/ui'
 import { MermaidChart } from '../mermaid-chart/mermaid-chart'
 
 function getInternalPath(href: string): string | null {
@@ -19,17 +20,22 @@ function getInternalPath(href: string): string | null {
   return null
 }
 
-function MarkdownLink({
-  href,
-  children,
-}: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children?: React.ReactNode }) {
+function MarkdownLink({ href, children }: AnchorHTMLAttributes<HTMLAnchorElement> & { children?: ReactNode }) {
+  const navigate = useNavigate()
   const internalPath = href ? getInternalPath(href) : null
 
   if (internalPath) {
     return (
-      <Link to={internalPath as string} color="brand" underline>
+      <a
+        href={internalPath}
+        className="text-brand transition-colors hover:underline"
+        onClick={(e: MouseEvent<HTMLAnchorElement>) => {
+          e.preventDefault()
+          navigate({ to: internalPath })
+        }}
+      >
         {children}
-      </Link>
+      </a>
     )
   }
 

--- a/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
@@ -25,6 +25,7 @@ function MarkdownLink({ href, children }: AnchorHTMLAttributes<HTMLAnchorElement
   const internalPath = href ? getInternalPath(href) : null
 
   if (internalPath) {
+    // Using <a> over <Link> because TanStack Router's `to` only accepts statically known routes, not dynamic strings.
     return (
       <a
         href={internalPath}

--- a/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
@@ -4,8 +4,41 @@ import Markdown from 'react-markdown'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { materialDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import remarkGfm from 'remark-gfm'
-import { CopyToClipboardButtonIcon } from '@qovery/shared/ui'
+import { CopyToClipboardButtonIcon, ExternalLink, Link } from '@qovery/shared/ui'
 import { MermaidChart } from '../mermaid-chart/mermaid-chart'
+
+function getInternalPath(href: string): string | null {
+  try {
+    const url = new URL(href)
+    if (url.hostname === window.location.hostname || url.hostname === 'console.qovery.com') {
+      return url.pathname + url.search + url.hash
+    }
+  } catch {
+    if (href.startsWith('/')) return href
+  }
+  return null
+}
+
+function MarkdownLink({
+  href,
+  children,
+}: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children?: React.ReactNode }) {
+  const internalPath = href ? getInternalPath(href) : null
+
+  if (internalPath) {
+    return (
+      <Link to={internalPath} color="brand" underline>
+        {children}
+      </Link>
+    )
+  }
+
+  return (
+    <ExternalLink href={href} color="brand" underline withIcon={false}>
+      {children}
+    </ExternalLink>
+  )
+}
 
 type CodeProps = PropsWithChildren<{
   inline?: boolean
@@ -44,15 +77,7 @@ export const RenderMarkdown: FC<Props> = ({ children, ...props }) => (
       ul: ({ node, ...props }) => <ul className="my-3 list-disc space-y-1 pl-6" {...props} />,
       ol: ({ node, ...props }) => <ol className="my-3 list-decimal space-y-1 pl-6" {...props} />,
       li: ({ node, ...props }) => <li className="my-1" {...props} />,
-      a: ({ node, ...props }) => (
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          title={typeof children === 'string' ? children : undefined}
-          className="text-brand transition-colors hover:underline"
-          {...props}
-        />
-      ),
+      a: ({ node, ...props }) => <MarkdownLink {...props} />,
       pre: ({ node, children, ...props }) => {
         const codeContent = isValidElement(children) ? (children.props as { children?: string })?.children : null
 

--- a/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
@@ -11,7 +11,7 @@ import { MermaidChart } from '../mermaid-chart/mermaid-chart'
 function getInternalPath(href: string): string | null {
   try {
     const url = new URL(href)
-    if (url.hostname === window.location.hostname || url.hostname === 'console.qovery.com') {
+    if (url.hostname === window.location.hostname) {
       return url.pathname + url.search + url.hash
     }
   } catch {

--- a/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-render-markdown/devops-render-markdown.tsx
@@ -27,7 +27,7 @@ function MarkdownLink({
 
   if (internalPath) {
     return (
-      <Link to={internalPath} color="brand" underline>
+      <Link to={internalPath as string} color="brand" underline>
         {children}
       </Link>
     )


### PR DESCRIPTION
## Summary

Use tanstack router for internal link to avoid reopen a new tab and to keep the chat open 

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code