### PR TITLE
fix(section-secret-manager-highlight): use request-access-secrets-manager pylon form id

### DIFF
--- a/libs/domains/organizations/feature/src/lib/organization-overview/section-secret-manager-highlight/section-secret-manager-highlight.tsx
+++ b/libs/domains/organizations/feature/src/lib/organization-overview/section-secret-manager-highlight/section-secret-manager-highlight.tsx
@@ -101,7 +101,7 @@ export function SectionSecretManagerHighlight() {
               variant="solid"
               size="lg"
               className="absolute bottom-3 z-10 w-[calc(100%-24px)] justify-center"
-              onClick={() => showPylonForm('request-upgrade-plan')}
+              onClick={() => showPylonForm('request-access-secrets-manager')}
             >
               Contact us
             </Button>


### PR DESCRIPTION
- The "Contact us" button in the Secret Manager highlight card (org overview) opened the generic request-upgrade-plan Pylon form instead of a dedicated one.
- Switched it to request-access-secrets-manager so support requests are routed correctly.
