### PR TITLE
fix: auto deploy toggle for helm overrides

### DIFF
--- a/libs/domains/service-settings/feature/src/lib/helm-values-override-file-settings/helm-values-override-file-settings.spec.tsx
+++ b/libs/domains/service-settings/feature/src/lib/helm-values-override-file-settings/helm-values-override-file-settings.spec.tsx
@@ -75,6 +75,20 @@ jest.mock('@qovery/domains/service-helm/feature', () => ({
         >
           Select public git
         </button>
+        <button
+          type="button"
+          onClick={() => {
+            methods.setValue('type', 'GIT_REPOSITORY')
+            methods.setValue('provider', 'GITHUB')
+            methods.setValue('is_public_repository', false)
+            methods.setValue('git_repository', { url: 'https://github.com/Qovery/console' })
+            methods.setValue('branch', 'main')
+            methods.setValue('paths', 'values.yaml')
+            methods.setValue('auto_deploy', false)
+          }}
+        >
+          Select private git with auto deploy off
+        </button>
         {children}
       </div>
     )
@@ -263,6 +277,46 @@ describe('HelmValuesOverrideFileSettings', () => {
                   git_token_id: undefined,
                 },
                 paths: ['values.yaml', 'extra.yaml'],
+              },
+            },
+          },
+        },
+      }),
+    })
+  })
+
+  it('persists auto deploy disabled for private git repositories even if it was previously enabled', async () => {
+    const service = makeHelmService()
+    service.auto_deploy = true
+
+    useServiceSpy.mockReturnValue({
+      data: service,
+    })
+
+    const { userEvent } = renderWithProviders(<HelmValuesOverrideFileSettings />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Select private git with auto deploy off' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Submit mocked form' }))
+
+    expect(mockEditService).toHaveBeenCalledWith({
+      serviceId: 'service-1',
+      payload: buildEditServicePayload({
+        service: {
+          ...service,
+          auto_deploy: false,
+        },
+        request: {
+          values_override: {
+            ...service.values_override,
+            file: {
+              git: {
+                git_repository: {
+                  provider: 'GITHUB',
+                  url: 'https://github.com/Qovery/console',
+                  branch: 'main',
+                  git_token_id: undefined,
+                },
+                paths: ['values.yaml'],
               },
             },
           },

--- a/libs/domains/service-settings/feature/src/lib/helm-values-override-file-settings/helm-values-override-file-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/helm-values-override-file-settings/helm-values-override-file-settings.tsx
@@ -142,7 +142,7 @@ export function HelmValuesOverrideFileSettings() {
 
     const nextService = {
       ...service,
-      auto_deploy: data.is_public_repository ? false : (service.auto_deploy ?? false) || (data.auto_deploy ?? false),
+      auto_deploy: data.is_public_repository ? false : (data.auto_deploy ?? false),
     }
 
     editService({

--- a/libs/domains/service-settings/feature/src/lib/helm-values-override-file-settings/helm-values-override-file-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/helm-values-override-file-settings/helm-values-override-file-settings.tsx
@@ -142,7 +142,7 @@ export function HelmValuesOverrideFileSettings() {
 
     const nextService = {
       ...service,
-      auto_deploy: data.is_public_repository ? false : (data.auto_deploy ?? false),
+      auto_deploy: data.is_public_repository ? false : data.auto_deploy ?? false,
     }
 
     editService({


### PR DESCRIPTION
### Summary
Fix auto_deploy toggle not persisting as disabled on the Helm "Values override as file" (Git source) settings page.

**Bug:** the submit handler merged the new auto_deploy value with the previous one using OR ((service.auto_deploy ?? false) || (data.auto_deploy ?? false)) instead of a direct assignment. Once auto_deploy was true — whether enabled from this page or from the chart's General Settings page, since both share one service-level boolean — unchecking the toggle here and saving could never persist false.
**Fix:** replaced the OR-merge with a direct assignment from the form value, matching the pattern already used by every other service-type submit handler (Git application, container, job, Terraform, and Helm's own chart-source handler). The public-repo branch, which force-disables auto-deploy, is unchanged.
**Test:** added a regression test (persists auto deploy disabled for private git repositories even if it was previously enabled) that sets service.auto_deploy = true, submits with the toggle off, and asserts the payload now carries auto_deploy: false.
**File changed:** [helm-values-override-file-settings.tsx](vscode-webview://1avotk9ijlbc48gg6q019prce8j7hh7glmv9eb1lg322obmes8gg/console/console/libs/domains/service-settings/feature/src/lib/helm-values-override-file-settings/helm-values-override-file-settings.tsx) (+1/-1 logic line)
**Test changed:** [helm-values-override-file-settings.spec.tsx](vscode-webview://1avotk9ijlbc48gg6q019prce8j7hh7glmv9eb1lg322obmes8gg/console/console/libs/domains/service-settings/feature/src/lib/helm-values-override-file-settings/helm-values-override-file-settings.spec.tsx) (+1 mock button, +1 test)

### Context
Reported via Pylon ticket 4539: auto-deploy toggle appeared to not work when overriding Helm values via a file from GitHub. Root cause traced to helm-values-override-file-settings.tsx:145, introduced in commit 7fcd7acfa ~2.5 years ago and unchanged through a recent UI refactor.

### Test plan
 nx test domains-service-settings-feature --testPathPatterns=helm-values-override-file-settings — 6/6 passing
 Manual verification in the UI: enable auto-deploy from chart General Settings, then disable it from the values-override-file page and confirm it stays disabled after reload