### PR TITLE
feat(sma): Add banner info for secret manager access plan

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
@@ -15,7 +15,17 @@ import {
   useEditCluster,
 } from '@qovery/domains/clusters/feature'
 import { SettingsHeading } from '@qovery/shared/console-shared'
-import { Badge, Button, DropdownMenu, Icon, Section, Tooltip, useModal, useModalConfirmation } from '@qovery/shared/ui'
+import {
+  Badge,
+  Button,
+  Callout,
+  DropdownMenu,
+  Icon,
+  Section,
+  Tooltip,
+  useModal,
+  useModalConfirmation,
+} from '@qovery/shared/ui'
 import { useDocumentTitle, useSupportChat } from '@qovery/shared/util-hooks'
 
 const SECRET_MANAGER_EARLY_ACCESS_FORM_SLUG = 'request-access-secrets-manager'
@@ -238,6 +248,16 @@ function RouteComponent() {
                       onDelete={handleDeleteSecretManager}
                       onViewAssociatedExternalSecrets={openSecretManagerAssociatedExternalSecretsModal}
                     />
+                    <Callout.Root color="sky" className="w-full">
+                      <Callout.Icon>
+                        <Icon iconName="info-circle" iconStyle="regular" />
+                      </Callout.Icon>
+                      <Callout.Text>
+                        <Callout.TextDescription>
+                          This feature is in beta. Behaviour and accessibility may change when released in GA.
+                        </Callout.TextDescription>
+                      </Callout.Text>
+                    </Callout.Root>
                   </div>
                 </div>
               </div>

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -5,6 +5,7 @@ import { isSameSecretManagerAccess } from '@qovery/domains/clusters/data-access'
 import {
   Badge,
   Button,
+  Callout,
   DropdownMenu,
   FunnelFlowBody,
   Heading,
@@ -186,6 +187,16 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                     )
                   }
                 />
+                <Callout.Root color="sky" className="w-full">
+                  <Callout.Icon>
+                    <Icon iconName="info-circle" iconStyle="regular" />
+                  </Callout.Icon>
+                  <Callout.Text>
+                    <Callout.TextDescription>
+                      This feature is in beta. Behaviour and accessibility may change when released in GA.
+                    </Callout.TextDescription>
+                  </Callout.Text>
+                </Callout.Root>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Adds a banner about plan linked to beta
* at create cluster:
<img width="684" height="562" alt="image" src="https://github.com/user-attachments/assets/c561c385-35ed-4e84-a278-a7d80da6f512" />

* at cluster settings:
<img width="765" height="634" alt="image" src="https://github.com/user-attachments/assets/4b292351-076a-44e5-912c-a19785cf3737" />
