### PR TITLE
fix(service-logs): normalize identical date range

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.spec.ts
+++ b/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.spec.ts
@@ -1,0 +1,44 @@
+import { normalizeServiceHistoryDateRange } from './normalize-service-history-date-range'
+
+describe('normalizeServiceHistoryDateRange', () => {
+  const now = new Date('2026-07-13T12:00:00.000Z')
+
+  it('expands identical dates into a one-hour range', () => {
+    const date = new Date('2026-07-13T10:00:00.000Z')
+
+    const result = normalizeServiceHistoryDateRange(date, date, now)
+
+    expect(result).toEqual({
+      startDate: new Date('2026-07-13T09:30:00.000Z'),
+      endDate: new Date('2026-07-13T10:30:00.000Z'),
+    })
+  })
+
+  it('caps the end date to the current time', () => {
+    const date = new Date('2026-07-13T12:00:00.000Z')
+
+    const result = normalizeServiceHistoryDateRange(date, date, now)
+
+    expect(result).toEqual({
+      startDate: new Date('2026-07-13T11:00:00.000Z'),
+      endDate: now,
+    })
+  })
+
+  it('keeps different dates unchanged', () => {
+    const startDate = new Date('2026-07-13T10:00:00.000Z')
+    const endDate = new Date('2026-07-13T11:00:00.000Z')
+
+    const result = normalizeServiceHistoryDateRange(startDate, endDate, now)
+
+    expect(result).toEqual({ startDate, endDate })
+  })
+
+  it('keeps an incomplete range unchanged', () => {
+    const startDate = new Date('2026-07-13T10:00:00.000Z')
+
+    const result = normalizeServiceHistoryDateRange(startDate, undefined, now)
+
+    expect(result).toEqual({ startDate, endDate: undefined })
+  })
+})

--- a/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.ts
+++ b/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.ts
@@ -1,0 +1,24 @@
+import { addMinutes, subMinutes } from 'date-fns'
+
+interface ServiceHistoryDateRange {
+  startDate?: Date
+  endDate?: Date
+}
+
+export function normalizeServiceHistoryDateRange(
+  startDate?: Date,
+  endDate?: Date,
+  now = new Date()
+): ServiceHistoryDateRange {
+  if (!startDate || !endDate || startDate.getTime() !== endDate.getTime()) {
+    return { startDate, endDate }
+  }
+
+  const adjustedEndDate = addMinutes(endDate, 30)
+  const normalizedEndDate = adjustedEndDate > now ? now : adjustedEndDate
+
+  return {
+    startDate: subMinutes(normalizedEndDate, 60),
+    endDate: normalizedEndDate,
+  }
+}

--- a/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/use-service-history-logs.ts
+++ b/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/use-service-history-logs.ts
@@ -3,6 +3,7 @@ import { useSearch } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { type ServiceLog, normalizeServiceLog, serviceLogs } from '@qovery/domains/service-logs/data-access'
 import { queries } from '@qovery/state/util-queries'
+import { normalizeServiceHistoryDateRange } from './normalize-service-history-date-range'
 
 export interface UseServiceHistoryLogsProps {
   clusterId: string
@@ -49,14 +50,13 @@ export function useServiceHistoryLogs({ clusterId, serviceId, enabled = false }:
     return Boolean(queryParams.startDate || queryParams.endDate)
   }, [queryParams.mode, queryParams.startDate, queryParams.endDate])
 
-  const startDate = useMemo(
-    () => (queryParams.startDate ? new Date(queryParams.startDate) : undefined),
-    [queryParams.startDate]
-  )
-
-  const endDate = useMemo(
-    () => (queryParams.endDate ? new Date(queryParams.endDate) : undefined),
-    [queryParams.endDate]
+  const { startDate, endDate } = useMemo(
+    () =>
+      normalizeServiceHistoryDateRange(
+        queryParams.startDate ? new Date(queryParams.startDate) : undefined,
+        queryParams.endDate ? new Date(queryParams.endDate) : undefined
+      ),
+    [queryParams.startDate, queryParams.endDate]
   )
 
   const startTimestampNs = useMemo(() => toTimestampNs(startDate), [startDate])


### PR DESCRIPTION
## What changed

- Normalize identical service-log `startDate` and `endDate` values into a one-hour range.
- Cap the normalized end date at the current time, matching the metrics dashboard behavior.
- Keep non-identical and incomplete ranges unchanged.
- Add focused unit coverage for the date-range normalization.

## Why

Alert links can only interpolate timestamps, so they may generate service-log URLs where `startDate === endDate`. Those values were passed unchanged to Loki, producing a zero-length query range and no useful logs.

## Validation

- `yarn jest --config libs/domains/service-logs/feature/jest.config.ts libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.spec.ts --runInBand` (4 tests passed)
- ESLint on the three changed files
- Prettier check on the three changed files
- `git diff --check`

## Environment note

The Nx project target could not start its plugin worker in the isolated worktree, so the focused Jest, ESLint, and Prettier commands were run directly.
