### PR TITLE
fix(service-logs): normalize identical date range

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.spec.ts
+++ b/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.spec.ts
@@ -1,0 +1,44 @@
+import { normalizeServiceHistoryDateRange } from './normalize-service-history-date-range'
+
+describe('normalizeServiceHistoryDateRange', () => {
+  const now = new Date('2026-07-13T12:00:00.000Z')
+
+  it('expands identical dates into a one-hour range', () => {
+    const date = new Date('2026-07-13T10:00:00.000Z')
+
+    const result = normalizeServiceHistoryDateRange(date, date, now)
+
+    expect(result).toEqual({
+      startDate: new Date('2026-07-13T09:30:00.000Z'),
+      endDate: new Date('2026-07-13T10:30:00.000Z'),
+    })
+  })
+
+  it('caps the end date to the current time', () => {
+    const date = new Date('2026-07-13T12:00:00.000Z')
+
+    const result = normalizeServiceHistoryDateRange(date, date, now)
+
+    expect(result).toEqual({
+      startDate: new Date('2026-07-13T11:00:00.000Z'),
+      endDate: now,
+    })
+  })
+
+  it('keeps different dates unchanged', () => {
+    const startDate = new Date('2026-07-13T10:00:00.000Z')
+    const endDate = new Date('2026-07-13T11:00:00.000Z')
+
+    const result = normalizeServiceHistoryDateRange(startDate, endDate, now)
+
+    expect(result).toEqual({ startDate, endDate })
+  })
+
+  it('keeps an incomplete range unchanged', () => {
+    const startDate = new Date('2026-07-13T10:00:00.000Z')
+
+    const result = normalizeServiceHistoryDateRange(startDate, undefined, now)
+
+    expect(result).toEqual({ startDate, endDate: undefined })
+  })
+})

--- a/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.ts
+++ b/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/normalize-service-history-date-range.ts
@@ -1,0 +1,24 @@
+import { addMinutes, subMinutes } from 'date-fns'
+
+interface ServiceHistoryDateRange {
+  startDate?: Date
+  endDate?: Date
+}
+
+export function normalizeServiceHistoryDateRange(
+  startDate?: Date,
+  endDate?: Date,
+  now = new Date()
+): ServiceHistoryDateRange {
+  if (!startDate || !endDate || startDate.getTime() !== endDate.getTime()) {
+    return { startDate, endDate }
+  }
+
+  const adjustedEndDate = addMinutes(endDate, 30)
+  const normalizedEndDate = adjustedEndDate > now ? now : adjustedEndDate
+
+  return {
+    startDate: subMinutes(normalizedEndDate, 60),
+    endDate: normalizedEndDate,
+  }
+}

--- a/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/use-service-history-logs.ts
+++ b/libs/domains/service-logs/feature/src/lib/hooks/use-service-history-logs/use-service-history-logs.ts
@@ -3,6 +3,7 @@ import { useSearch } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { type ServiceLog, normalizeServiceLog, serviceLogs } from '@qovery/domains/service-logs/data-access'
 import { queries } from '@qovery/state/util-queries'
+import { normalizeServiceHistoryDateRange } from './normalize-service-history-date-range'
 
 export interface UseServiceHistoryLogsProps {
   clusterId: string
@@ -49,14 +50,13 @@ export function useServiceHistoryLogs({ clusterId, serviceId, enabled = false }:
     return Boolean(queryParams.startDate || queryParams.endDate)
   }, [queryParams.mode, queryParams.startDate, queryParams.endDate])
 
-  const startDate = useMemo(
-    () => (queryParams.startDate ? new Date(queryParams.startDate) : undefined),
-    [queryParams.startDate]
-  )
-
-  const endDate = useMemo(
-    () => (queryParams.endDate ? new Date(queryParams.endDate) : undefined),
-    [queryParams.endDate]
+  const { startDate, endDate } = useMemo(
+    () =>
+      normalizeServiceHistoryDateRange(
+        queryParams.startDate ? new Date(queryParams.startDate) : undefined,
+        queryParams.endDate ? new Date(queryParams.endDate) : undefined
+      ),
+    [queryParams.startDate, queryParams.endDate]
   )
 
   const startTimestampNs = useMemo(() => toTimestampNs(startDate), [startDate])


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Alert links can generate service-log URLs where `startDate === endDate`. These values were passed unchanged to Loki, resulting in a zero-length query range and no useful logs.

This PR:

- expands identical service-log dates into a one-hour range;
- caps the normalized end date at the current time, matching the metrics dashboard behavior;
- keeps different or incomplete ranges unchanged;
- adds focused unit tests for the normalization logic.

To review, open service logs with identical `startDate` and `endDate` query parameters and verify that logs are queried over the normalized one-hour range.

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

Focused validation completed:

- [x] 4 unit tests passed with Jest
- [x] Changed files checked with Prettier
- [x] Changed files checked with ESLint
- [x] `git diff --check`

The Nx project target could not start its plugin worker in the isolated worktree, so Jest, ESLint, and Prettier were run directly on the affected files.

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer — N/A, no UI changes
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
