### PR TITLE
chore(release): add production promotion workflow

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -1,0 +1,162 @@
+name: Open production promotion PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "confirm" to open the production promotion PR'
+        required: true
+      auto_merge:
+        description: 'Enable auto-merge once branch protection requirements are met'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
+
+jobs:
+  open-promotion-pr:
+    name: Open staging to main PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate confirmation
+        if: ${{ inputs.confirm != 'confirm' }}
+        run: |
+          echo 'Invalid confirmation. Type "confirm" to open the production promotion PR.'
+          exit 1
+
+      - name: Check if staging has changes to promote
+        id: compare
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          ahead_by="$(gh api "repos/${REPOSITORY}/compare/main...staging" --jq '.ahead_by')"
+          echo "ahead_by=${ahead_by}" >> "$GITHUB_OUTPUT"
+
+          if [ "$ahead_by" = "0" ]; then
+            echo "staging is already aligned with main. Nothing to promote."
+          fi
+
+      - name: Find existing promotion PR
+        id: existing-pr
+        if: ${{ steps.compare.outputs.ahead_by != '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          pr_url="$(gh pr list \
+            --repo "$REPOSITORY" \
+            --base main \
+            --head staging \
+            --state open \
+            --json url \
+            --jq '.[0].url')"
+
+          echo "url=${pr_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Create promotion PR
+        id: create-pr
+        if: ${{ steps.compare.outputs.ahead_by != '0' && steps.existing-pr.outputs.url == '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          pr_body="$(printf '%s\n\n%s' \
+            'Opens the production promotion path from staging to main. Merging this PR triggers semantic-release, then the existing production deployment workflow.' \
+            'Do not squash this PR. Use a merge commit to preserve the original conventional commits for semantic-release.')"
+
+          pr_url="$(gh pr create \
+            --repo "$REPOSITORY" \
+            --base main \
+            --head staging \
+            --title "chore(release): promote staging to production" \
+            --body "$pr_body")"
+
+          echo "url=${pr_url}" >> "$GITHUB_OUTPUT"
+          echo "Created promotion PR: ${pr_url}"
+
+      - name: Wait for required CI checks
+        if: ${{ inputs.auto_merge && steps.compare.outputs.ahead_by != '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          EXISTING_PR_URL: ${{ steps.existing-pr.outputs.url }}
+          CREATED_PR_URL: ${{ steps.create-pr.outputs.url }}
+        run: |
+          set -euo pipefail
+
+          pr_url="${EXISTING_PR_URL:-$CREATED_PR_URL}"
+
+          for attempt in $(seq 1 60); do
+            set +e
+            checks="$(gh pr checks "$pr_url" \
+              --repo "$REPOSITORY" \
+              --json name,state,workflow \
+              --jq '[.[] | select(((.name // "") | ascii_downcase | contains("codecov") | not) and ((.workflow // "") | ascii_downcase | contains("codecov") | not))]')"
+            checks_exit_code="$?"
+            set -e
+
+            if [ "$checks_exit_code" != "0" ] && [ "$checks_exit_code" != "1" ] && [ "$checks_exit_code" != "8" ]; then
+              echo "Unable to read PR checks."
+              exit "$checks_exit_code"
+            fi
+
+            total_count="$(echo "$checks" | jq 'length')"
+            blocking_count="$(echo "$checks" | jq '[.[] | select(.state == "FAILURE" or .state == "CANCELLED" or .state == "SKIPPED" or .state == "TIMED_OUT")] | length')"
+            pending_count="$(echo "$checks" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS" or .state == "WAITING" or .state == "REQUESTED")] | length')"
+
+            if [ "$blocking_count" != "0" ]; then
+              echo "A non-Codecov CI check failed. Production promotion is blocked."
+              echo "$checks" | jq -r '.[] | select(.state == "FAILURE" or .state == "CANCELLED" or .state == "SKIPPED" or .state == "TIMED_OUT") | "- \(.workflow): \(.name) [\(.state)]"'
+              exit 1
+            fi
+
+            if [ "$total_count" = "0" ]; then
+              echo "No non-Codecov CI checks found yet. Waiting before enabling auto-merge."
+            elif [ "$pending_count" = "0" ]; then
+              echo "All non-Codecov CI checks passed."
+              exit 0
+            fi
+
+            echo "Waiting for non-Codecov CI checks to finish. Attempt ${attempt}/60."
+            sleep 30
+          done
+
+          echo "Timed out waiting for non-Codecov CI checks."
+          exit 1
+
+      - name: Enable auto-merge
+        if: ${{ inputs.auto_merge && steps.compare.outputs.ahead_by != '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          EXISTING_PR_URL: ${{ steps.existing-pr.outputs.url }}
+          CREATED_PR_URL: ${{ steps.create-pr.outputs.url }}
+        run: |
+          pr_url="${EXISTING_PR_URL:-$CREATED_PR_URL}"
+
+          gh pr merge "$pr_url" \
+            --repo "$REPOSITORY" \
+            --auto \
+            --merge
+
+          echo "Auto-merge enabled for ${pr_url}"
+
+      - name: Summary
+        env:
+          AHEAD_BY: ${{ steps.compare.outputs.ahead_by }}
+          EXISTING_PR_URL: ${{ steps.existing-pr.outputs.url }}
+          CREATED_PR_URL: ${{ steps.create-pr.outputs.url }}
+        run: |
+          if [ "$AHEAD_BY" = "0" ]; then
+            echo "staging is already aligned with main. Nothing to promote." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          pr_url="${EXISTING_PR_URL:-$CREATED_PR_URL}"
+          echo "Promotion PR: ${pr_url}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Adds a manual GitHub Actions workflow to open a production promotion PR from `staging` to `main`

### Behavior

1. A user opens **Actions > Open production promotion PR** and manually runs the workflow
2. The workflow requires the user to type `confirm` before doing anything
3. The workflow checks whether `staging` contains commits that are not yet on `main`
4. If `staging` is already aligned with `main`, the workflow stops without creating a PR
5. If an open `staging` to `main` promotion PR already exists, the workflow reuses it
6. If no promotion PR exists, the workflow creates one with the title `chore(release): promote staging to production`
7. Opening the PR triggers the regular PR checks against `main`
8. Codecov is ignored by the promotion workflow and is not required to allow the production promotion
9. Any failing, cancelled, skipped, or timed-out non-Codecov check blocks the promotion
10. Auto-merge is enabled after all non-Codecov checks pass
11. The promotion PR is merged with a merge commit, not squash, so the original conventional commits remain available for semantic-release
12. Once the PR is merged into `main`, the existing semantic-release workflow creates the GitHub release
13. The existing production deployment workflow then runs from the created release

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
