### PR TITLE
fix(cluster): correct override issue when updating Karpenter config

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.spec.tsx
@@ -213,8 +213,6 @@ describe('ClusterResourcesSettings', () => {
             ...defaultValues,
             karpenter: {
               enabled: true,
-              spot_enabled: false,
-              disk_size_in_gib: 40,
               default_service_architecture: 'AMD64',
               qovery_node_pools: {
                 requirements: [{ key: 'InstanceSize', operator: 'In', values: ['2xlarge'] }],
@@ -251,6 +249,8 @@ describe('ClusterResourcesSettings', () => {
 
     expect(JSON.parse(screen.getByTestId('karpenter-values').textContent ?? '{}')).toEqual(
       expect.objectContaining({
+        spot_enabled: false,
+        disk_size_in_gib: 50,
         default_service_architecture: 'ARM64',
         qovery_node_pools: {
           requirements: [{ key: 'InstanceSize', operator: 'In', values: ['4xlarge'] }],

--- a/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.spec.tsx
@@ -1,8 +1,13 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
-import { CloudProviderEnum } from 'qovery-typescript-axios'
+import { act } from 'react'
+import { CloudProviderEnum, type Cluster } from 'qovery-typescript-axios'
+import { useFormContext } from 'react-hook-form'
 import { type ClusterResourcesData } from '@qovery/shared/interfaces'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { fireEvent, renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { ClusterResourcesSettings } from './cluster-resources-settings'
+
+const mockOpenModal = jest.fn()
+const mockCloseModal = jest.fn()
 
 jest.mock('@qovery/domains/cloud-providers/feature', () => ({
   ...jest.requireActual('@qovery/domains/cloud-providers/feature'),
@@ -24,14 +29,16 @@ jest.mock('../gpu-resources-settings/gpu-resources-settings', () => ({
 }))
 
 jest.mock('../nodepools-resources-settings/nodepools-resources-settings', () => ({
+  __esModule: true,
+  default: () => <div data-testid="nodepools-settings">Nodepools Settings</div>,
   NodepoolsResourcesSettings: () => <div data-testid="nodepools-settings">Nodepools Settings</div>,
 }))
 
 jest.mock('@qovery/shared/ui', () => ({
   ...jest.requireActual('@qovery/shared/ui'),
   useModal: () => ({
-    openModal: jest.fn(),
-    closeModal: jest.fn(),
+    openModal: mockOpenModal,
+    closeModal: mockCloseModal,
   }),
 }))
 
@@ -42,9 +49,28 @@ const defaultValues: ClusterResourcesData = {
   nodes: [3, 10],
 }
 
+const cluster = {
+  region: 'us-east-1',
+  features: [
+    {
+      id: 'KARPENTER',
+      value: {
+        default_service_architecture: 'AMD64',
+      },
+    },
+  ],
+} as Cluster
+
+function FormValuesProbe() {
+  const { watch } = useFormContext<ClusterResourcesData>()
+
+  return <pre data-testid="karpenter-values">{JSON.stringify(watch('karpenter'))}</pre>
+}
+
 describe('ClusterResourcesSettings', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    window.scrollTo = jest.fn()
   })
 
   it('should render successfully', () => {
@@ -145,6 +171,94 @@ describe('ClusterResourcesSettings', () => {
 
     expect(screen.getByText('GPU nodepools configuration')).toBeInTheDocument()
     expect(screen.getByText('Enable GPU nodepools')).toBeInTheDocument()
+  })
+
+  it('should preserve nodepool overrides when changing Karpenter instance types scope', () => {
+    const stableOverride = {
+      limits: {
+        enabled: false,
+        max_cpu_in_vcpu: 6,
+        max_memory_in_gibibytes: 10,
+      },
+      consolidation: {
+        enabled: true,
+        days: ['SUNDAY'],
+        start_time: 'PT10:00',
+        duration: 'PT2H',
+      },
+      consolidate_after: '30s',
+    }
+    const defaultOverride = {
+      limits: {
+        enabled: false,
+        max_cpu_in_vcpu: 6,
+        max_memory_in_gibibytes: 10,
+      },
+      consolidate_after: '30m',
+    }
+
+    renderWithProviders(
+      wrapWithReactHookForm<ClusterResourcesData>(
+        <>
+          <ClusterResourcesSettings
+            cluster={cluster}
+            clusterRegion="us-east-1"
+            fromDetail
+            cloudProvider={CloudProviderEnum.AWS}
+          />
+          <FormValuesProbe />
+        </>,
+        {
+          defaultValues: {
+            ...defaultValues,
+            karpenter: {
+              enabled: true,
+              spot_enabled: false,
+              disk_size_in_gib: 40,
+              default_service_architecture: 'AMD64',
+              qovery_node_pools: {
+                requirements: [{ key: 'InstanceSize', operator: 'In', values: ['2xlarge'] }],
+                stable_override: stableOverride,
+                default_override: defaultOverride,
+              },
+            },
+          },
+        }
+      )
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+    const modalContent = mockOpenModal.mock.calls[0][0].content as {
+      props: {
+        onChange: (values: {
+          default_service_architecture: 'ARM64'
+          qovery_node_pools: {
+            requirements: Array<{ key: string; operator: string; values: string[] }>
+          }
+        }) => void
+      }
+    }
+
+    act(() => {
+      modalContent.props.onChange({
+        default_service_architecture: 'ARM64',
+        qovery_node_pools: {
+          requirements: [{ key: 'InstanceSize', operator: 'In', values: ['4xlarge'] }],
+        },
+      })
+    })
+
+    expect(JSON.parse(screen.getByTestId('karpenter-values').textContent ?? '{}')).toEqual(
+      expect.objectContaining({
+        default_service_architecture: 'ARM64',
+        qovery_node_pools: {
+          requirements: [{ key: 'InstanceSize', operator: 'In', values: ['4xlarge'] }],
+          stable_override: stableOverride,
+          default_override: defaultOverride,
+        },
+      })
+    )
   })
 
   it('should not render Karpenter section for non-AWS providers', () => {

--- a/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.spec.tsx
@@ -3,7 +3,7 @@ import { CloudProviderEnum, type Cluster } from 'qovery-typescript-axios'
 import { act } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { type ClusterResourcesData } from '@qovery/shared/interfaces'
-import { fireEvent, renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { ClusterResourcesSettings } from './cluster-resources-settings'
 
 const mockOpenModal = jest.fn()
@@ -225,7 +225,9 @@ describe('ClusterResourcesSettings', () => {
       )
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    act(() => {
+      screen.getByRole('button', { name: /edit/i }).click()
+    })
 
     const modalContent = mockOpenModal.mock.calls[0][0].content as {
       props: {

--- a/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
-import { act } from 'react'
 import { CloudProviderEnum, type Cluster } from 'qovery-typescript-axios'
+import { act } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { type ClusterResourcesData } from '@qovery/shared/interfaces'
 import { fireEvent, renderWithProviders, screen } from '@qovery/shared/util-tests'

--- a/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.tsx
@@ -319,12 +319,14 @@ export function ClusterResourcesSettings(props: ClusterResourcesSettingsProps) {
                                         onClose={closeModal}
                                         onChange={(values) => {
                                           setValue('karpenter', {
-                                            ...watchKarpenter,
+                                            ...(watchKarpenter ?? {}),
                                             enabled: watchKarpenterEnabled,
+                                            spot_enabled: watchKarpenter?.spot_enabled ?? false,
+                                            disk_size_in_gib: watchKarpenter?.disk_size_in_gib ?? 50,
                                             ...values,
                                             qovery_node_pools: {
-                                              ...watchKarpenter?.qovery_node_pools,
-                                              requirements: values.qovery_node_pools.requirements,
+                                              ...(watchKarpenter?.qovery_node_pools ?? {}),
+                                              ...values.qovery_node_pools,
                                             },
                                           })
                                         }}

--- a/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-resources-settings/cluster-resources-settings.tsx
@@ -319,10 +319,13 @@ export function ClusterResourcesSettings(props: ClusterResourcesSettingsProps) {
                                         onClose={closeModal}
                                         onChange={(values) => {
                                           setValue('karpenter', {
+                                            ...watchKarpenter,
                                             enabled: watchKarpenterEnabled,
-                                            spot_enabled: watchKarpenter?.spot_enabled ?? false,
-                                            disk_size_in_gib: watchKarpenter?.disk_size_in_gib ?? 50,
                                             ...values,
+                                            qovery_node_pools: {
+                                              ...watchKarpenter?.qovery_node_pools,
+                                              requirements: values.qovery_node_pools.requirements,
+                                            },
                                           })
                                         }}
                                       />


### PR DESCRIPTION
## Some of the Karpenter config gets overwritten

**Issue**: [Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1782996922160759)

This PR fixes an issue where some of the Karpenter configuration was overwritten even though it was not updated by the user.

Reproduction steps can be found in the Slack thread.

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
