### PR TITLE
feat(qov-1844): Allow any user to set gke kms key at cluster creation

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-general-settings/cluster-general-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-general-settings/cluster-general-settings.spec.tsx
@@ -6,7 +6,7 @@ import ClusterGeneralSettings, { type ClusterGeneralSettingsProps } from './clus
 jest.mock('@qovery/shared/iam/feature', () => ({
   ...jest.requireActual('@qovery/shared/iam/feature'),
   useUserRole: () => ({
-    isQoveryAdminUser: true,
+    isQoveryAdminUser: false,
     isQoveryUser: false,
     loading: false,
     roles: [],

--- a/libs/domains/clusters/feature/src/lib/cluster-general-settings/cluster-general-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-general-settings/cluster-general-settings.tsx
@@ -78,7 +78,7 @@ export function ClusterGeneralSettings(props: ClusterGeneralSettingsProps) {
           </div>
         )}
       />
-      {isQoveryAdminUser && cloudProvider === 'GCP' && <GkeKmsKey fromDetail={fromDetail} />}
+      {cloudProvider === 'GCP' && <GkeKmsKey fromDetail={fromDetail} />}
       {fromDetail && isQoveryAdminUser && (
         <>
           <Controller


### PR DESCRIPTION
## Summary

Enable any user to set gke kms key at cluster creation.
Remove qovery admin filter (linked to initial PR here: https://github.com/Qovery/console/pull/2768)
