### PR TITLE
fix(clusters): show ARM supported badge for GCP regions

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.spec.tsx
@@ -117,7 +117,7 @@ describe('StepGeneral', () => {
     expect(screen.getByTestId('button-submit')).toBeDisabled()
   })
 
-  it('should display an ARM supported badge for GCP regions with ARM support', async () => {
+  it('should display an ARM badge for GCP regions with ARM support', async () => {
     useCloudProvidersMockSpy.mockReturnValue({
       data: [
         {
@@ -137,6 +137,6 @@ describe('StepGeneral', () => {
     const regionSelect = await screen.findByLabelText('Region')
     selectEvent.openMenu(regionSelect)
 
-    expect(await screen.findAllByText('ARM supported')).toHaveLength(1)
+    expect(await screen.findAllByText('ARM')).toHaveLength(1)
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.spec.tsx
@@ -117,7 +117,7 @@ describe('StepGeneral', () => {
     expect(screen.getByTestId('button-submit')).toBeDisabled()
   })
 
-  it('should display an ARM not supported badge for GCP regions without ARM support', async () => {
+  it('should display an ARM supported badge for GCP regions with ARM support', async () => {
     useCloudProvidersMockSpy.mockReturnValue({
       data: [
         {
@@ -137,6 +137,6 @@ describe('StepGeneral', () => {
     const regionSelect = await screen.findByLabelText('Region')
     selectEvent.openMenu(regionSelect)
 
-    expect(await screen.findAllByText('No ARM')).toHaveLength(1)
+    expect(await screen.findAllByText('ARM supported')).toHaveLength(1)
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
@@ -79,16 +79,16 @@ export function StepGeneral({ organizationId, onSubmit, labelsSetting }: StepGen
     () =>
       currentProvider?.regions?.map((region: ClusterRegion) => {
         const label = `${region.city} (${region.name})`
-        const showArmUnsupportedBadge =
-          currentProvider.short_name === CloudProviderEnum.GCP && region.arm_supported === false
+        const showArmSupportedBadge =
+          currentProvider.short_name === CloudProviderEnum.GCP && region.arm_supported === true
 
         return {
           label: (
             <span className="flex items-center gap-2">
               <span className="truncate">{label}</span>
-              {showArmUnsupportedBadge && (
-                <Badge color="yellow" variant="surface" size="sm" className="gap-1">
-                  No ARM
+              {showArmSupportedBadge && (
+                <Badge color="green" variant="surface" size="sm" className="gap-1">
+                  ARM supported
                 </Badge>
               )}
             </span>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
@@ -88,7 +88,8 @@ export function StepGeneral({ organizationId, onSubmit, labelsSetting }: StepGen
               <span className="truncate">{label}</span>
               {showArmSupportedBadge && (
                 <Badge color="green" variant="surface" size="sm" className="gap-1">
-                  ARM supported
+                  <Icon iconName="check" className="text-xs text-positive" />
+                  ARM
                 </Badge>
               )}
             </span>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-general/step-general.tsx
@@ -87,7 +87,7 @@ export function StepGeneral({ organizationId, onSubmit, labelsSetting }: StepGen
             <span className="flex items-center gap-2">
               <span className="truncate">{label}</span>
               {showArmSupportedBadge && (
-                <Badge color="green" variant="surface" size="sm" className="gap-1">
+                <Badge color="green" variant="surface" size="sm" className="gap-0.5">
                   <Icon iconName="check" className="text-xs text-positive" />
                   ARM
                 </Badge>


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: <!-- QOV-1234 -->

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings
From
<img width="770" height="275" alt="Screenshot 2026-06-29 at 17 52 41" src="https://github.com/user-attachments/assets/15e241eb-21ef-4505-9813-644bf11339e5" />

to

<img width="760" height="675" alt="Screenshot 2026-06-29 at 21 24 08" src="https://github.com/user-attachments/assets/11a5dbf6-6387-42fc-8093-49a39f824883" />




<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
