### PR TITLE
chore(release): promote staging to production

### DIFF
--- a/apps/console/src/app/components/section-onboarding/section-onboarding.tsx
+++ b/apps/console/src/app/components/section-onboarding/section-onboarding.tsx
@@ -327,7 +327,7 @@ export function SectionOnboarding() {
       title: 'Bring your own cluster',
       icon: 'cloud',
       description:
-        'You will manage the infrastructure, including any update/ upgrade. Advanced Kubernetes knowledge required.',
+        'You will manage the infrastructure, including any updates/upgrades. Advanced Kubernetes knowledge required.',
       compatibleWith: [
         IconEnum.AWS,
         IconEnum.GCP,


### PR DESCRIPTION
Opens the production promotion path from staging to main. Merging this PR triggers semantic-release, then the existing production deployment workflow.

Do not squash this PR. Use a merge commit to preserve the original conventional commits for semantic-release.