### PR TITLE
fix(clusters): stop labeling unhealthy nodes as Deploying

### DIFF
--- a/libs/domains/cluster-metrics/feature/src/lib/cluster-table-node/cluster-table-node.spec.tsx
+++ b/libs/domains/cluster-metrics/feature/src/lib/cluster-table-node/cluster-table-node.spec.tsx
@@ -196,4 +196,147 @@ describe('ClusterTableNode', () => {
 
     expect(screen.getByText('20 GB')).toBeInTheDocument()
   })
+
+  it('should show Deploying status when node has not reported any condition yet', () => {
+    const mockMetrics = {
+      nodes: [
+        {
+          name: 'node-1',
+          labels: {
+            'karpenter.sh/nodepool': 'default',
+          },
+          metrics_usage: {
+            cpu_milli_usage: 2000,
+            memory_mib_working_set_usage: 4096,
+            disk_mib_usage: 10240,
+          },
+          resources_allocated: {
+            request_cpu_milli: 2000,
+            request_memory_mib: 4096,
+          },
+          resources_allocatable: {
+            cpu_milli: 4000,
+            memory_mib: 8192,
+          },
+          resources_capacity: {
+            ephemeral_storage_mib: 20480,
+          },
+          instance_type: 't3_medium',
+          created_at: '2024-01-01T00:00:00Z',
+          conditions: [],
+        },
+      ],
+    }
+
+    const mockUseClusterMetrics = useClusterMetrics as jest.Mock
+    mockUseClusterMetrics.mockReturnValue({
+      data: mockMetrics,
+    })
+
+    renderWithProviders(
+      <ClusterTableNode organizationId={mockOrganizationId} clusterId={mockClusterId} nodePool={mockNodePool} />
+    )
+
+    const nodeRow = screen.getByText('node-1').closest('div[class*="bg-surface-brand-subtle"]')
+    expect(nodeRow).toBeInTheDocument()
+  })
+
+  it('should show NotReady status (not Deploying) when node reported Ready=False and is not being removed', () => {
+    const mockMetrics = {
+      nodes: [
+        {
+          name: 'node-1',
+          labels: {
+            'karpenter.sh/nodepool': 'default',
+          },
+          metrics_usage: {
+            cpu_milli_usage: 2000,
+            memory_mib_working_set_usage: 4096,
+            disk_mib_usage: 10240,
+          },
+          resources_allocated: {
+            request_cpu_milli: 2000,
+            request_memory_mib: 4096,
+          },
+          resources_allocatable: {
+            cpu_milli: 4000,
+            memory_mib: 8192,
+          },
+          resources_capacity: {
+            ephemeral_storage_mib: 20480,
+          },
+          instance_type: 't3_medium',
+          created_at: '2024-01-01T00:00:00Z',
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'False',
+            },
+          ],
+        },
+      ],
+    }
+
+    const mockUseClusterMetrics = useClusterMetrics as jest.Mock
+    mockUseClusterMetrics.mockReturnValue({
+      data: mockMetrics,
+    })
+
+    renderWithProviders(
+      <ClusterTableNode organizationId={mockOrganizationId} clusterId={mockClusterId} nodePool={mockNodePool} />
+    )
+
+    expect(screen.getByText('node-1').closest('div[class*="bg-surface-warning-subtle"]')).toBeInTheDocument()
+    expect(screen.getByText('node-1').closest('div[class*="bg-surface-brand-subtle"]')).not.toBeInTheDocument()
+  })
+
+  it('should show Removing status when node is unschedulable, even without a Ready condition', () => {
+    const mockMetrics = {
+      nodes: [
+        {
+          name: 'node-1',
+          labels: {
+            'karpenter.sh/nodepool': 'default',
+          },
+          metrics_usage: {
+            cpu_milli_usage: 2000,
+            memory_mib_working_set_usage: 4096,
+            disk_mib_usage: 10240,
+          },
+          resources_allocated: {
+            request_cpu_milli: 2000,
+            request_memory_mib: 4096,
+          },
+          resources_allocatable: {
+            cpu_milli: 4000,
+            memory_mib: 8192,
+          },
+          resources_capacity: {
+            ephemeral_storage_mib: 20480,
+          },
+          instance_type: 't3_medium',
+          created_at: '2024-01-01T00:00:00Z',
+          unschedulable: true,
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'False',
+            },
+          ],
+        },
+      ],
+    }
+
+    const mockUseClusterMetrics = useClusterMetrics as jest.Mock
+    mockUseClusterMetrics.mockReturnValue({
+      data: mockMetrics,
+    })
+
+    renderWithProviders(
+      <ClusterTableNode organizationId={mockOrganizationId} clusterId={mockClusterId} nodePool={mockNodePool} />
+    )
+
+    expect(screen.getByText('node-1').closest('div[class*="bg-surface-brand-subtle"]')).not.toBeInTheDocument()
+    expect(screen.getByText('node-1').closest('div[class*="bg-surface-warning-subtle"]')).not.toBeInTheDocument()
+  })
 })

--- a/libs/domains/cluster-metrics/feature/src/lib/cluster-table-node/cluster-table-node.tsx
+++ b/libs/domains/cluster-metrics/feature/src/lib/cluster-table-node/cluster-table-node.tsx
@@ -143,6 +143,7 @@ export function ClusterTableNode({
       {nodes?.map((node) => {
         const nodeWarning = nodeWarnings[node.name]
 
+        const hasReadyCondition = node.conditions?.some((condition) => condition.type === 'Ready')
         const isReady = node.conditions?.some((condition) => condition.type === 'Ready' && condition.status === 'True')
         const isDiskPressure = node.conditions?.some(
           (condition) => condition.type === 'DiskPressure' && condition.status === 'True'
@@ -155,14 +156,12 @@ export function ClusterTableNode({
         )
 
         const isRemoving = node.unschedulable
-        const isDeploying = !isReady && !isRemoving
+        // The kubelet hasn't reported any status yet: the node is still joining the cluster.
+        const isDeploying = !hasReadyCondition && !isRemoving
+        // The kubelet has reported a status, but the node isn't healthy (distinct from still bootstrapping).
+        const isNotReady = hasReadyCondition && !isReady && !isRemoving
 
-        const isWarning =
-          isDiskPressure ||
-          isMemoryPressure ||
-          (!isReady && !isDeploying && !isRemoving) ||
-          isPIDPressure ||
-          nodeWarning
+        const isWarning = isDiskPressure || isMemoryPressure || isPIDPressure || isNotReady || nodeWarning
 
         const status = () => {
           if (isRemoving) {
@@ -174,7 +173,7 @@ export function ClusterTableNode({
           if (!isWarning) {
             return 'Ready'
           }
-          if (!isReady) {
+          if (isNotReady) {
             return 'NotReady'
           }
           if (isDiskPressure) {


### PR DESCRIPTION
## Summary
- The node status badge in the cluster nodes table treated any not-Ready node as "Deploying" as soon as it wasn't cordoned, hiding real problems (kubelet down, network issue, resource pressure) behind the calm blue "bootstrapping" indicator.
- "Deploying" is now reserved for nodes that haven't reported any condition yet (true cluster-join phase).
- "NotReady" is now reachable when the node has reported a `Ready` condition with `status=False` and isn't being removed — previously this branch was dead code.
- Draining/scale-down nodes keep showing "Removing" (`node.unschedulable`), unchanged.

## Test plan
- [x] `yarn jest cluster-table-node.spec.tsx` — 6/6 passing (3 existing + 3 new: bootstrapping node, NotReady node, cordoned node without Ready condition)
- [x] `yarn nx lint domains-cluster-metrics-feature` — no new warnings