### PR TITLE
fix(terraform): restore Dockerfile fragment settings

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration.tsx
@@ -69,7 +69,7 @@ const TerraformConfigurationSettingsWrapper = () => {
           description="Customize the resources assigned to the service."
         />
         <div className="max-w-content-with-navigation-left">
-          <TerraformConfigurationSettings methods={methods} />
+          <TerraformConfigurationSettings methods={methods} isSettings />
           <div className="mt-10 flex justify-end">
             <Button
               type="submit"

--- a/libs/domains/service-terraform/feature/src/lib/terraform-configuration-settings/terraform-configuration-settings.spec.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-configuration-settings/terraform-configuration-settings.spec.tsx
@@ -1,0 +1,65 @@
+import { TerraformEngineEnum } from 'qovery-typescript-axios'
+import { useForm } from 'react-hook-form'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { type TerraformGeneralData } from '../terraform-general-data/terraform-general-data'
+import { TerraformConfigurationSettings } from './terraform-configuration-settings'
+
+jest.mock('@tanstack/react-router', () => ({
+  useParams: () => ({
+    organizationId: 'org',
+    projectId: 'project',
+    environmentId: 'environment',
+    serviceId: 'service',
+  }),
+}))
+
+jest.mock('../hooks/use-terraform-available-versions/use-terraform-available-versions', () => ({
+  useTerraformAvailableVersions: () => ({ data: [], isLoading: false }),
+}))
+
+function TestComponent({ isSettings = false }: { isSettings?: boolean }) {
+  const methods = useForm<TerraformGeneralData>({
+    mode: 'onChange',
+    defaultValues: {
+      engine: TerraformEngineEnum.TERRAFORM,
+      provider_version: { read_from_terraform_block: false, explicit_version: '1.9.0' },
+      backend: { kubernetes: {} },
+      use_cluster_credentials: true,
+      timeout_sec: '300',
+      dockerfile_fragment_source: 'none',
+    },
+  })
+
+  return <TerraformConfigurationSettings methods={methods} isSettings={isSettings} />
+}
+
+describe('TerraformConfigurationSettings', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('configures a file-based Dockerfile fragment', async () => {
+    const { userEvent } = renderWithProviders(<TestComponent isSettings />)
+
+    expect(screen.getByRole('heading', { name: 'Dockerfile fragment' })).toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: 'File path' })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Custom file path'))
+
+    expect(screen.getByRole('textbox', { name: 'File path' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+      'href',
+      'https://www.qovery.com/docs/configuration/terraform#file-based-fragment'
+    )
+  })
+
+  it('does not display Dockerfile fragment settings during service creation', () => {
+    renderWithProviders(<TestComponent />)
+
+    expect(screen.queryByRole('heading', { name: 'Dockerfile fragment' })).not.toBeInTheDocument()
+  })
+})

--- a/libs/domains/service-terraform/feature/src/lib/terraform-configuration-settings/terraform-configuration-settings.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-configuration-settings/terraform-configuration-settings.tsx
@@ -3,6 +3,7 @@ import { Controller, type UseFormReturn } from 'react-hook-form'
 import {
   Callout,
   CopyButton,
+  ExternalLink,
   Heading,
   Icon,
   InputSelect,
@@ -12,14 +13,25 @@ import {
   Section,
 } from '@qovery/shared/ui'
 import { useTerraformAvailableVersions } from '../hooks/use-terraform-available-versions/use-terraform-available-versions'
-import { type TerraformGeneralData } from '../terraform-general-data/terraform-general-data'
+import {
+  type DockerfileFragmentSource,
+  type TerraformGeneralData,
+} from '../terraform-general-data/terraform-general-data'
+import { DockerfileFragmentInlineSetting } from '../terraform-variables-settings/dockerfile-fragment-inline-setting/dockerfile-fragment-inline-setting'
 import { TERRAFORM_ENGINES } from '../utils/terraform-engines'
 
-export const TerraformConfigurationSettings = ({ methods }: { methods: UseFormReturn<TerraformGeneralData> }) => {
+export const TerraformConfigurationSettings = ({
+  methods,
+  isSettings = false,
+}: {
+  methods: UseFormReturn<TerraformGeneralData>
+  isSettings?: boolean
+}) => {
   const { organizationId = '', projectId = '', environmentId = '', serviceId = '' } = useParams({ strict: false })
   const { data: versions = [], isLoading: isTerraformVersionLoading } = useTerraformAvailableVersions()
   const cliCommand = `qovery terraform setup-backend --terraform ${serviceId || '<SERVICE_ID>'}`
   const backend = methods.watch('backend')
+  const dockerfileFragmentSource = methods.watch('dockerfile_fragment_source') ?? 'none'
 
   return (
     <div className="space-y-10">
@@ -214,6 +226,105 @@ export const TerraformConfigurationSettings = ({ methods }: { methods: UseFormRe
           )}
         />
       </Section>
+
+      {isSettings ? (
+        <Section className="gap-4">
+          <div className="space-y-1">
+            <Heading level={2}>Dockerfile fragment</Heading>
+            <p className="text-sm text-neutral-subtle">
+              Install additional tools in the Terraform execution environment with custom Dockerfile commands.{' '}
+              <ExternalLink href="https://www.qovery.com/docs/configuration/terraform#file-based-fragment">
+                Learn more
+              </ExternalLink>
+            </p>
+          </div>
+
+          <Callout.Root color="neutral" className="p-4">
+            <Callout.Text className="w-full">
+              <Controller
+                name="dockerfile_fragment_source"
+                control={methods.control}
+                defaultValue={methods.getValues('dockerfile_fragment_source') ?? 'none'}
+                render={({ field }) => (
+                  <RadioGroup.Root
+                    className="flex flex-col gap-5"
+                    value={field.value}
+                    onValueChange={(value: DockerfileFragmentSource) => field.onChange(value)}
+                  >
+                    <label className="grid grid-cols-[16px_1fr] gap-3">
+                      <RadioGroup.Item value="none" />
+                      <div className="flex flex-col gap-1">
+                        <span className="font-medium">No fragment</span>
+                        <span className="text-sm text-neutral-subtle">
+                          Use the default Terraform image without modifications.
+                        </span>
+                      </div>
+                    </label>
+
+                    <div>
+                      <label className="grid grid-cols-[16px_1fr] gap-3">
+                        <RadioGroup.Item value="file" />
+                        <div className="flex flex-col gap-1">
+                          <span className="font-medium">Custom file path</span>
+                          <span className="text-sm text-neutral-subtle">
+                            Reference a Dockerfile fragment stored in your repository.
+                          </span>
+                        </div>
+                      </label>
+                      {dockerfileFragmentSource === 'file' ? (
+                        <div className="ml-7 mt-3">
+                          <Controller
+                            name="dockerfile_fragment_path"
+                            control={methods.control}
+                            rules={{
+                              required: 'File path is required',
+                              pattern: {
+                                value: /^\/[^/]+(\/[^/]+)*$/,
+                                message: 'Enter an absolute path starting with /',
+                              },
+                            }}
+                            render={({ field: pathField, fieldState: { error } }) => (
+                              <InputText
+                                name={pathField.name}
+                                type="text"
+                                onChange={pathField.onChange}
+                                value={pathField.value ?? ''}
+                                label="File path"
+                                error={error?.message}
+                                hint="Absolute path within the service root path, for example /terraform/custom-build.dockerfile"
+                              />
+                            )}
+                          />
+                        </div>
+                      ) : null}
+                    </div>
+
+                    <div>
+                      <label className="grid grid-cols-[16px_1fr] gap-3">
+                        <RadioGroup.Item value="inline" />
+                        <div className="flex flex-col gap-1">
+                          <span className="font-medium">Inline content</span>
+                          <span className="text-sm text-neutral-subtle">Enter Dockerfile commands directly.</span>
+                        </div>
+                      </label>
+                      {dockerfileFragmentSource === 'inline' ? (
+                        <div className="ml-7 mt-3">
+                          <DockerfileFragmentInlineSetting
+                            content={methods.watch('dockerfile_fragment_content') ?? ''}
+                            onSubmit={(value) =>
+                              methods.setValue('dockerfile_fragment_content', value ?? '', { shouldDirty: true })
+                            }
+                          />
+                        </div>
+                      ) : null}
+                    </div>
+                  </RadioGroup.Root>
+                )}
+              />
+            </Callout.Text>
+          </Callout.Root>
+        </Section>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

The Dockerfile fragment settings were lost during the new Console UI migration, even though the API mapping and inline editor remained available.

This PR:

- restores the Dockerfile fragment section in Terraform service settings;
- supports no fragment, a repository file path, and inline Dockerfile commands;
- validates that file-based fragments use an absolute path;
- links to the Terraform Dockerfile fragment documentation;
- keeps the section hidden from the Terraform creation flow, matching the original behavior.

The restored behavior is based on the [original Dockerfile fragment implementation](https://github.com/Qovery/console/commit/98276c205cd7b672b1af481f365840b23c4e162c).

## Screenshots / Recordings

<img width="754" height="311" alt="Screenshot 2026-07-15 at 11 39 08" src="https://github.com/user-attachments/assets/3c71e196-bcdc-4653-8675-daa1eb0a4ca9" />

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

Focused validation completed:

- [x] 2 targeted Jest tests passed
- [x] Changed files checked with Prettier
- [x] Changed files checked with ESLint
- [x] `git diff --check`

The Nx project target could not compute its project graph in the isolated worktree, so Jest, ESLint, and Prettier were run directly on the affected files.

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
