### PR TITLE
fix(onboarding): fix typo in bring-your-own-cluster description

### DIFF
--- a/apps/console/src/app/components/section-onboarding/section-onboarding.tsx
+++ b/apps/console/src/app/components/section-onboarding/section-onboarding.tsx
@@ -327,7 +327,7 @@ export function SectionOnboarding() {
       title: 'Bring your own cluster',
       icon: 'cloud',
       description:
-        'You will manage the infrastructure, including any update/ upgrade. Advanced Kubernetes knowledge required.',
+        'You will manage the infrastructure, including any updates/upgrades. Advanced Kubernetes knowledge required.',
       compatibleWith: [
         IconEnum.AWS,
         IconEnum.GCP,


### PR DESCRIPTION
## Summary

- Fixed a typo in the "Bring your own cluster" onboarding option: "update/ upgrade" (stray space, singular) is now "updates/upgrades".

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
