### PR TITLE
feat(blueprints): add logs to creation flow

### DIFF
--- a/libs/domains/services/feature/src/lib/hooks/use-blueprint-creation-logs/use-blueprint-creation-logs.spec.tsx
+++ b/libs/domains/services/feature/src/lib/hooks/use-blueprint-creation-logs/use-blueprint-creation-logs.spec.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import { type EnvironmentLogs } from 'qovery-typescript-axios'
+import { type PropsWithChildren } from 'react'
+import { useReactQueryWsSubscription } from '@qovery/state/util-queries'
+import { useBlueprintCreationLogs } from './use-blueprint-creation-logs'
+
+jest.mock('@qovery/shared/util-node-env', () => ({
+  QOVERY_WS: 'wss://ws.qovery.com',
+}))
+
+jest.mock('@qovery/state/util-queries', () => ({
+  ...jest.requireActual('@qovery/state/util-queries'),
+  useReactQueryWsSubscription: jest.fn(),
+}))
+
+const useReactQueryWsSubscriptionMock = jest.mocked(useReactQueryWsSubscription)
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function renderUseBlueprintCreationLogs(props: Parameters<typeof useBlueprintCreationLogs>[0]) {
+  const queryClient = new QueryClient()
+  const result = renderHook(() => useBlueprintCreationLogs(props), {
+    wrapper: createWrapper(queryClient),
+  })
+
+  return { ...result, queryClient }
+}
+
+function createLog(transmitter: { id: string; type: string }) {
+  return {
+    timestamp: `${transmitter.id}-${transmitter.type}`,
+    details: { transmitter },
+  } as EnvironmentLogs
+}
+
+describe('useBlueprintCreationLogs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should subscribe to deployment logs only when all creation identifiers are available', () => {
+    renderUseBlueprintCreationLogs({
+      blueprintId: 'blueprint-1',
+      clusterId: 'cluster-1',
+      environmentId: 'environment-1',
+      organizationId: 'organization-1',
+      projectId: 'project-1',
+    })
+
+    expect(useReactQueryWsSubscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'wss://ws.qovery.com/deployment/logs',
+        urlSearchParams: {
+          organization: 'organization-1',
+          cluster: 'cluster-1',
+          project: 'project-1',
+          environment: 'environment-1',
+        },
+        enabled: true,
+      })
+    )
+  })
+
+  it('should keep only logs emitted by the created blueprint', () => {
+    const { result, queryClient } = renderUseBlueprintCreationLogs({
+      blueprintId: 'blueprint-1',
+      clusterId: 'cluster-1',
+      environmentId: 'environment-1',
+      organizationId: 'organization-1',
+      projectId: 'project-1',
+    })
+    const subscriptionConfig = useReactQueryWsSubscriptionMock.mock.calls[0]?.[0]
+
+    act(() => {
+      subscriptionConfig?.onMessage?.(queryClient, [
+        createLog({ id: 'blueprint-1', type: 'Blueprint' }),
+        createLog({ id: 'blueprint-2', type: 'Blueprint' }),
+        createLog({ id: 'blueprint-1', type: 'Environment' }),
+      ])
+    })
+
+    expect(result.current.logs).toEqual([createLog({ id: 'blueprint-1', type: 'Blueprint' })])
+  })
+})

--- a/libs/domains/services/feature/src/lib/hooks/use-blueprint-creation-logs/use-blueprint-creation-logs.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-blueprint-creation-logs/use-blueprint-creation-logs.ts
@@ -1,0 +1,68 @@
+import { type QueryClient } from '@tanstack/react-query'
+import { type EnvironmentLogs } from 'qovery-typescript-axios'
+import { useCallback, useEffect, useState } from 'react'
+import { QOVERY_WS } from '@qovery/shared/util-node-env'
+import { useReactQueryWsSubscription } from '@qovery/state/util-queries'
+
+export interface UseBlueprintCreationLogsProps {
+  blueprintId?: string
+  clusterId?: string
+  environmentId?: string
+  organizationId?: string
+  projectId?: string
+  enabled?: boolean
+}
+
+export function useBlueprintCreationLogs({
+  blueprintId,
+  clusterId,
+  environmentId,
+  organizationId,
+  projectId,
+  enabled = true,
+}: UseBlueprintCreationLogsProps) {
+  const [logs, setLogs] = useState<EnvironmentLogs[]>([])
+
+  useEffect(() => {
+    setLogs([])
+  }, [blueprintId])
+
+  const handleMessage = useCallback(
+    (_: QueryClient, message: EnvironmentLogs[]) => {
+      const blueprintLogs = message.filter(
+        (log) => log.details.transmitter?.type === 'Blueprint' && log.details.transmitter.id === blueprintId
+      )
+
+      if (blueprintLogs.length === 0) {
+        return
+      }
+
+      setLogs((currentLogs) => [
+        ...new Map([...currentLogs, ...blueprintLogs].map((log) => [log.timestamp, log])).values(),
+      ])
+    },
+    [blueprintId]
+  )
+
+  useReactQueryWsSubscription({
+    url: QOVERY_WS + '/deployment/logs',
+    urlSearchParams: {
+      organization: organizationId,
+      cluster: clusterId,
+      project: projectId,
+      environment: environmentId,
+    },
+    enabled:
+      enabled &&
+      Boolean(blueprintId) &&
+      Boolean(clusterId) &&
+      Boolean(environmentId) &&
+      Boolean(organizationId) &&
+      Boolean(projectId),
+    onMessage: handleMessage,
+  })
+
+  return { logs }
+}
+
+export default useBlueprintCreationLogs

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.spec.tsx
@@ -531,6 +531,7 @@ describe('BlueprintCreationFlow', () => {
     await waitFor(() => {
       expect(mockCreateBlueprint).toHaveBeenCalled()
     })
+    expect(screen.queryByRole('heading', { name: 'Creating custom-postgres...' })).not.toBeInTheDocument()
 
     const enabledSocketCall = mockUseBlueprintServiceCreatedSocket.mock.calls.find(
       ([props]) =>

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.spec.tsx
@@ -531,7 +531,6 @@ describe('BlueprintCreationFlow', () => {
     await waitFor(() => {
       expect(mockCreateBlueprint).toHaveBeenCalled()
     })
-    expect(await screen.findByRole('dialog', { name: 'Creating custom-postgres' })).toBeInTheDocument()
 
     const enabledSocketCall = mockUseBlueprintServiceCreatedSocket.mock.calls.find(
       ([props]) =>

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.spec.tsx
@@ -19,6 +19,8 @@ const mockUseBlueprintCatalogServiceManifest = jest.fn()
 const mockPrefetchBlueprintManifestFields = jest.fn()
 const mockUseBlueprintCatalogServiceReadme = jest.fn()
 const mockUseBlueprintServiceCreatedSocket = jest.fn()
+const mockUseBlueprintCreationLogs = jest.fn()
+const mockUseEnvironment = jest.fn()
 const mockCreateBlueprint = jest.fn()
 const mockToast = jest.fn()
 
@@ -55,6 +57,14 @@ jest.mock('../../hooks/use-blueprint-catalog-service-readme/use-blueprint-catalo
 
 jest.mock('../../hooks/use-blueprint-service-created-socket/use-blueprint-service-created-socket', () => ({
   useBlueprintServiceCreatedSocket: (props: unknown) => mockUseBlueprintServiceCreatedSocket(props),
+}))
+
+jest.mock('../../hooks/use-blueprint-creation-logs/use-blueprint-creation-logs', () => ({
+  useBlueprintCreationLogs: (props: unknown) => mockUseBlueprintCreationLogs(props) ?? { logs: [] },
+}))
+
+jest.mock('../../hooks/use-environment/use-environment', () => ({
+  useEnvironment: () => mockUseEnvironment(),
 }))
 
 jest.mock('../../hooks/use-create-blueprint/use-create-blueprint', () => ({
@@ -218,7 +228,8 @@ describe('BlueprintCreationFlow', () => {
         repository_url: 'https://github.com/qovery-blueprints/postgres',
       },
     })
-    mockCreateBlueprint.mockResolvedValue({ environment_id: 'env-1' })
+    mockUseEnvironment.mockReturnValue({ data: { cluster_id: 'cluster-1' } })
+    mockCreateBlueprint.mockResolvedValue({ id: 'blueprint-1', environment_id: 'env-1' })
   })
 
   it('should open the blueprint details drawer from the configuration header', async () => {
@@ -498,10 +509,10 @@ describe('BlueprintCreationFlow', () => {
 
   it('should start listening for the blueprint service-created event before creating the blueprint', async () => {
     jest.useFakeTimers()
-    let resolveCreateBlueprint: (value: { environment_id: string }) => void = jest.fn()
+    let resolveCreateBlueprint: (value: { id: string; environment_id: string }) => void = jest.fn()
     mockCreateBlueprint.mockImplementationOnce(
       () =>
-        new Promise<{ environment_id: string }>((resolve) => {
+        new Promise<{ id: string; environment_id: string }>((resolve) => {
           resolveCreateBlueprint = resolve
         })
     )
@@ -520,6 +531,7 @@ describe('BlueprintCreationFlow', () => {
     await waitFor(() => {
       expect(mockCreateBlueprint).toHaveBeenCalled()
     })
+    expect(await screen.findByRole('dialog', { name: 'Creating custom-postgres' })).toBeInTheDocument()
 
     const enabledSocketCall = mockUseBlueprintServiceCreatedSocket.mock.calls.find(
       ([props]) =>
@@ -552,8 +564,17 @@ describe('BlueprintCreationFlow', () => {
     })
 
     await act(async () => {
-      resolveCreateBlueprint({ environment_id: 'env-1' })
+      resolveCreateBlueprint({ id: 'blueprint-1', environment_id: 'env-1' })
     })
+    await waitFor(() =>
+      expect(mockUseBlueprintCreationLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blueprintId: 'blueprint-1',
+          clusterId: 'cluster-1',
+          enabled: true,
+        })
+      )
+    )
     expect(mockToast).not.toHaveBeenCalled()
 
     act(() => {
@@ -586,10 +607,10 @@ describe('BlueprintCreationFlow', () => {
 
   it('should complete the blueprint creation flow after a fallback timeout when the websocket event is missed', async () => {
     jest.useFakeTimers()
-    let resolveCreateBlueprint: (value: { environment_id: string }) => void = jest.fn()
+    let resolveCreateBlueprint: (value: { id: string; environment_id: string }) => void = jest.fn()
     mockCreateBlueprint.mockImplementationOnce(
       () =>
-        new Promise<{ environment_id: string }>((resolve) => {
+        new Promise<{ id: string; environment_id: string }>((resolve) => {
           resolveCreateBlueprint = resolve
         })
     )
@@ -610,7 +631,7 @@ describe('BlueprintCreationFlow', () => {
     })
 
     await act(async () => {
-      resolveCreateBlueprint({ environment_id: 'env-1' })
+      resolveCreateBlueprint({ id: 'blueprint-1', environment_id: 'env-1' })
     })
 
     expect(mockToast).not.toHaveBeenCalled()

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
@@ -1,0 +1,37 @@
+import { type EnvironmentLogs } from 'qovery-typescript-axios'
+import { LogsType } from '@qovery/shared/enums'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { BlueprintCreationLoadingModal } from './blueprint-creation-loading-modal'
+
+const errorLog = {
+  type: LogsType.ERROR,
+  timestamp: '2026-07-13T12:00:43.000Z',
+  error: {
+    user_log_message: 'Error: Failed to connect to authentication server',
+  },
+} as EnvironmentLogs
+
+describe('BlueprintCreationLoadingModal', () => {
+  it('renders recovery actions and highlights the error log', async () => {
+    const onEditConfig = jest.fn()
+    const onRetry = jest.fn()
+    const { userEvent } = renderWithProviders(
+      <BlueprintCreationLoadingModal
+        logs={[errorLog]}
+        open
+        serviceName="postgres"
+        onEditConfig={onEditConfig}
+        onRetry={onRetry}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Creating postgres' })).toBeVisible()
+    expect(screen.getByText('Error: Failed to connect to authentication server')).toHaveClass('text-negative')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit config' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(onEditConfig).toHaveBeenCalledTimes(1)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
@@ -11,6 +11,14 @@ const errorLog = {
   },
 } as EnvironmentLogs
 
+const infoLog = {
+  type: LogsType.INFO,
+  timestamp: '2026-07-13T12:00:42.000Z',
+  message: {
+    safe_message: 'Creating service resources',
+  },
+} as EnvironmentLogs
+
 describe('BlueprintCreationLoadingModal', () => {
   it('renders log skeletons while waiting for the first log', () => {
     renderWithProviders(
@@ -24,6 +32,32 @@ describe('BlueprintCreationLoadingModal', () => {
     )
 
     expect(screen.getByLabelText('Waiting for creation logs')).toBeVisible()
+  })
+
+  it('scrolls to the latest log', () => {
+    const { rerender } = renderWithProviders(
+      <BlueprintCreationLoadingModal
+        logs={[infoLog]}
+        open
+        serviceName="postgres"
+        onEditConfig={jest.fn()}
+        onRetry={jest.fn()}
+      />
+    )
+    const logsContainer = screen.getByRole('log')
+    Object.defineProperty(logsContainer, 'scrollHeight', { configurable: true, value: 240 })
+
+    rerender(
+      <BlueprintCreationLoadingModal
+        logs={[infoLog, errorLog]}
+        open
+        serviceName="postgres"
+        onEditConfig={jest.fn()}
+        onRetry={jest.fn()}
+      />
+    )
+
+    expect(logsContainer.scrollTop).toBe(240)
   })
 
   it('renders recovery actions and highlights the error log', async () => {

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
@@ -12,6 +12,20 @@ const errorLog = {
 } as EnvironmentLogs
 
 describe('BlueprintCreationLoadingModal', () => {
+  it('renders log skeletons while waiting for the first log', () => {
+    renderWithProviders(
+      <BlueprintCreationLoadingModal
+        logs={[]}
+        open
+        serviceName="postgres"
+        onEditConfig={jest.fn()}
+        onRetry={jest.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText('Waiting for creation logs')).toBeVisible()
+  })
+
   it('renders recovery actions and highlights the error log', async () => {
     const onEditConfig = jest.fn()
     const onRetry = jest.fn()

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
@@ -11,14 +11,6 @@ const errorLog = {
   },
 } as EnvironmentLogs
 
-const infoLog = {
-  type: LogsType.INFO,
-  timestamp: '2026-07-13T12:00:42.000Z',
-  message: {
-    safe_message: 'Creating service resources',
-  },
-} as EnvironmentLogs
-
 describe('BlueprintCreationLoadingModal', () => {
   it('renders log skeletons while waiting for the first log', () => {
     renderWithProviders(
@@ -32,32 +24,6 @@ describe('BlueprintCreationLoadingModal', () => {
     )
 
     expect(screen.getByLabelText('Waiting for creation logs')).toBeVisible()
-  })
-
-  it('scrolls to the latest log', () => {
-    const { rerender } = renderWithProviders(
-      <BlueprintCreationLoadingModal
-        logs={[infoLog]}
-        open
-        serviceName="postgres"
-        onEditConfig={jest.fn()}
-        onRetry={jest.fn()}
-      />
-    )
-    const logsContainer = screen.getByRole('log')
-    Object.defineProperty(logsContainer, 'scrollHeight', { configurable: true, value: 240 })
-
-    rerender(
-      <BlueprintCreationLoadingModal
-        logs={[infoLog, errorLog]}
-        open
-        serviceName="postgres"
-        onEditConfig={jest.fn()}
-        onRetry={jest.fn()}
-      />
-    )
-
-    expect(logsContainer.scrollTop).toBe(240)
   })
 
   it('renders recovery actions and highlights the error log', async () => {
@@ -74,7 +40,9 @@ describe('BlueprintCreationLoadingModal', () => {
     )
 
     expect(screen.getByRole('heading', { name: 'Creating postgres' })).toBeVisible()
-    expect(screen.getByText('Error: Failed to connect to authentication server')).toHaveClass('text-negative')
+    expect(screen.getByText('Error: Failed to connect to authentication server').closest('div')).toHaveClass(
+      'text-negative'
+    )
 
     await userEvent.click(screen.getByRole('button', { name: 'Edit config' }))
     await userEvent.click(screen.getByRole('button', { name: 'Retry' }))

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.spec.tsx
@@ -12,20 +12,6 @@ const errorLog = {
 } as EnvironmentLogs
 
 describe('BlueprintCreationLoadingModal', () => {
-  it('renders log skeletons while waiting for the first log', () => {
-    renderWithProviders(
-      <BlueprintCreationLoadingModal
-        logs={[]}
-        open
-        serviceName="postgres"
-        onEditConfig={jest.fn()}
-        onRetry={jest.fn()}
-      />
-    )
-
-    expect(screen.getByLabelText('Waiting for creation logs')).toBeVisible()
-  })
-
   it('renders recovery actions and highlights the error log', async () => {
     const onEditConfig = jest.fn()
     const onRetry = jest.fn()

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
@@ -1,5 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { type EnvironmentLogs } from 'qovery-typescript-axios'
+import { useLayoutEffect, useRef } from 'react'
 import { LogsType } from '@qovery/shared/enums'
 import { Ansi, Button, Heading, Icon, Skeleton } from '@qovery/shared/ui'
 import { dateFullFormat } from '@qovery/shared/util-dates'
@@ -20,6 +21,14 @@ export function BlueprintCreationLoadingModal({
   serviceName,
 }: BlueprintCreationLoadingModalProps) {
   const hasError = logs.some((log) => log.type === LogsType.ERROR)
+  const logsContainerRef = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    const logsContainer = logsContainerRef.current
+    if (!logsContainer || logs.length === 0) return
+
+    logsContainer.scrollTop = logsContainer.scrollHeight
+  }, [logs])
 
   return (
     <Dialog.Root open={open} onOpenChange={() => undefined}>
@@ -57,6 +66,7 @@ export function BlueprintCreationLoadingModal({
           </div>
 
           <div
+            ref={logsContainerRef}
             className="min-h-0 flex-1 overflow-auto bg-surface-neutral-subtle py-3 font-code text-xs leading-5 text-neutral"
             role="log"
           >

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
@@ -1,59 +1,85 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { type EnvironmentLogs } from 'qovery-typescript-axios'
 import { LogsType } from '@qovery/shared/enums'
-import { Ansi, Heading, LoaderSpinner, Section } from '@qovery/shared/ui'
+import { Ansi, Button, Heading, Icon } from '@qovery/shared/ui'
 import { dateFullFormat } from '@qovery/shared/util-dates'
 
 export interface BlueprintCreationLoadingModalProps {
   logs: EnvironmentLogs[]
+  onEditConfig: () => void
+  onRetry: () => void
   open: boolean
   serviceName: string
 }
 
-export function BlueprintCreationLoadingModal({ logs, open, serviceName }: BlueprintCreationLoadingModalProps) {
+export function BlueprintCreationLoadingModal({
+  logs,
+  onEditConfig,
+  onRetry,
+  open,
+  serviceName,
+}: BlueprintCreationLoadingModalProps) {
+  const hasError = logs.some((log) => log.type === LogsType.ERROR)
+
   return (
     <Dialog.Root open={open} onOpenChange={() => undefined}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-overlay bg-background-overlay" />
         <Dialog.Content
           aria-describedby="blueprint-creation-loading-description"
-          className="fixed left-1/2 top-1/2 z-overlay flex h-[480px] w-[680px] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-lg border border-neutral bg-surface-neutral shadow-lg focus:outline-none"
+          className="fixed left-1/2 top-1/2 z-overlay flex h-[480px] w-[680px] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-md border border-neutral bg-surface-neutral shadow-lg focus:outline-none"
           onEscapeKeyDown={(event) => event.preventDefault()}
           onInteractOutside={(event) => event.preventDefault()}
           onPointerDownOutside={(event) => event.preventDefault()}
         >
-          <Section className="shrink-0 gap-1 border-b border-neutral px-5 py-4">
+          <div className="flex shrink-0 items-center justify-between gap-4 border-b border-neutral px-5 py-5">
             <Dialog.Title asChild>
-              <Heading level={3}>Creating {serviceName}</Heading>
+              <Heading level={1} className="min-w-0 flex-1 truncate leading-8">
+                Creating <span className="text-neutral-subtle">{serviceName}</span>
+                {hasError ? '' : '...'}
+              </Heading>
             </Dialog.Title>
-            <Dialog.Description id="blueprint-creation-loading-description" className="text-sm text-neutral-subtle">
-              Your blueprint service is being created. Creation logs will appear below.
-            </Dialog.Description>
-          </Section>
-
-          <div className="min-h-0 flex-1 overflow-auto px-5 py-4 font-code text-xs leading-5 text-neutral" role="log">
-            {logs.length > 0 ? (
-              <div className="flex flex-col gap-1">
-                {logs.map((log) => {
-                  const isError = log.type === LogsType.ERROR
-                  const message = isError ? log.error?.user_log_message : log.message?.safe_message
-
-                  return (
-                    <div key={log.timestamp} className={isError ? 'text-negative' : 'text-neutral'}>
-                      <span className="mr-3 select-none text-neutral-subtle">
-                        {dateFullFormat(log.timestamp, 'UTC', 'HH:mm:ss')}
-                      </span>
-                      <Ansi>{message}</Ansi>
-                    </div>
-                  )
-                })}
-              </div>
-            ) : (
-              <div className="flex h-full items-center justify-center gap-2 font-sans text-sm text-neutral-subtle">
-                <LoaderSpinner />
-                <span>Waiting for creation logs</span>
+            {hasError && (
+              <div className="flex shrink-0 items-center gap-2">
+                <Button type="button" variant="outline" color="neutral" size="md" onClick={onEditConfig}>
+                  <Icon iconName="pen" iconStyle="regular" />
+                  Edit config
+                </Button>
+                <Button type="button" size="md" onClick={onRetry}>
+                  <Icon iconName="arrow-rotate-right" iconStyle="regular" />
+                  Retry
+                </Button>
               </div>
             )}
+            <Dialog.Description id="blueprint-creation-loading-description" className="sr-only">
+              Blueprint service creation logs.
+            </Dialog.Description>
+          </div>
+
+          <div
+            className="min-h-0 flex-1 overflow-auto bg-surface-neutral-subtle py-3 font-code text-xs leading-5 text-neutral"
+            role="log"
+          >
+            <div className="flex flex-col gap-1">
+              {logs.map((log) => {
+                const isError = log.type === LogsType.ERROR
+                const message = isError ? log.error?.user_log_message : log.message?.safe_message
+
+                return (
+                  <div
+                    key={log.timestamp}
+                    className={isError ? 'bg-surface-negative-subtle px-5 text-negative' : 'px-5 text-neutral'}
+                  >
+                    <span
+                      className={isError ? 'mr-3 select-none text-negative' : 'mr-3 select-none text-neutral-subtle'}
+                    >
+                      {dateFullFormat(log.timestamp, 'UTC', 'HH:mm:ss')}
+                    </span>
+                    <Ansi>{message}</Ansi>
+                  </div>
+                )
+              })}
+            </div>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { type EnvironmentLogs } from 'qovery-typescript-axios'
 import { LogsType } from '@qovery/shared/enums'
-import { Ansi, Button, Heading, Icon } from '@qovery/shared/ui'
+import { Ansi, Button, Heading, Icon, Skeleton } from '@qovery/shared/ui'
 import { dateFullFormat } from '@qovery/shared/util-dates'
 
 export interface BlueprintCreationLoadingModalProps {
@@ -60,30 +60,49 @@ export function BlueprintCreationLoadingModal({
             className="min-h-0 flex-1 overflow-auto bg-surface-neutral-subtle py-3 font-code text-xs leading-5 text-neutral"
             role="log"
           >
-            <div className="flex flex-col gap-1">
-              {logs.map((log) => {
-                const isError = log.type === LogsType.ERROR
-                const message = isError ? log.error?.user_log_message : log.message?.safe_message
+            {logs.length === 0 ? (
+              <BlueprintCreationLogsSkeleton />
+            ) : (
+              <div className="flex flex-col gap-1">
+                {logs.map((log) => {
+                  const isError = log.type === LogsType.ERROR
+                  const message = isError ? log.error?.user_log_message : log.message?.safe_message
 
-                return (
-                  <div
-                    key={log.timestamp}
-                    className={isError ? 'bg-surface-negative-subtle px-5 text-negative' : 'px-5 text-neutral'}
-                  >
-                    <span
-                      className={isError ? 'mr-3 select-none text-negative' : 'mr-3 select-none text-neutral-subtle'}
+                  return (
+                    <div
+                      key={log.timestamp}
+                      className={isError ? 'bg-surface-negative-subtle px-5 text-negative' : 'px-5 text-neutral'}
                     >
-                      {dateFullFormat(log.timestamp, 'UTC', 'HH:mm:ss')}
-                    </span>
-                    <Ansi>{message}</Ansi>
-                  </div>
-                )
-              })}
-            </div>
+                      <span
+                        className={isError ? 'mr-3 select-none text-negative' : 'mr-3 select-none text-neutral-subtle'}
+                      >
+                        {dateFullFormat(log.timestamp, 'UTC', 'HH:mm:ss')}
+                      </span>
+                      <Ansi>{message}</Ansi>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
           </div>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
+  )
+}
+
+function BlueprintCreationLogsSkeleton() {
+  const lineWidths = ['64%', '48%', '72%', '56%', '68%', '42%', '76%', '52%', '62%', '44%', '70%', '58%']
+
+  return (
+    <div aria-label="Waiting for creation logs" className="flex flex-col gap-3 px-5 py-1">
+      {lineWidths.map((width, index) => (
+        <div key={`${width}-${index}`} className="flex items-center gap-3">
+          <Skeleton width={56} height={12} />
+          <Skeleton width={width} height={12} />
+        </div>
+      ))}
+    </div>
   )
 }
 

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
@@ -1,0 +1,64 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { type EnvironmentLogs } from 'qovery-typescript-axios'
+import { LogsType } from '@qovery/shared/enums'
+import { Ansi, Heading, LoaderSpinner, Section } from '@qovery/shared/ui'
+import { dateFullFormat } from '@qovery/shared/util-dates'
+
+export interface BlueprintCreationLoadingModalProps {
+  logs: EnvironmentLogs[]
+  open: boolean
+  serviceName: string
+}
+
+export function BlueprintCreationLoadingModal({ logs, open, serviceName }: BlueprintCreationLoadingModalProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={() => undefined}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-overlay bg-background-overlay" />
+        <Dialog.Content
+          aria-describedby="blueprint-creation-loading-description"
+          className="fixed left-1/2 top-1/2 z-overlay flex h-[480px] w-[680px] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-lg border border-neutral bg-surface-neutral shadow-lg focus:outline-none"
+          onEscapeKeyDown={(event) => event.preventDefault()}
+          onInteractOutside={(event) => event.preventDefault()}
+          onPointerDownOutside={(event) => event.preventDefault()}
+        >
+          <Section className="shrink-0 gap-1 border-b border-neutral px-5 py-4">
+            <Dialog.Title asChild>
+              <Heading level={3}>Creating {serviceName}</Heading>
+            </Dialog.Title>
+            <Dialog.Description id="blueprint-creation-loading-description" className="text-sm text-neutral-subtle">
+              Your blueprint service is being created. Creation logs will appear below.
+            </Dialog.Description>
+          </Section>
+
+          <div className="min-h-0 flex-1 overflow-auto px-5 py-4 font-code text-xs leading-5 text-neutral" role="log">
+            {logs.length > 0 ? (
+              <div className="flex flex-col gap-1">
+                {logs.map((log) => {
+                  const isError = log.type === LogsType.ERROR
+                  const message = isError ? log.error?.user_log_message : log.message?.safe_message
+
+                  return (
+                    <div key={log.timestamp} className={isError ? 'text-negative' : 'text-neutral'}>
+                      <span className="mr-3 select-none text-neutral-subtle">
+                        {dateFullFormat(log.timestamp, 'UTC', 'HH:mm:ss')}
+                      </span>
+                      <Ansi>{message}</Ansi>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <div className="flex h-full items-center justify-center gap-2 font-sans text-sm text-neutral-subtle">
+                <LoaderSpinner />
+                <span>Waiting for creation logs</span>
+              </div>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+export default BlueprintCreationLoadingModal

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-creation-loading-modal/blueprint-creation-loading-modal.tsx
@@ -2,7 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { type EnvironmentLogs } from 'qovery-typescript-axios'
 import { useLayoutEffect, useRef } from 'react'
 import { LogsType } from '@qovery/shared/enums'
-import { Ansi, Button, Heading, Icon, Skeleton } from '@qovery/shared/ui'
+import { Ansi, Button, Heading, Icon } from '@qovery/shared/ui'
 import { dateFullFormat } from '@qovery/shared/util-dates'
 
 export interface BlueprintCreationLoadingModalProps {
@@ -70,49 +70,30 @@ export function BlueprintCreationLoadingModal({
             className="min-h-0 flex-1 overflow-auto bg-surface-neutral-subtle py-3 font-code text-xs leading-5 text-neutral"
             role="log"
           >
-            {logs.length === 0 ? (
-              <BlueprintCreationLogsSkeleton />
-            ) : (
-              <div className="flex flex-col gap-1">
-                {logs.map((log) => {
-                  const isError = log.type === LogsType.ERROR
-                  const message = isError ? log.error?.user_log_message : log.message?.safe_message
+            <div className="flex flex-col gap-1">
+              {logs.map((log) => {
+                const isError = log.type === LogsType.ERROR
+                const message = isError ? log.error?.user_log_message : log.message?.safe_message
 
-                  return (
-                    <div
-                      key={log.timestamp}
-                      className={isError ? 'bg-surface-negative-subtle px-5 text-negative' : 'px-5 text-neutral'}
+                return (
+                  <div
+                    key={log.timestamp}
+                    className={isError ? 'bg-surface-negative-subtle px-5 text-negative' : 'px-5 text-neutral'}
+                  >
+                    <span
+                      className={isError ? 'mr-3 select-none text-negative' : 'mr-3 select-none text-neutral-subtle'}
                     >
-                      <span
-                        className={isError ? 'mr-3 select-none text-negative' : 'mr-3 select-none text-neutral-subtle'}
-                      >
-                        {dateFullFormat(log.timestamp, 'UTC', 'HH:mm:ss')}
-                      </span>
-                      <Ansi>{message}</Ansi>
-                    </div>
-                  )
-                })}
-              </div>
-            )}
+                      {dateFullFormat(log.timestamp, 'UTC', 'HH:mm:ss')}
+                    </span>
+                    <Ansi>{message}</Ansi>
+                  </div>
+                )
+              })}
+            </div>
           </div>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
-  )
-}
-
-function BlueprintCreationLogsSkeleton() {
-  const lineWidths = ['64%', '48%', '72%', '56%', '68%', '42%', '76%', '52%', '62%', '44%', '70%', '58%']
-
-  return (
-    <div aria-label="Waiting for creation logs" className="flex flex-col gap-3 px-5 py-1">
-      {lineWidths.map((width, index) => (
-        <div key={`${width}-${index}`} className="flex items-center gap-3">
-          <Skeleton width={56} height={12} />
-          <Skeleton width={width} height={12} />
-        </div>
-      ))}
-    </div>
   )
 }
 

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
@@ -8,11 +8,14 @@ import {
   getSummaryFieldValue,
   isFieldValid,
 } from '../../../blueprint-field-utils/blueprint-field-utils'
+import { useBlueprintCreationLogs } from '../../../hooks/use-blueprint-creation-logs/use-blueprint-creation-logs'
 import { useBlueprintServiceCreatedSocket } from '../../../hooks/use-blueprint-service-created-socket/use-blueprint-service-created-socket'
 import { useCreateBlueprint } from '../../../hooks/use-create-blueprint/use-create-blueprint'
+import { useEnvironment } from '../../../hooks/use-environment/use-environment'
 import { useBlueprintCreateContext } from '../blueprint-create-context/blueprint-create-context'
 import { buildBlueprintVariables } from '../blueprint-creation-utils/blueprint-creation-utils'
 import { useBlueprintManifestFields } from '../blueprint-manifest-context/blueprint-manifest-context'
+import { BlueprintCreationLoadingModal } from './blueprint-creation-loading-modal/blueprint-creation-loading-modal'
 
 type BlueprintConfigurationSection = 'service-information' | 'blueprint-setup' | 'overrides'
 
@@ -26,6 +29,7 @@ export function BlueprintStepSummary() {
     useBlueprintManifestFields()
   const [submitMode, setSubmitMode] = useState<'create' | 'create-and-deploy' | null>(null)
   const [isWaitingForServiceCreated, setIsWaitingForServiceCreated] = useState(false)
+  const [createdBlueprintId, setCreatedBlueprintId] = useState<string>()
   const [pendingBlueprintCreation, setPendingBlueprintCreation] = useState<{
     deploy: boolean
     payload: BlueprintCreateRequest
@@ -34,11 +38,20 @@ export function BlueprintStepSummary() {
   const hasStartedBlueprintCreationRef = useRef(false)
   const serviceCreatedFallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { mutateAsync: createBlueprint } = useCreateBlueprint()
+  const { data: environment } = useEnvironment({ environmentId })
   const { fields, serviceName } = form.watch()
   const variableFields = [...requiredBlueprintFields, ...optionalBlueprintFields]
   const overrideFields = [...optionalBlueprintFields, ...overridableContextBlueprintFields]
   const blueprintFields = [...variableFields, ...overridableContextBlueprintFields]
   const isBlueprintSetupValid = requiredBlueprintFields.every((field) => isFieldValid(field, fields[field.name]))
+  const { logs: blueprintCreationLogs } = useBlueprintCreationLogs({
+    blueprintId: createdBlueprintId,
+    clusterId: environment?.cluster_id,
+    environmentId,
+    organizationId,
+    projectId,
+    enabled: isWaitingForServiceCreated,
+  })
 
   const handleEditSection = (section: BlueprintConfigurationSection) => {
     navigate({ to: `${creationFlowUrl}/${section}` })
@@ -120,7 +133,7 @@ export function BlueprintStepSummary() {
 
     async function createPendingBlueprint() {
       try {
-        await createBlueprint({
+        const createdBlueprint = await createBlueprint({
           environmentId,
           deploy: blueprintCreation.deploy,
           payload: blueprintCreation.payload,
@@ -130,6 +143,7 @@ export function BlueprintStepSummary() {
           return
         }
 
+        setCreatedBlueprintId(createdBlueprint.id)
         posthog.capture('create-service', {
           selectedServiceType: 'blueprint',
           selectedServiceSubType: blueprint.serviceFamily ?? blueprint.provider,
@@ -173,6 +187,7 @@ export function BlueprintStepSummary() {
     clearServiceCreatedFallbackTimeout()
     hasHandledServiceCreatedRef.current = false
     hasStartedBlueprintCreationRef.current = false
+    setCreatedBlueprintId(undefined)
     setIsWaitingForServiceCreated(true)
     setPendingBlueprintCreation({
       deploy: withDeploy,
@@ -186,129 +201,136 @@ export function BlueprintStepSummary() {
   }
 
   return (
-    <FunnelFlowBody customContentWidth="max-w-[1024px]">
-      <Section className="space-y-10">
-        <div className="flex flex-col gap-2">
-          <Heading className="mb-2">Ready to create your blueprint service</Heading>
-          <p className="text-sm text-neutral-subtle">
-            Review the configuration generated from the selected blueprint before creating the service.
-          </p>
-        </div>
+    <>
+      <FunnelFlowBody customContentWidth="max-w-[1024px]">
+        <Section className="space-y-10">
+          <div className="flex flex-col gap-2">
+            <Heading className="mb-2">Ready to create your blueprint service</Heading>
+            <p className="text-sm text-neutral-subtle">
+              Review the configuration generated from the selected blueprint before creating the service.
+            </p>
+          </div>
 
-        <div className="flex flex-col gap-6">
-          <Section className="rounded-md border border-neutral bg-surface-neutral-subtle p-4">
-            <div className="flex justify-between">
-              <Heading>Service information</Heading>
-              <Button
-                aria-label="Edit service information"
-                type="button"
-                variant="outline"
-                color="neutral"
-                size="md"
-                onClick={() => handleEditSection('service-information')}
-                iconOnly
-              >
-                <Icon className="text-base" iconName="gear-complex" />
-              </Button>
-            </div>
-            <ul className="list-none space-y-2 text-sm text-neutral-subtle">
-              <SummaryValue label="Name" value={serviceName} />
-              <SummaryValue label="Blueprint" value={blueprint.name} />
-              <SummaryValue label="Blueprint version" value={serviceVersion} />
-            </ul>
-          </Section>
-
-          {requiredBlueprintFields.length > 0 && (
+          <div className="flex flex-col gap-6">
             <Section className="rounded-md border border-neutral bg-surface-neutral-subtle p-4">
               <div className="flex justify-between">
-                <Heading>Blueprint setup</Heading>
+                <Heading>Service information</Heading>
                 <Button
-                  aria-label="Edit blueprint setup"
+                  aria-label="Edit service information"
                   type="button"
                   variant="outline"
                   color="neutral"
                   size="md"
-                  onClick={() => handleEditSection('blueprint-setup')}
+                  onClick={() => handleEditSection('service-information')}
                   iconOnly
                 >
                   <Icon className="text-base" iconName="gear-complex" />
                 </Button>
               </div>
               <ul className="list-none space-y-2 text-sm text-neutral-subtle">
-                {requiredBlueprintFields.map((field) => (
-                  <SummaryValue
-                    key={field.name}
-                    label={formatFieldLabel(field.name)}
-                    value={getSummaryFieldValue(field, fields[field.name])}
-                  />
-                ))}
+                <SummaryValue label="Name" value={serviceName} />
+                <SummaryValue label="Blueprint" value={blueprint.name} />
+                <SummaryValue label="Blueprint version" value={serviceVersion} />
               </ul>
             </Section>
-          )}
 
-          <Section className="rounded-md border border-neutral bg-surface-neutral-subtle p-4">
-            <div className="flex justify-between">
-              <Heading>Overrides</Heading>
+            {requiredBlueprintFields.length > 0 && (
+              <Section className="rounded-md border border-neutral bg-surface-neutral-subtle p-4">
+                <div className="flex justify-between">
+                  <Heading>Blueprint setup</Heading>
+                  <Button
+                    aria-label="Edit blueprint setup"
+                    type="button"
+                    variant="outline"
+                    color="neutral"
+                    size="md"
+                    onClick={() => handleEditSection('blueprint-setup')}
+                    iconOnly
+                  >
+                    <Icon className="text-base" iconName="gear-complex" />
+                  </Button>
+                </div>
+                <ul className="list-none space-y-2 text-sm text-neutral-subtle">
+                  {requiredBlueprintFields.map((field) => (
+                    <SummaryValue
+                      key={field.name}
+                      label={formatFieldLabel(field.name)}
+                      value={getSummaryFieldValue(field, fields[field.name])}
+                    />
+                  ))}
+                </ul>
+              </Section>
+            )}
+
+            <Section className="rounded-md border border-neutral bg-surface-neutral-subtle p-4">
+              <div className="flex justify-between">
+                <Heading>Overrides</Heading>
+                <Button
+                  aria-label="Edit overrides"
+                  type="button"
+                  variant="outline"
+                  color="neutral"
+                  size="md"
+                  onClick={() => handleEditSection('overrides')}
+                  iconOnly
+                >
+                  <Icon className="text-base" iconName="gear-complex" />
+                </Button>
+              </div>
+              {overrideFields.length > 0 ? (
+                <ul className="list-none space-y-2 text-sm text-neutral-subtle">
+                  {overrideFields.map((field) => (
+                    <SummaryValue
+                      key={field.name}
+                      label={formatFieldLabel(field.name)}
+                      value={getSummaryFieldValue(field, fields[field.name])}
+                    />
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-neutral-subtle">No overrides configured.</p>
+              )}
+            </Section>
+          </div>
+
+          <div className="flex justify-between">
+            <Button
+              onClick={() => navigate({ to: `${creationFlowUrl}/overrides` })}
+              type="button"
+              size="lg"
+              variant="plain"
+            >
+              Back
+            </Button>
+            <div className="flex gap-2">
               <Button
-                aria-label="Edit overrides"
+                data-testid="button-create"
+                loading={submitMode === 'create'}
+                onClick={() => handleSubmit(false)}
+                size="lg"
                 type="button"
                 variant="outline"
-                color="neutral"
-                size="md"
-                onClick={() => handleEditSection('overrides')}
-                iconOnly
               >
-                <Icon className="text-base" iconName="gear-complex" />
+                Create
+              </Button>
+              <Button
+                data-testid="button-create-deploy"
+                loading={submitMode === 'create-and-deploy'}
+                onClick={() => handleSubmit(true)}
+                type="button"
+                size="lg"
+              >
+                Create and deploy
               </Button>
             </div>
-            {overrideFields.length > 0 ? (
-              <ul className="list-none space-y-2 text-sm text-neutral-subtle">
-                {overrideFields.map((field) => (
-                  <SummaryValue
-                    key={field.name}
-                    label={formatFieldLabel(field.name)}
-                    value={getSummaryFieldValue(field, fields[field.name])}
-                  />
-                ))}
-              </ul>
-            ) : (
-              <p className="text-sm text-neutral-subtle">No overrides configured.</p>
-            )}
-          </Section>
-        </div>
-
-        <div className="flex justify-between">
-          <Button
-            onClick={() => navigate({ to: `${creationFlowUrl}/overrides` })}
-            type="button"
-            size="lg"
-            variant="plain"
-          >
-            Back
-          </Button>
-          <div className="flex gap-2">
-            <Button
-              data-testid="button-create"
-              loading={submitMode === 'create'}
-              onClick={() => handleSubmit(false)}
-              size="lg"
-              type="button"
-              variant="outline"
-            >
-              Create
-            </Button>
-            <Button
-              data-testid="button-create-deploy"
-              loading={submitMode === 'create-and-deploy'}
-              onClick={() => handleSubmit(true)}
-              type="button"
-              size="lg"
-            >
-              Create and deploy
-            </Button>
           </div>
-        </div>
-      </Section>
-    </FunnelFlowBody>
+        </Section>
+      </FunnelFlowBody>
+      <BlueprintCreationLoadingModal
+        logs={blueprintCreationLogs}
+        open={isWaitingForServiceCreated}
+        serviceName={serviceName}
+      />
+    </>
   )
 }

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
@@ -246,7 +246,7 @@ export function BlueprintStepSummary() {
     setIsWaitingForServiceCreated(false)
     setIsBlueprintCreationFailed(false)
     setSubmitMode(null)
-    navigate({ to: `${creationFlowUrl}/overrides` }) // TODO [blueprints]: Should redirect to the main section, not "overrides"
+    navigate({ to: `${creationFlowUrl}/service-information` })
   }
 
   return (

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useParams } from '@tanstack/react-router'
 import posthog from 'posthog-js'
 import { type BlueprintCreateRequest } from 'qovery-typescript-axios'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { LogsType } from '@qovery/shared/enums'
 import { Button, FunnelFlowBody, Heading, Icon, Section, SummaryValue, toast } from '@qovery/shared/ui'
 import {
   formatFieldLabel,
@@ -18,6 +19,10 @@ import { useBlueprintManifestFields } from '../blueprint-manifest-context/bluepr
 import { BlueprintCreationLoadingModal } from './blueprint-creation-loading-modal/blueprint-creation-loading-modal'
 
 type BlueprintConfigurationSection = 'service-information' | 'blueprint-setup' | 'overrides'
+type PendingBlueprintCreation = {
+  deploy: boolean
+  payload: BlueprintCreateRequest
+}
 
 const BLUEPRINT_SERVICE_CREATED_FALLBACK_TIMEOUT_MS = 30_000
 
@@ -29,12 +34,12 @@ export function BlueprintStepSummary() {
     useBlueprintManifestFields()
   const [submitMode, setSubmitMode] = useState<'create' | 'create-and-deploy' | null>(null)
   const [isWaitingForServiceCreated, setIsWaitingForServiceCreated] = useState(false)
+  const [isBlueprintCreationFailed, setIsBlueprintCreationFailed] = useState(false)
   const [createdBlueprintId, setCreatedBlueprintId] = useState<string>()
-  const [pendingBlueprintCreation, setPendingBlueprintCreation] = useState<{
-    deploy: boolean
-    payload: BlueprintCreateRequest
-  } | null>(null)
+  const [pendingBlueprintCreation, setPendingBlueprintCreation] = useState<PendingBlueprintCreation | null>(null)
+  const [lastBlueprintCreation, setLastBlueprintCreation] = useState<PendingBlueprintCreation | null>(null)
   const hasHandledServiceCreatedRef = useRef(false)
+  const hasBlueprintCreationErrorRef = useRef(false)
   const hasStartedBlueprintCreationRef = useRef(false)
   const serviceCreatedFallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { mutateAsync: createBlueprint } = useCreateBlueprint()
@@ -50,8 +55,10 @@ export function BlueprintStepSummary() {
     environmentId,
     organizationId,
     projectId,
-    enabled: isWaitingForServiceCreated,
+    enabled: isWaitingForServiceCreated && !isBlueprintCreationFailed,
   })
+  const hasBlueprintCreationError =
+    Boolean(createdBlueprintId) && blueprintCreationLogs.some((log) => log.type === LogsType.ERROR)
 
   const handleEditSection = (section: BlueprintConfigurationSection) => {
     navigate({ to: `${creationFlowUrl}/${section}` })
@@ -78,7 +85,7 @@ export function BlueprintStepSummary() {
   }, [])
 
   const handleBlueprintServiceCreated = useCallback(() => {
-    if (hasHandledServiceCreatedRef.current) {
+    if (hasHandledServiceCreatedRef.current || hasBlueprintCreationErrorRef.current) {
       return
     }
 
@@ -105,7 +112,7 @@ export function BlueprintStepSummary() {
     organizationId,
     projectId,
     environmentId,
-    enabled: isWaitingForServiceCreated,
+    enabled: isWaitingForServiceCreated && !isBlueprintCreationFailed,
     onServiceCreated: handleBlueprintServiceCreated,
   })
 
@@ -114,6 +121,19 @@ export function BlueprintStepSummary() {
   }, [setCurrentStep])
 
   useEffect(() => () => clearServiceCreatedFallbackTimeout(), [clearServiceCreatedFallbackTimeout])
+
+  useEffect(() => {
+    if (!hasBlueprintCreationError) {
+      return
+    }
+
+    hasBlueprintCreationErrorRef.current = true
+    clearServiceCreatedFallbackTimeout()
+    setPendingBlueprintCreation(null)
+    setIsWaitingForServiceCreated(false)
+    setIsBlueprintCreationFailed(true)
+    setSubmitMode(null)
+  }, [clearServiceCreatedFallbackTimeout, hasBlueprintCreationError])
 
   useEffect(() => {
     if (!serviceName.trim() || !isBlueprintSetupValid) {
@@ -182,14 +202,7 @@ export function BlueprintStepSummary() {
 
   const handleSubmit = (withDeploy: boolean) => {
     const formValues = form.getValues()
-
-    setSubmitMode(withDeploy ? 'create-and-deploy' : 'create')
-    clearServiceCreatedFallbackTimeout()
-    hasHandledServiceCreatedRef.current = false
-    hasStartedBlueprintCreationRef.current = false
-    setCreatedBlueprintId(undefined)
-    setIsWaitingForServiceCreated(true)
-    setPendingBlueprintCreation({
+    const blueprintCreation = {
       deploy: withDeploy,
       payload: {
         name: formValues.serviceName,
@@ -197,7 +210,43 @@ export function BlueprintStepSummary() {
         icon: blueprint.icon,
         variables: buildBlueprintVariables(formValues.fields, blueprintFields),
       },
-    })
+    }
+
+    setSubmitMode(withDeploy ? 'create-and-deploy' : 'create')
+    clearServiceCreatedFallbackTimeout()
+    hasHandledServiceCreatedRef.current = false
+    hasBlueprintCreationErrorRef.current = false
+    hasStartedBlueprintCreationRef.current = false
+    setCreatedBlueprintId(undefined)
+    setIsBlueprintCreationFailed(false)
+    setLastBlueprintCreation(blueprintCreation)
+    setIsWaitingForServiceCreated(true)
+
+    setPendingBlueprintCreation(blueprintCreation)
+  }
+
+  const handleRetry = () => {
+    if (!lastBlueprintCreation) return
+
+    clearServiceCreatedFallbackTimeout()
+    hasHandledServiceCreatedRef.current = false
+    hasBlueprintCreationErrorRef.current = false
+    hasStartedBlueprintCreationRef.current = false
+    setCreatedBlueprintId(undefined)
+    setIsBlueprintCreationFailed(false)
+    setSubmitMode(lastBlueprintCreation.deploy ? 'create-and-deploy' : 'create')
+    setIsWaitingForServiceCreated(true)
+
+    setPendingBlueprintCreation(lastBlueprintCreation)
+  }
+
+  const handleEditConfig = () => {
+    clearServiceCreatedFallbackTimeout()
+    hasBlueprintCreationErrorRef.current = false
+    setIsWaitingForServiceCreated(false)
+    setIsBlueprintCreationFailed(false)
+    setSubmitMode(null)
+    navigate({ to: `${creationFlowUrl}/overrides` }) // TODO [blueprints]: Should redirect to the main section, not "overrides"
   }
 
   return (
@@ -328,7 +377,9 @@ export function BlueprintStepSummary() {
       </FunnelFlowBody>
       <BlueprintCreationLoadingModal
         logs={blueprintCreationLogs}
-        open={isWaitingForServiceCreated}
+        onEditConfig={handleEditConfig}
+        onRetry={handleRetry}
+        open={isWaitingForServiceCreated || isBlueprintCreationFailed}
         serviceName={serviceName}
       />
     </>

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
@@ -379,7 +379,7 @@ export function BlueprintStepSummary() {
         logs={blueprintCreationLogs}
         onEditConfig={handleEditConfig}
         onRetry={handleRetry}
-        open={isWaitingForServiceCreated || isBlueprintCreationFailed}
+        open={blueprintCreationLogs.length > 0 && (isWaitingForServiceCreated || isBlueprintCreationFailed)}
         serviceName={serviceName}
       />
     </>


### PR DESCRIPTION
## feat(blueprints): add logs to creation flow

This PR introduces a non-dismissible modal, that opens at the end of the blueprint-based service creation flow. This modal surfaces the logs of everything happening during the creation of the service. 

## Screenshots / Recordings

https://www.loom.com/share/7ad14a4d0fe248b1bf1b34631a171d48

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
