### PR TITLE
fix(organizations): allow custom git branch selection

### DIFF
--- a/libs/domains/organizations/feature/src/lib/git-branch-settings/git-branch-settings.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-branch-settings/git-branch-settings.spec.tsx
@@ -1,6 +1,12 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
-import { renderWithProviders } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { GitBranchSettings } from './git-branch-settings'
+
+let mockBranches: { name: string }[] = [
+  {
+    name: 'main',
+  },
+]
 
 jest.mock('../hooks/use-branches/use-branches', () => {
   return {
@@ -8,20 +14,42 @@ jest.mock('../hooks/use-branches/use-branches', () => {
     useBranches: () => ({
       isLoading: false,
       isRefetching: false,
-      data: [
-        {
-          name: 'main',
-        },
-      ],
+      data: mockBranches,
     }),
   }
 })
 
 describe('GitBranchSettings', () => {
+  beforeEach(() => {
+    mockBranches = [
+      {
+        name: 'main',
+      },
+    ]
+  })
+
   it('should match snapshot', () => {
     const { baseElement } = renderWithProviders(
       wrapWithReactHookForm(<GitBranchSettings organizationId="org-1" gitProvider="GITHUB" />)
     )
     expect(baseElement).toMatchSnapshot()
+  })
+
+  it('should display the selected branch when it is not part of returned branches', () => {
+    mockBranches = [
+      {
+        name: 'develop',
+      },
+    ]
+
+    renderWithProviders(
+      wrapWithReactHookForm(<GitBranchSettings organizationId="org-1" gitProvider="GITHUB" />, {
+        defaultValues: {
+          branch: 'main',
+        },
+      })
+    )
+
+    expect(screen.getByText('main')).toBeInTheDocument()
   })
 })

--- a/libs/domains/organizations/feature/src/lib/git-branch-settings/git-branch-settings.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-branch-settings/git-branch-settings.tsx
@@ -1,4 +1,5 @@
 import { type GitProviderEnum } from 'qovery-typescript-axios'
+import { useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { InputSelect, InputText, LoaderSpinner } from '@qovery/shared/ui'
 import { useBranches } from '../hooks/use-branches/use-branches'
@@ -40,6 +41,25 @@ export function GitBranchSettings({
     enabled: !disabled,
   })
 
+  const branchOptionsWithSelectedValue = useMemo(() => {
+    const branchOptions = branches.map((branch) => ({
+      label: branch.name,
+      value: branch.name,
+    }))
+
+    if (disabled || !watchFieldBranch || branchOptions.some((branch) => branch.value === watchFieldBranch)) {
+      return branchOptions
+    }
+
+    return [
+      ...branchOptions,
+      {
+        label: watchFieldBranch,
+        value: watchFieldBranch,
+      },
+    ]
+  }, [branches, disabled, watchFieldBranch])
+
   if (isError) {
     return null
   }
@@ -71,16 +91,14 @@ export function GitBranchSettings({
                       value: watchFieldBranch ?? '',
                     },
                   ]
-                : branches.map((branch) => ({
-                    label: branch.name,
-                    value: branch.name,
-                  }))
+                : branchOptionsWithSelectedValue
             }
             onChange={field.onChange}
             value={field.value}
             error={error?.message}
             disabled={disabled}
             isSearchable
+            isCreatable
           />
         )}
       />


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Allow users to manually select a Git branch even when it is not returned by the API.
https://qovery.slack.com/archives/C0A4CDDJBRQ/p1783347250876129

## Screenshots / Recordings

https://github.com/user-attachments/assets/0ba6c92c-5e41-4054-b218-e5a401070fa9

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
