### PR TITLE
fix(clusters): use working S3 URL format for CloudFormation role template link

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-credentials-modal/cluster-credentials-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-credentials-modal/cluster-credentials-modal.tsx
@@ -644,7 +644,7 @@ bash -s -- $GOOGLE_CLOUD_PROJECT qovery_role qovery-service-account"
                   Execute the following Cloudformation stack and retrieve the role ARN from the “Output” section.
                 </p>
                 <ExternalLink
-                  href="https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https%3A%2F%2Fs3.amazonaws.com%2Fcloudformation-qovery-role-creation%2Ftemplate.json&stackName=qovery-role-creation"
+                  href="https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https%3A%2F%2Fcloudformation-qovery-role-creation.s3.amazonaws.com%2Ftemplate.json&stackName=qovery-role-creation"
                   size="sm"
                 >
                   Cloudformation stack


### PR DESCRIPTION
## Summary
- The AWS "Cloudformation stack" quick-launch link in the cluster credentials modal used the legacy path-style S3 URL (`https://s3.amazonaws.com/cloudformation-qovery-role-creation/template.json`).
- That URL returns a `301` with no `Location` header for this bucket (it lives in `us-east-2`, and the legacy global path-style endpoint is really only well-behaved for `us-east-1` buckets). Switched to the virtual-hosted-style URL (`https://cloudformation-qovery-role-creation.s3.amazonaws.com/template.json`), matching the format already used in our docs, which resolves directly with a `200 OK`.

Note: this was initially raised as a possible fix for a customer (Semble) `Access Denied` report on Quick Create Stack, but we've since confirmed the customer's error is unrelated to this URL format (they got the same result on both URL variants) - it's most likely caused by an SCP or IAM restriction on their AWS account, still under investigation. This PR stands on its own as a minor robustness fix, not a resolution to that customer issue.

## Test plan
- [x] Verified the old URL returns `301` with no `Location` header via curl
- [x] Verified the new URL returns `200 OK` via curl
- [ ] Manually click "Cloudformation stack" link in the cluster credentials modal and confirm the AWS Quick Create Stack page loads the template without error