### PR TITLE
feat(variables): separate secret creation flow

### DIFF
--- a/libs/domains/service-job/feature/src/lib/job-creation-flow/step-variables/step-variables.tsx
+++ b/libs/domains/service-job/feature/src/lib/job-creation-flow/step-variables/step-variables.tsx
@@ -47,10 +47,10 @@ export function StepVariables() {
 
   const [variables, setVariables] = useState(methods.getValues().variables)
 
-  const onAddPort = () => {
+  const onAddPort = (isSecret = false) => {
     const newVariableRow: VariableData = {
       variable: '',
-      isSecret: false,
+      isSecret,
       value: '',
       scope: APIVariableScopeEnum.JOB,
     }

--- a/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.spec.tsx
@@ -40,7 +40,6 @@ jest.mock('@qovery/domains/variables/feature', () => ({
   VariableFormModal: ({
     onSubmit,
     scope,
-    isFile,
     isSecret,
   }: {
     onSubmit?: (data: {
@@ -52,19 +51,17 @@ jest.mock('@qovery/domains/variables/feature', () => ({
       mountPath?: string
     }) => void
     scope: 'APPLICATION' | 'CONTAINER'
-    isFile?: boolean
     isSecret?: boolean
   }) => (
     <button
       type="button"
       onClick={() =>
         onSubmit?.({
-          key: isFile ? 'CONFIG_FILE' : 'NODE_ENV',
-          value: isFile ? '{"key":"value"}' : 'production',
+          key: 'NODE_ENV',
+          value: 'production',
           scope,
           isSecret: !!isSecret,
-          isFile: !!isFile,
-          mountPath: isFile ? '/vault/secrets/config-file' : undefined,
+          isFile: false,
         })
       }
     >

--- a/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.spec.tsx
@@ -41,6 +41,7 @@ jest.mock('@qovery/domains/variables/feature', () => ({
     onSubmit,
     scope,
     isFile,
+    isSecret,
   }: {
     onSubmit?: (data: {
       key: string
@@ -52,6 +53,7 @@ jest.mock('@qovery/domains/variables/feature', () => ({
     }) => void
     scope: 'APPLICATION' | 'CONTAINER'
     isFile?: boolean
+    isSecret?: boolean
   }) => (
     <button
       type="button"
@@ -60,7 +62,7 @@ jest.mock('@qovery/domains/variables/feature', () => ({
           key: isFile ? 'CONFIG_FILE' : 'NODE_ENV',
           value: isFile ? '{"key":"value"}' : 'production',
           scope,
-          isSecret: false,
+          isSecret: !!isSecret,
           isFile: !!isFile,
           mountPath: isFile ? '/vault/secrets/config-file' : undefined,
         })
@@ -113,6 +115,28 @@ describe('ApplicationContainerStepVariables', () => {
     })
   })
 
+  it('adds a secret with application scope by default', async () => {
+    const { userEvent } = renderWithProviders(
+      <ApplicationContainerCreationFlow
+        creationFlowUrl="/organization/org-1/project/proj-1/environment/env-1/service/create/application"
+        defaultServiceType="APPLICATION"
+      >
+        <>
+          <ApplicationContainerStepVariables onBack={onBack} onSubmit={onSubmit} />
+          <VariablesState />
+        </>
+      </ApplicationContainerCreationFlow>
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /^add secret$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /confirm variable modal/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-state')).toHaveTextContent('"scope":"APPLICATION"')
+      expect(screen.getByTestId('variables-state')).toHaveTextContent('"isSecret":true')
+    })
+  })
+
   it('calls onBack when going back', async () => {
     const { userEvent } = renderWithProviders(
       <ApplicationContainerCreationFlow
@@ -154,7 +178,6 @@ describe('ApplicationContainerStepVariables', () => {
     )
 
     expect(screen.getByText('No secret manager linked on your cluster')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^add secret$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^add secret as file$/i })).not.toBeInTheDocument()
   })
 })

--- a/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.tsx
@@ -176,14 +176,12 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
   }, [setCurrentStep])
 
   const openVariableModal = ({
-    isFile,
     isSecret = false,
     index,
   }: {
-    isFile: boolean
     isSecret?: boolean
     index?: number
-  }) => {
+  } = {}) => {
     const currentVariable = typeof index === 'number' ? variables[index] : undefined
     const mode = typeof index === 'number' ? 'UPDATE' : 'CREATE'
 
@@ -193,7 +191,6 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
           closeModal={closeModal}
           mode={mode}
           type={currentVariable?.file ? APIVariableTypeEnum.FILE : APIVariableTypeEnum.VALUE}
-          isFile={isFile}
           variable={
             typeof index === 'number' && currentVariable
               ? mapVariableToModalVariable(currentVariable, index, serviceScope)
@@ -275,7 +272,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                       variant="outline"
                       size="sm"
                       className="text-ssm"
-                      onClick={() => openVariableModal({ isFile: false, isSecret: true })}
+                      onClick={() => openVariableModal({ isSecret: true })}
                     >
                       <Icon iconName="lock-keyhole" iconStyle="regular" className="text-ssm" />
                       Add secret
@@ -286,7 +283,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                       variant="solid"
                       size="sm"
                       className="text-ssm"
-                      onClick={() => openVariableModal({ isFile: false })}
+                      onClick={() => openVariableModal()}
                     >
                       <Icon iconName="key" className="text-ssm" />
                       Add variable
@@ -311,7 +308,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                         variant="solid"
                         size="md"
                         className="text-ssm"
-                        onClick={() => openVariableModal({ isFile: false })}
+                        onClick={() => openVariableModal()}
                       >
                         <Icon iconName="key" className="text-ssm" />
                         Add variable
@@ -322,7 +319,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                         variant="outline"
                         size="md"
                         className="text-ssm"
-                        onClick={() => openVariableModal({ isFile: false, isSecret: true })}
+                        onClick={() => openVariableModal({ isSecret: true })}
                       >
                         <Icon iconName="lock-keyhole" iconStyle="regular" className="text-ssm" />
                         Add secret
@@ -393,7 +390,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                             size="xs"
                             iconOnly
                             disabled={variable.isReadOnly}
-                            onClick={() => openVariableModal({ isFile: !!variable.file, index })}
+                            onClick={() => openVariableModal({ index })}
                           >
                             <Icon iconName="pen" />
                           </Button>

--- a/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.tsx
@@ -87,62 +87,6 @@ function emptyState({
   )
 }
 
-function customVariableActions({
-  buttonSize,
-  variableFirst = false,
-  onAddVariable,
-  onAddSecret,
-}: {
-  buttonSize: 'sm' | 'md'
-  variableFirst?: boolean
-  onAddVariable: () => void
-  onAddSecret: () => void
-}) {
-  const variableButton = (
-    <Button
-      type="button"
-      color="neutral"
-      variant="solid"
-      size={buttonSize}
-      className="gap-1.5 text-ssm"
-      onClick={onAddVariable}
-    >
-      <Icon iconName="key" className="text-ssm" />
-      Add variable
-    </Button>
-  )
-
-  const secretButton = (
-    <Button
-      type="button"
-      color="neutral"
-      variant="outline"
-      size={buttonSize}
-      className="gap-1.5 text-ssm"
-      onClick={onAddSecret}
-    >
-      <Icon iconName="lock-keyhole" iconStyle="regular" className="text-ssm" />
-      Add secret
-    </Button>
-  )
-
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-2">
-      {variableFirst ? (
-        <>
-          {variableButton}
-          {secretButton}
-        </>
-      ) : (
-        <>
-          {secretButton}
-          {variableButton}
-        </>
-      )}
-    </div>
-  )
-}
-
 function mapModalDataToVariable(data: CreateUpdateVariableModalSubmitData, current?: VariableData): VariableData {
   return {
     variable: data.key,
@@ -323,12 +267,32 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
             <div className="relative overflow-hidden rounded-t-lg border-x border-t border-neutral bg-surface-neutral-subtle">
               <div className="flex min-h-[52px] items-center justify-between px-4 pb-5 pt-3">
                 <p className="text-sm font-medium text-neutral">Custom variables</p>
-                {variables.length > 0 &&
-                  customVariableActions({
-                    buttonSize: 'sm',
-                    onAddVariable: () => openVariableModal({ isFile: false }),
-                    onAddSecret: () => openVariableModal({ isFile: false, isSecret: true }),
-                  })}
+                {variables.length > 0 && (
+                  <div className="flex flex-wrap items-center justify-center gap-2">
+                    <Button
+                      type="button"
+                      color="neutral"
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5 text-ssm"
+                      onClick={() => openVariableModal({ isFile: false, isSecret: true })}
+                    >
+                      <Icon iconName="lock-keyhole" iconStyle="regular" className="text-ssm" />
+                      Add secret
+                    </Button>
+                    <Button
+                      type="button"
+                      color="neutral"
+                      variant="solid"
+                      size="sm"
+                      className="gap-1.5 text-ssm"
+                      onClick={() => openVariableModal({ isFile: false })}
+                    >
+                      <Icon iconName="key" className="text-ssm" />
+                      Add variable
+                    </Button>
+                  </div>
+                )}
               </div>
             </div>
 
@@ -340,12 +304,30 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                     icon="lock-keyhole"
                     className="h-auto rounded-none border-0 bg-transparent px-8 py-8"
                   >
-                    {customVariableActions({
-                      buttonSize: 'md',
-                      variableFirst: true,
-                      onAddVariable: () => openVariableModal({ isFile: false }),
-                      onAddSecret: () => openVariableModal({ isFile: false, isSecret: true }),
-                    })}
+                    <div className="flex flex-wrap items-center justify-center gap-2">
+                      <Button
+                        type="button"
+                        color="neutral"
+                        variant="solid"
+                        size="md"
+                        className="gap-1.5 text-ssm"
+                        onClick={() => openVariableModal({ isFile: false })}
+                      >
+                        <Icon iconName="key" className="text-ssm" />
+                        Add variable
+                      </Button>
+                      <Button
+                        type="button"
+                        color="neutral"
+                        variant="outline"
+                        size="md"
+                        className="gap-1.5 text-ssm"
+                        onClick={() => openVariableModal({ isFile: false, isSecret: true })}
+                      >
+                        <Icon iconName="lock-keyhole" iconStyle="regular" className="text-ssm" />
+                        Add secret
+                      </Button>
+                    </div>
                   </EmptyState>
                 ) : (
                   <>

--- a/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.tsx
@@ -274,7 +274,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                       color="neutral"
                       variant="outline"
                       size="sm"
-                      className="gap-1.5 text-ssm"
+                      className="text-ssm"
                       onClick={() => openVariableModal({ isFile: false, isSecret: true })}
                     >
                       <Icon iconName="lock-keyhole" iconStyle="regular" className="text-ssm" />
@@ -285,7 +285,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                       color="neutral"
                       variant="solid"
                       size="sm"
-                      className="gap-1.5 text-ssm"
+                      className="text-ssm"
                       onClick={() => openVariableModal({ isFile: false })}
                     >
                       <Icon iconName="key" className="text-ssm" />
@@ -310,7 +310,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                         color="neutral"
                         variant="solid"
                         size="md"
-                        className="gap-1.5 text-ssm"
+                        className="text-ssm"
                         onClick={() => openVariableModal({ isFile: false })}
                       >
                         <Icon iconName="key" className="text-ssm" />
@@ -321,7 +321,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
                         color="neutral"
                         variant="outline"
                         size="md"
-                        className="gap-1.5 text-ssm"
+                        className="text-ssm"
                         onClick={() => openVariableModal({ isFile: false, isSecret: true })}
                       >
                         <Icon iconName="lock-keyhole" iconStyle="regular" className="text-ssm" />

--- a/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.tsx
@@ -87,6 +87,62 @@ function emptyState({
   )
 }
 
+function customVariableActions({
+  buttonSize,
+  variableFirst = false,
+  onAddVariable,
+  onAddSecret,
+}: {
+  buttonSize: 'sm' | 'md'
+  variableFirst?: boolean
+  onAddVariable: () => void
+  onAddSecret: () => void
+}) {
+  const variableButton = (
+    <Button
+      type="button"
+      color="neutral"
+      variant="solid"
+      size={buttonSize}
+      className="gap-1.5 text-ssm"
+      onClick={onAddVariable}
+    >
+      <Icon iconName="key" className="text-ssm" />
+      Add variable
+    </Button>
+  )
+
+  const secretButton = (
+    <Button
+      type="button"
+      color="neutral"
+      variant="outline"
+      size={buttonSize}
+      className="gap-1.5 text-ssm"
+      onClick={onAddSecret}
+    >
+      <Icon iconName="lock-keyhole" iconStyle="regular" className="text-ssm" />
+      Add secret
+    </Button>
+  )
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      {variableFirst ? (
+        <>
+          {variableButton}
+          {secretButton}
+        </>
+      ) : (
+        <>
+          {secretButton}
+          {variableButton}
+        </>
+      )}
+    </div>
+  )
+}
+
 function mapModalDataToVariable(data: CreateUpdateVariableModalSubmitData, current?: VariableData): VariableData {
   return {
     variable: data.key,
@@ -175,7 +231,15 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
     setCurrentStep(5)
   }, [setCurrentStep])
 
-  const openVariableModal = ({ isFile, index }: { isFile: boolean; index?: number }) => {
+  const openVariableModal = ({
+    isFile,
+    isSecret = false,
+    index,
+  }: {
+    isFile: boolean
+    isSecret?: boolean
+    index?: number
+  }) => {
     const currentVariable = typeof index === 'number' ? variables[index] : undefined
     const mode = typeof index === 'number' ? 'UPDATE' : 'CREATE'
 
@@ -200,6 +264,7 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
             }
           }}
           scope={serviceScope}
+          isSecret={typeof index === 'number' ? currentVariable?.isSecret : isSecret}
           projectId={projectId}
           environmentId={environmentId}
         />
@@ -259,11 +324,10 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
               <div className="flex min-h-[52px] items-center justify-between px-4 pb-5 pt-3">
                 <p className="text-sm font-medium text-neutral">Custom variables</p>
                 {variables.length > 0 &&
-                  cardHeaderActions({
-                    onAddDefault: () => openVariableModal({ isFile: false }),
-                    onAddAsFile: () => openVariableModal({ isFile: true }),
-                    defaultLabel: 'Add variable',
-                    asFileLabel: 'Add variable as file',
+                  customVariableActions({
+                    buttonSize: 'sm',
+                    onAddVariable: () => openVariableModal({ isFile: false }),
+                    onAddSecret: () => openVariableModal({ isFile: false, isSecret: true }),
                   })}
               </div>
             </div>
@@ -271,13 +335,18 @@ export function ApplicationContainerStepVariables({ onBack, onSubmit }: Applicat
             <div className="relative -mt-2 rounded-lg">
               <div className="overflow-hidden rounded-lg border border-neutral bg-surface-neutral">
                 {variables.length === 0 ? (
-                  emptyState({
-                    title: 'No custom variables added yet',
-                    onAddDefault: () => openVariableModal({ isFile: false }),
-                    onAddAsFile: () => openVariableModal({ isFile: true }),
-                    defaultLabel: 'Add variable',
-                    asFileLabel: 'Add variable as file',
-                  })
+                  <EmptyState
+                    title="No custom variables added yet"
+                    icon="lock-keyhole"
+                    className="h-auto rounded-none border-0 bg-transparent px-8 py-8"
+                  >
+                    {customVariableActions({
+                      buttonSize: 'md',
+                      variableFirst: true,
+                      onAddVariable: () => openVariableModal({ isFile: false }),
+                      onAddSecret: () => openVariableModal({ isFile: false, isSecret: true }),
+                    })}
+                  </EmptyState>
                 ) : (
                   <>
                     <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_88px] border-b border-neutral text-xs">

--- a/libs/domains/services/feature/src/lib/service-variables-tabs/service-variables-custom-tab.tsx
+++ b/libs/domains/services/feature/src/lib/service-variables-tabs/service-variables-custom-tab.tsx
@@ -42,7 +42,13 @@ export function ServiceVariablesCustomTab() {
     return null
   }
 
-  const handleOpenCreateVariableModal = (isFile = false) =>
+  const handleOpenCreateVariableModal = ({
+    isFile = false,
+    isSecret = false,
+  }: {
+    isFile?: boolean
+    isSecret?: boolean
+  } = {}) =>
     openModal({
       content: (
         <CreateUpdateVariableModal
@@ -51,6 +57,7 @@ export function ServiceVariablesCustomTab() {
           mode="CREATE"
           onSubmit={onCreateVariableToast}
           isFile={isFile}
+          isSecret={isSecret}
           hasClusterSecretManagerConfigured={hasClusterSecretManagerConfigured}
           scope={scope}
           projectId={projectId}
@@ -89,26 +96,27 @@ export function ServiceVariablesCustomTab() {
           className="rounded-none border-0 bg-transparent py-12"
         >
           <div className="flex items-center gap-2">
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <Button color="neutral" variant="solid" size="md" className="gap-1.5">
-                  <Icon iconName="circle-plus" iconStyle="regular" />
-                  Add variable
-                  <Icon iconName="angle-down" />
-                </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content>
-                <DropdownMenu.Item onSelect={() => handleOpenCreateVariableModal()} icon={<Icon iconName="key" />}>
-                  Variable
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  onSelect={() => handleOpenCreateVariableModal(true)}
-                  icon={<Icon iconName="file-lines" iconStyle="regular" />}
-                >
-                  Variable as file
-                </DropdownMenu.Item>
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
+            <Button
+              color="neutral"
+              variant="solid"
+              size="md"
+              className="gap-1.5"
+              onClick={() => handleOpenCreateVariableModal()}
+            >
+              <Icon iconName="key" />
+              Add variable
+            </Button>
+
+            <Button
+              color="neutral"
+              variant="outline"
+              size="md"
+              className="gap-1.5"
+              onClick={() => handleOpenCreateVariableModal({ isSecret: true })}
+            >
+              <Icon iconName="lock-keyhole" iconStyle="regular" />
+              Add secret
+            </Button>
 
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
@@ -121,12 +129,6 @@ export function ServiceVariablesCustomTab() {
               <DropdownMenu.Content>
                 <DropdownMenu.Item onSelect={handleOpenImportVariablesModal} icon={<Icon iconName="file-import" />}>
                   Import from .env file
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  onSelect={() => window.open('https://dashboard.doppler.com', '_blank')}
-                  icon={<Icon iconName="arrow-up-right-from-square" />}
-                >
-                  Import from Doppler
                 </DropdownMenu.Item>
               </DropdownMenu.Content>
             </DropdownMenu.Root>

--- a/libs/domains/services/feature/src/lib/service-variables-tabs/service-variables-custom-tab.tsx
+++ b/libs/domains/services/feature/src/lib/service-variables-tabs/service-variables-custom-tab.tsx
@@ -42,13 +42,7 @@ export function ServiceVariablesCustomTab() {
     return null
   }
 
-  const handleOpenCreateVariableModal = ({
-    isFile = false,
-    isSecret = false,
-  }: {
-    isFile?: boolean
-    isSecret?: boolean
-  } = {}) =>
+  const handleOpenCreateVariableModal = (isSecret = false) =>
     openModal({
       content: (
         <CreateUpdateVariableModal
@@ -56,7 +50,6 @@ export function ServiceVariablesCustomTab() {
           type="VALUE"
           mode="CREATE"
           onSubmit={onCreateVariableToast}
-          isFile={isFile}
           isSecret={isSecret}
           hasClusterSecretManagerConfigured={hasClusterSecretManagerConfigured}
           scope={scope}
@@ -101,12 +94,7 @@ export function ServiceVariablesCustomTab() {
               Add variable
             </Button>
 
-            <Button
-              color="neutral"
-              variant="outline"
-              size="md"
-              onClick={() => handleOpenCreateVariableModal({ isSecret: true })}
-            >
+            <Button color="neutral" variant="outline" size="md" onClick={() => handleOpenCreateVariableModal(true)}>
               <Icon iconName="lock-keyhole" iconStyle="regular" />
               Add secret
             </Button>

--- a/libs/domains/services/feature/src/lib/service-variables-tabs/service-variables-custom-tab.tsx
+++ b/libs/domains/services/feature/src/lib/service-variables-tabs/service-variables-custom-tab.tsx
@@ -96,13 +96,7 @@ export function ServiceVariablesCustomTab() {
           className="rounded-none border-0 bg-transparent py-12"
         >
           <div className="flex items-center gap-2">
-            <Button
-              color="neutral"
-              variant="solid"
-              size="md"
-              className="gap-1.5"
-              onClick={() => handleOpenCreateVariableModal()}
-            >
+            <Button color="neutral" variant="solid" size="md" onClick={() => handleOpenCreateVariableModal()}>
               <Icon iconName="key" />
               Add variable
             </Button>
@@ -111,7 +105,6 @@ export function ServiceVariablesCustomTab() {
               color="neutral"
               variant="outline"
               size="md"
-              className="gap-1.5"
               onClick={() => handleOpenCreateVariableModal({ isSecret: true })}
             >
               <Icon iconName="lock-keyhole" iconStyle="regular" />

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
@@ -118,6 +118,34 @@ describe('CreateUpdateVariableModal', () => {
     expect(screen.getByText('Variable interpolation')).toBeInTheDocument()
   })
 
+  it('should render secret file edit with hidden value control', async () => {
+    const { userEvent } = renderWithProviders(
+      <CreateUpdateVariableModal
+        {...baseProps}
+        mode="UPDATE"
+        type="FILE"
+        variable={{
+          ...baseVariable,
+          value: '',
+          mount_path: '/vault/secrets/my-secret',
+          variable_type: 'FILE',
+          variable_kind: 'Private',
+          is_secret: true,
+        }}
+      />
+    )
+
+    const valueField = screen.getByLabelText('Value')
+
+    expect(screen.getByText('Edit secret as file')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /show value/i })).toBeInTheDocument()
+    expect(valueField).toHaveClass('[-webkit-text-security:disc]')
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /show value/i }))
+
+    expect(valueField).not.toHaveClass('[-webkit-text-security:disc]')
+  })
+
   it('should not render the open editor button for aliases', () => {
     renderWithProviders(<CreateUpdateVariableModal {...baseProps} mode="CREATE" type="ALIAS" variable={baseVariable} />)
 

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
@@ -97,6 +97,27 @@ describe('CreateUpdateVariableModal', () => {
     expect(descriptionField).not.toBeInstanceOf(HTMLTextAreaElement)
   })
 
+  it('should render secret creation without the secret toggle and with hidden value control', () => {
+    renderWithProviders(<CreateUpdateVariableModal {...baseProps} mode="CREATE" type="VALUE" isSecret />)
+
+    expect(screen.getByText('New secret')).toBeInTheDocument()
+    expect(screen.queryByText('Secret variable')).not.toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /show value/i })).toBeInTheDocument()
+  })
+
+  it('should default to value format and show file inputs when selecting as file', async () => {
+    const { userEvent } = renderWithProviders(<CreateUpdateVariableModal {...baseProps} mode="CREATE" type="VALUE" />)
+
+    expect(screen.getByRole('radio', { name: /value/i })).toHaveAttribute('data-state', 'on')
+    expect(screen.queryByLabelText('Path')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('radio', { name: /as file/i }))
+
+    expect(screen.getByText('New variable as file')).toBeInTheDocument()
+    expect(screen.getByLabelText('Path')).toBeInTheDocument()
+    expect(screen.getByText('Variable interpolation')).toBeInTheDocument()
+  })
+
   it('should not render the open editor button for aliases', () => {
     renderWithProviders(<CreateUpdateVariableModal {...baseProps} mode="CREATE" type="ALIAS" variable={baseVariable} />)
 

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
@@ -113,9 +113,16 @@ describe('CreateUpdateVariableModal', () => {
 
     await userEvent.click(screen.getByRole('radio', { name: /as file/i }))
 
+    const pathField = screen.getByLabelText('Path')
+
     expect(screen.getByText('New variable as file')).toBeInTheDocument()
-    expect(screen.getByLabelText('Path')).toBeInTheDocument()
+    expect(pathField).toHaveAttribute('placeholder', '/path/to/file')
+    expect(pathField).toHaveValue('')
     expect(screen.getByText('Variable interpolation')).toBeInTheDocument()
+
+    await userEvent.click(pathField)
+
+    expect(pathField).toHaveValue('/')
   })
 
   it('should render secret file edit with hidden value control', async () => {

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
@@ -115,7 +115,7 @@ describe('CreateUpdateVariableModal', () => {
 
     const pathField = screen.getByLabelText('Path')
 
-    expect(screen.getByText('New variable as file')).toBeInTheDocument()
+    expect(screen.getByText('New variable file')).toBeInTheDocument()
     expect(pathField).not.toHaveAttribute('placeholder')
     expect(pathField).toHaveValue('')
     expect(screen.getByText('Variable interpolation')).toBeInTheDocument()
@@ -144,7 +144,7 @@ describe('CreateUpdateVariableModal', () => {
 
     const valueField = screen.getByLabelText('Value')
 
-    expect(screen.getByText('Edit secret as file')).toBeInTheDocument()
+    expect(screen.getByText('Edit secret file')).toBeInTheDocument()
     expect(screen.getByRole('checkbox', { name: /show value/i })).toBeInTheDocument()
     expect(valueField).toHaveClass('[-webkit-text-security:disc]')
 

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
@@ -1,7 +1,7 @@
 import { type VariableResponse } from 'qovery-typescript-axios'
 import { type ReactNode } from 'react'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
-import { CreateUpdateVariableModal } from './create-update-variable-modal'
+import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { CreateUpdateVariableModal, VariableFormModal } from './create-update-variable-modal'
 
 jest.mock('@qovery/shared/ui', () => {
   const actual = jest.requireActual('@qovery/shared/ui')
@@ -151,6 +151,33 @@ describe('CreateUpdateVariableModal', () => {
     await userEvent.click(screen.getByRole('checkbox', { name: /show value/i }))
 
     expect(valueField).not.toHaveClass('[-webkit-text-security:disc]')
+  })
+
+  it('should submit a secret created as a file with the selected format', async () => {
+    const onSubmit = jest.fn()
+    const { userEvent } = renderWithProviders(
+      <VariableFormModal {...baseProps} mode="CREATE" type="VALUE" isSecret onSubmit={onSubmit} />
+    )
+
+    await userEvent.click(screen.getByRole('radio', { name: /as file/i }))
+    await userEvent.type(screen.getByLabelText('Variable'), 'MY_SECRET')
+    await userEvent.click(screen.getByLabelText('Path'))
+    await userEvent.type(screen.getByLabelText('Path'), 'vault/secrets/my-secret')
+    await userEvent.type(screen.getByLabelText('Value'), 'secret-value')
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'MY_SECRET',
+          value: 'secret-value',
+          scope: 'ENVIRONMENT',
+          isSecret: true,
+          isFile: true,
+          mountPath: '/vault/secrets/my-secret',
+        })
+      )
+    })
   })
 
   it('should not render the open editor button for aliases', () => {

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx
@@ -116,7 +116,7 @@ describe('CreateUpdateVariableModal', () => {
     const pathField = screen.getByLabelText('Path')
 
     expect(screen.getByText('New variable as file')).toBeInTheDocument()
-    expect(pathField).toHaveAttribute('placeholder', '/path/to/file')
+    expect(pathField).not.toHaveAttribute('placeholder')
     expect(pathField).toHaveValue('')
     expect(screen.getByText('Variable interpolation')).toBeInTheDocument()
 

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -1,5 +1,5 @@
 import { type APIVariableScopeEnum, type APIVariableTypeEnum, type VariableResponse } from 'qovery-typescript-axios'
-import { useEffect, useId, useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import {
@@ -31,7 +31,6 @@ import { VariableValueEditorModal } from './variable-value-editor-modal/variable
 
 type Scope = Exclude<keyof typeof APIVariableScopeEnum, 'BUILT_IN'>
 type ValueEditorScope = Extract<Scope, 'APPLICATION' | 'CONTAINER' | 'JOB' | 'HELM' | 'TERRAFORM'>
-type VariableFormat = 'VALUE' | 'FILE'
 
 function isValueEditorScope(scope: Scope | undefined): scope is ValueEditorScope {
   return ['APPLICATION', 'CONTAINER', 'JOB', 'HELM', 'TERRAFORM'].includes(scope ?? '')
@@ -112,17 +111,15 @@ export function VariableFormModal(props: VariableFormModalProps) {
     isSecret,
     hasClusterSecretManagerConfigured = false,
   } = props
-  const initialIsFile = (variable && environmentVariableFile(variable)) || (isFile ?? false)
-  const canSelectVariableFormat = mode === 'CREATE' && type === 'VALUE'
-  const [variableFormat, setVariableFormat] = useState<VariableFormat>(initialIsFile ? 'FILE' : 'VALUE')
-  const _isFile = canSelectVariableFormat ? variableFormat === 'FILE' : initialIsFile
+  const isCreateValue = mode === 'CREATE' && type === 'VALUE'
+  const [isFileVariable, setIsFileVariable] = useState(() =>
+    Boolean((variable && environmentVariableFile(variable)) || isFile)
+  )
   const { enableAlertClickOutside } = useModal()
   const [isValueEditorOpen, setIsValueEditorOpen] = useState(false)
   const [showSecretValue, setShowSecretValue] = useState(false)
   const showSecretValueId = useId()
-  const isCreateValue = mode === 'CREATE' && type === 'VALUE'
   const isSecretVariable = isCreateValue ? Boolean(isSecret) : Boolean(variable?.is_secret)
-  const isSecretValueHidden = isSecretVariable && !showSecretValue
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
@@ -153,7 +150,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
 
   const defaultScope =
     // Check if it's a file and the scope is one of services and assign the default scope to 'ENVIRONMENT'
-    isFile && ['APPLICATION', 'CONTAINER', 'JOB', 'HELM'].includes(scope)
+    isFileVariable && ['APPLICATION', 'CONTAINER', 'JOB', 'HELM'].includes(scope)
       ? 'ENVIRONMENT'
       : variable?.scope === 'BUILT_IN'
         ? undefined
@@ -180,16 +177,16 @@ export function VariableFormModal(props: VariableFormModalProps) {
       value: variable?.value,
       isSecret: isSecretVariable,
       description: variable?.description,
-      enable_interpolation_in_file: initialIsFile ? variable?.enable_interpolation_in_file ?? true : undefined,
+      enable_interpolation_in_file: isFileVariable ? variable?.enable_interpolation_in_file ?? true : undefined,
       mountPath,
     },
     mode: 'onChange',
   })
 
-  const handleVariableFormatChange = (format: VariableFormat) => {
-    setVariableFormat(format)
+  const handleVariableFormatChange = (isFileSelected: boolean) => {
+    setIsFileVariable(isFileSelected)
 
-    if (format !== 'FILE') {
+    if (!isFileSelected) {
       return
     }
 
@@ -204,16 +201,10 @@ export function VariableFormModal(props: VariableFormModalProps) {
     }
   }
 
-  useEffect(() => {
-    if (_isFile && methods.getValues('enable_interpolation_in_file') === undefined) {
-      methods.setValue('enable_interpolation_in_file', true)
-    }
-  }, [_isFile, methods])
-
   methods.watch(() => enableAlertClickOutside(methods.formState.isDirty))
   const watchScope = methods.watch('scope')
   const watchMountPath = methods.watch('mountPath')
-  const valueEditorLanguage = getValueEditorLanguage({ isFile: _isFile, mountPath: watchMountPath })
+  const valueEditorLanguage = getValueEditorLanguage({ isFile: isFileVariable, mountPath: watchMountPath })
   const valueEditorServiceId = isValueEditorScope(watchScope) ? props.serviceId : undefined
   const valueEditorScope = isValueEditorScope(watchScope) ? watchScope : undefined
 
@@ -223,7 +214,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
     // allow empty variable value
     if (!cloneData.value) cloneData.value = ''
 
-    if (!_isFile) {
+    if (!isFileVariable) {
       delete cloneData.mountPath
       delete cloneData.enable_interpolation_in_file
     } else if (cloneData.enable_interpolation_in_file === undefined) {
@@ -233,7 +224,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
     try {
       await onSubmit({
         ...cloneData,
-        isFile: _isFile,
+        isFile: isFileVariable,
       })
       closeModal()
     } catch (e) {
@@ -258,13 +249,13 @@ export function VariableFormModal(props: VariableFormModalProps) {
     title += ' variable'
   }
 
-  title += _isFile ? ' as file' : ''
+  title += isFileVariable ? ' as file' : ''
 
-  const description = match({ type, _isFile })
+  const description = match({ type, isFileVariable })
     .with({ type: 'ALIAS' }, () => 'Aliases allow you to specify a different name for a variable on a specific scope.')
     .with({ type: 'OVERRIDE' }, () => 'Overrides allow you to define a different env var value on a specific scope.')
     .with(
-      { _isFile: true },
+      { isFileVariable: true },
       () =>
         'The content of the Value field will be mounted as a file in the specified "Path". Accessing the environment variable at runtime will return the "Path" of the file.'
     )
@@ -284,12 +275,12 @@ export function VariableFormModal(props: VariableFormModalProps) {
         onSubmit={_onSubmit}
         loading={loading}
       >
-        {canSelectVariableFormat && (
+        {isCreateValue && (
           <SegmentedControl.Root
             aria-label="Variable format"
             className="mb-3 w-full text-sm"
-            value={variableFormat}
-            onValueChange={(value) => handleVariableFormatChange(value as VariableFormat)}
+            value={isFileVariable ? 'FILE' : 'VALUE'}
+            onValueChange={(value) => handleVariableFormatChange(value === 'FILE')}
           >
             <SegmentedControl.Item value="VALUE">Value</SegmentedControl.Item>
             <SegmentedControl.Item value="FILE">As file</SegmentedControl.Item>
@@ -318,7 +309,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
           />
         )}
 
-        {_isFile &&
+        {isFileVariable &&
           (type === 'ALIAS' || type === 'OVERRIDE' || mode === 'UPDATE' ? (
             <InputText className="mb-3" name="Path" value={mountPath} label="Path" disabled />
           ) : (
@@ -414,7 +405,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
                     value={value}
                     label="Value"
                     error={error?.message}
-                    maskValue={isSecretValueHidden}
+                    maskValue={isSecretVariable && !showSecretValue}
                   />
                   {props.environmentId && (
                     <DropdownVariable
@@ -462,7 +453,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
           />
         )}
 
-        {_isFile && (
+        {isFileVariable && (
           <Controller
             name="enable_interpolation_in_file"
             control={methods.control}

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -121,8 +121,8 @@ export function VariableFormModal(props: VariableFormModalProps) {
   const [showSecretValue, setShowSecretValue] = useState(false)
   const showSecretValueId = useId()
   const isCreateValue = mode === 'CREATE' && type === 'VALUE'
-  const isSecretCreation = isCreateValue && Boolean(isSecret)
-  const isSecretValueHidden = isSecretCreation && !showSecretValue
+  const isSecretVariable = isCreateValue ? Boolean(isSecret) : Boolean(variable?.is_secret)
+  const isSecretValueHidden = isSecretVariable && !showSecretValue
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
@@ -178,7 +178,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
       key: variable?.key,
       scope: defaultScope,
       value: variable?.value,
-      isSecret: isCreateValue ? Boolean(isSecret) : variable?.is_secret,
+      isSecret: isSecretVariable,
       description: variable?.description,
       enable_interpolation_in_file: initialIsFile ? variable?.enable_interpolation_in_file ?? true : undefined,
       mountPath,
@@ -251,7 +251,9 @@ export function VariableFormModal(props: VariableFormModalProps) {
   }
 
   if (isCreateValue) {
-    title += isSecretCreation ? ' secret' : ' variable'
+    title += isSecretVariable ? ' secret' : ' variable'
+  } else if (mode === 'UPDATE' && type !== 'ALIAS' && type !== 'OVERRIDE') {
+    title += isSecretVariable ? ' secret' : ' variable'
   } else {
     title += ' variable'
   }
@@ -267,7 +269,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
         'The content of the Value field will be mounted as a file in the specified "Path". Accessing the environment variable at runtime will return the "Path" of the file.'
     )
     .otherwise(() =>
-      isSecretCreation
+      isSecretVariable
         ? 'Secrets can only be accessed by your application at runtime. Use them for sensitive values such as tokens, credentials, and private configuration.'
         : "Environment variables can be accessed at both build and run time. Set them as ARGS in your Dockerfile to use them during build processes. At runtime, they're available to your application automatically."
     )
@@ -400,7 +402,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
                 <div className="relative">
                   <InputTextArea
                     ref={textareaRef}
-                    className={isSecretCreation ? 'mb-2' : 'mb-3'}
+                    className={isSecretVariable ? 'mb-2' : 'mb-3'}
                     name={name}
                     onChange={onChange}
                     value={value}
@@ -425,7 +427,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
                     </DropdownVariable>
                   )}
                 </div>
-                {isSecretCreation && (
+                {isSecretVariable && (
                   <div className="mb-3 flex w-fit items-center gap-2">
                     <Checkbox
                       id={showSecretValueId}
@@ -507,7 +509,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
           }
         />
 
-        {isSecretCreation && hasClusterSecretManagerConfigured && (
+        {isCreateValue && isSecretVariable && hasClusterSecretManagerConfigured && (
           <Callout.Root color="yellow" className="mb-3">
             <Callout.Icon>
               <Icon iconName="exclamation-triangle" iconStyle="regular" />

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -320,20 +320,22 @@ export function VariableFormModal(props: VariableFormModalProps) {
                 required: 'Please enter a mount path.',
               }}
               render={({ field, fieldState: { error } }) => (
-                <InputText
-                  className="mb-3"
-                  name={field.name}
-                  onChange={field.onChange}
-                  onFocus={() => {
+                <div
+                  onFocusCapture={() => {
                     if (!field.value) {
                       field.onChange('/')
                     }
                   }}
-                  value={field.value}
-                  label="Path"
-                  placeholder="/path/to/file"
-                  error={error?.message}
-                />
+                >
+                  <InputText
+                    className="mb-3"
+                    name={field.name}
+                    onChange={field.onChange}
+                    value={field.value}
+                    label="Path"
+                    error={error?.message}
+                  />
+                </div>
               )}
             />
           ))}

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -333,8 +333,14 @@ export function VariableFormModal(props: VariableFormModalProps) {
                   className="mb-3"
                   name={field.name}
                   onChange={field.onChange}
+                  onFocus={() => {
+                    if (!field.value) {
+                      field.onChange('/')
+                    }
+                  }}
                   value={field.value}
                   label="Path"
+                  placeholder="/path/to/file"
                   error={error?.message}
                 />
               )}

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -249,7 +249,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
     title += ' variable'
   }
 
-  title += isFileVariable ? ' as file' : ''
+  title += isFileVariable ? ' file' : ''
 
   const description = match({ type, isFileVariable })
     .with({ type: 'ALIAS' }, () => 'Aliases allow you to specify a different name for a variable on a specific scope.')

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -89,7 +89,6 @@ export type VariableFormModalProps = {
   variable?: VariableResponse
   mode: 'CREATE' | 'UPDATE'
   type: keyof typeof APIVariableTypeEnum
-  isFile?: boolean
   isSecret?: boolean
   hasClusterSecretManagerConfigured?: boolean
   scope: Scope
@@ -107,13 +106,12 @@ export function VariableFormModal(props: VariableFormModalProps) {
     variable,
     mode,
     type,
-    isFile,
     isSecret,
     hasClusterSecretManagerConfigured = false,
   } = props
   const isCreateValue = mode === 'CREATE' && type === 'VALUE'
   const [isFileVariable, setIsFileVariable] = useState(() =>
-    Boolean((variable && environmentVariableFile(variable)) || isFile)
+    Boolean(type === 'FILE' || (variable && environmentVariableFile(variable)))
   )
   const { enableAlertClickOutside } = useModal()
   const [isValueEditorOpen, setIsValueEditorOpen] = useState(false)
@@ -561,7 +559,6 @@ export type CreateUpdateVariableModalProps = {
   variable?: VariableResponse
   mode: 'CREATE' | 'UPDATE'
   type: keyof typeof APIVariableTypeEnum
-  isFile?: boolean
   isSecret?: boolean
   hasClusterSecretManagerConfigured?: boolean
 } & CreateUpdateVariableModalScopeProps

--- a/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
+++ b/libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.tsx
@@ -1,16 +1,18 @@
 import { type APIVariableScopeEnum, type APIVariableTypeEnum, type VariableResponse } from 'qovery-typescript-axios'
-import { useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import {
   Button,
   Callout,
+  Checkbox,
   Icon,
   InputSelect,
   InputText,
   InputTextArea,
   InputToggle,
   ModalCrud,
+  SegmentedControl,
   Tooltip,
   useModal,
 } from '@qovery/shared/ui'
@@ -29,6 +31,7 @@ import { VariableValueEditorModal } from './variable-value-editor-modal/variable
 
 type Scope = Exclude<keyof typeof APIVariableScopeEnum, 'BUILT_IN'>
 type ValueEditorScope = Extract<Scope, 'APPLICATION' | 'CONTAINER' | 'JOB' | 'HELM' | 'TERRAFORM'>
+type VariableFormat = 'VALUE' | 'FILE'
 
 function isValueEditorScope(scope: Scope | undefined): scope is ValueEditorScope {
   return ['APPLICATION', 'CONTAINER', 'JOB', 'HELM', 'TERRAFORM'].includes(scope ?? '')
@@ -88,6 +91,7 @@ export type VariableFormModalProps = {
   mode: 'CREATE' | 'UPDATE'
   type: keyof typeof APIVariableTypeEnum
   isFile?: boolean
+  isSecret?: boolean
   hasClusterSecretManagerConfigured?: boolean
   scope: Scope
   projectId?: string
@@ -105,11 +109,20 @@ export function VariableFormModal(props: VariableFormModalProps) {
     mode,
     type,
     isFile,
+    isSecret,
     hasClusterSecretManagerConfigured = false,
   } = props
-  const _isFile = (variable && environmentVariableFile(variable)) || (isFile ?? false)
+  const initialIsFile = (variable && environmentVariableFile(variable)) || (isFile ?? false)
+  const canSelectVariableFormat = mode === 'CREATE' && type === 'VALUE'
+  const [variableFormat, setVariableFormat] = useState<VariableFormat>(initialIsFile ? 'FILE' : 'VALUE')
+  const _isFile = canSelectVariableFormat ? variableFormat === 'FILE' : initialIsFile
   const { enableAlertClickOutside } = useModal()
   const [isValueEditorOpen, setIsValueEditorOpen] = useState(false)
+  const [showSecretValue, setShowSecretValue] = useState(false)
+  const showSecretValueId = useId()
+  const isCreateValue = mode === 'CREATE' && type === 'VALUE'
+  const isSecretCreation = isCreateValue && Boolean(isSecret)
+  const isSecretValueHidden = isSecretCreation && !showSecretValue
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
@@ -165,17 +178,40 @@ export function VariableFormModal(props: VariableFormModalProps) {
       key: variable?.key,
       scope: defaultScope,
       value: variable?.value,
-      isSecret: variable?.is_secret,
+      isSecret: isCreateValue ? Boolean(isSecret) : variable?.is_secret,
       description: variable?.description,
-      enable_interpolation_in_file: _isFile ? variable?.enable_interpolation_in_file ?? true : undefined,
+      enable_interpolation_in_file: initialIsFile ? variable?.enable_interpolation_in_file ?? true : undefined,
       mountPath,
     },
     mode: 'onChange',
   })
 
+  const handleVariableFormatChange = (format: VariableFormat) => {
+    setVariableFormat(format)
+
+    if (format !== 'FILE') {
+      return
+    }
+
+    if (methods.getValues('enable_interpolation_in_file') === undefined) {
+      methods.setValue('enable_interpolation_in_file', true)
+    }
+
+    const currentScope = methods.getValues('scope')
+
+    if (currentScope && ['APPLICATION', 'CONTAINER', 'JOB', 'HELM'].includes(currentScope)) {
+      methods.setValue('scope', 'ENVIRONMENT', { shouldValidate: true, shouldDirty: true })
+    }
+  }
+
+  useEffect(() => {
+    if (_isFile && methods.getValues('enable_interpolation_in_file') === undefined) {
+      methods.setValue('enable_interpolation_in_file', true)
+    }
+  }, [_isFile, methods])
+
   methods.watch(() => enableAlertClickOutside(methods.formState.isDirty))
   const watchScope = methods.watch('scope')
-  const watchIsSecret = methods.watch('isSecret')
   const watchMountPath = methods.watch('mountPath')
   const valueEditorLanguage = getValueEditorLanguage({ isFile: _isFile, mountPath: watchMountPath })
   const valueEditorServiceId = isValueEditorScope(watchScope) ? props.serviceId : undefined
@@ -189,6 +225,9 @@ export function VariableFormModal(props: VariableFormModalProps) {
 
     if (!_isFile) {
       delete cloneData.mountPath
+      delete cloneData.enable_interpolation_in_file
+    } else if (cloneData.enable_interpolation_in_file === undefined) {
+      cloneData.enable_interpolation_in_file = true
     }
 
     try {
@@ -211,7 +250,13 @@ export function VariableFormModal(props: VariableFormModalProps) {
     title = 'Create ' + (type === 'ALIAS' ? 'alias' : type === 'OVERRIDE' ? 'override' : '')
   }
 
-  title += ' variable' + (_isFile ? ' file' : '')
+  if (isCreateValue) {
+    title += isSecretCreation ? ' secret' : ' variable'
+  } else {
+    title += ' variable'
+  }
+
+  title += _isFile ? ' as file' : ''
 
   const description = match({ type, _isFile })
     .with({ type: 'ALIAS' }, () => 'Aliases allow you to specify a different name for a variable on a specific scope.')
@@ -221,9 +266,10 @@ export function VariableFormModal(props: VariableFormModalProps) {
       () =>
         'The content of the Value field will be mounted as a file in the specified "Path". Accessing the environment variable at runtime will return the "Path" of the file.'
     )
-    .otherwise(
-      () =>
-        "Environment variables can be accessed at both build and run time. Set them as ARGS in your Dockerfile to use them during build processes. At runtime, they're available to your application automatically. Secrets value can only be accessed by your application."
+    .otherwise(() =>
+      isSecretCreation
+        ? 'Secrets can only be accessed by your application at runtime. Use them for sensitive values such as tokens, credentials, and private configuration.'
+        : "Environment variables can be accessed at both build and run time. Set them as ARGS in your Dockerfile to use them during build processes. At runtime, they're available to your application automatically."
     )
 
   return (
@@ -236,6 +282,18 @@ export function VariableFormModal(props: VariableFormModalProps) {
         onSubmit={_onSubmit}
         loading={loading}
       >
+        {canSelectVariableFormat && (
+          <SegmentedControl.Root
+            aria-label="Variable format"
+            className="mb-3 w-full text-sm"
+            value={variableFormat}
+            onValueChange={(value) => handleVariableFormatChange(value as VariableFormat)}
+          >
+            <SegmentedControl.Item value="VALUE">Value</SegmentedControl.Item>
+            <SegmentedControl.Item value="FILE">As file</SegmentedControl.Item>
+          </SegmentedControl.Root>
+        )}
+
         {type === 'ALIAS' || type === 'OVERRIDE' ? (
           <InputText className="mb-3" name="Variable" value={variable?.key} label="Variable" disabled />
         ) : (
@@ -342,12 +400,13 @@ export function VariableFormModal(props: VariableFormModalProps) {
                 <div className="relative">
                   <InputTextArea
                     ref={textareaRef}
-                    className="mb-3"
+                    className={isSecretCreation ? 'mb-2' : 'mb-3'}
                     name={name}
                     onChange={onChange}
                     value={value}
                     label="Value"
                     error={error?.message}
+                    maskValue={isSecretValueHidden}
                   />
                   {props.environmentId && (
                     <DropdownVariable
@@ -366,6 +425,18 @@ export function VariableFormModal(props: VariableFormModalProps) {
                     </DropdownVariable>
                   )}
                 </div>
+                {isSecretCreation && (
+                  <div className="mb-3 flex w-fit items-center gap-2">
+                    <Checkbox
+                      id={showSecretValueId}
+                      checked={showSecretValue}
+                      onCheckedChange={(checked) => setShowSecretValue(checked === true)}
+                    />
+                    <label htmlFor={showSecretValueId} className="text-sm font-medium text-neutral">
+                      Show value
+                    </label>
+                  </div>
+                )}
                 <VariableValueEditorModal
                   open={isValueEditorOpen}
                   onOpenChange={setIsValueEditorOpen}
@@ -436,24 +507,7 @@ export function VariableFormModal(props: VariableFormModalProps) {
           }
         />
 
-        {mode === 'CREATE' && type === 'VALUE' && (
-          <div className="mb-8 flex items-center gap-3">
-            <Controller
-              name="isSecret"
-              control={methods.control}
-              render={({ field }) => (
-                <InputToggle
-                  small
-                  value={field.value}
-                  onChange={field.onChange}
-                  title={`Secret ${_isFile ? 'file' : 'variable'}`}
-                />
-              )}
-            />
-          </div>
-        )}
-
-        {mode === 'CREATE' && type === 'VALUE' && watchIsSecret && hasClusterSecretManagerConfigured && (
+        {isSecretCreation && hasClusterSecretManagerConfigured && (
           <Callout.Root color="yellow" className="mb-3">
             <Callout.Icon>
               <Icon iconName="exclamation-triangle" iconStyle="regular" />
@@ -507,6 +561,7 @@ export type CreateUpdateVariableModalProps = {
   mode: 'CREATE' | 'UPDATE'
   type: keyof typeof APIVariableTypeEnum
   isFile?: boolean
+  isSecret?: boolean
   hasClusterSecretManagerConfigured?: boolean
 } & CreateUpdateVariableModalScopeProps
 

--- a/libs/domains/variables/feature/src/lib/flow-create-variable/flow-create-variable.tsx
+++ b/libs/domains/variables/feature/src/lib/flow-create-variable/flow-create-variable.tsx
@@ -10,7 +10,7 @@ import VariableRow from './variable-row/variable-row'
 export interface FlowCreateVariableProps {
   onBack: () => void
   onSubmit: FormEventHandler<HTMLFormElement>
-  onAdd: () => void
+  onAdd: (isSecret?: boolean) => void
   onRemove: (index: number) => void
   variables: VariableData[]
   availableScopes: APIVariableScopeEnum[]
@@ -27,16 +27,20 @@ export function FlowCreateVariable({
   availableScopes,
 }: FlowCreateVariableProps) {
   const { formState } = useFormContext<FlowVariableData>()
-  const gridTemplateColumns = '1fr 1fr 1fr 56px 32px'
+  const gridTemplateColumns = '1fr 1fr 1fr 32px'
 
   return (
     <Section>
       <div className="flex justify-between">
         <Heading className="mb-2">Environment variables</Heading>
-        <Button size="md" onClick={onAdd}>
-          Add Variable
-          <Icon iconName="plus-circle" iconStyle="regular" />
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button size="md" color="neutral" variant="outline" onClick={() => onAdd(true)}>
+            Add secret
+          </Button>
+          <Button size="md" onClick={() => onAdd(false)}>
+            Add variable
+          </Button>
+        </div>
       </div>
 
       <form className="space-y-10" onSubmit={onSubmit}>
@@ -71,7 +75,6 @@ export function FlowCreateVariable({
               <span className="text-sm font-medium text-neutral">Variable</span>
               <span className="text-sm font-medium text-neutral">Value</span>
               <span className="text-sm font-medium text-neutral">Scope</span>
-              <span className="pl-1.5 text-sm font-medium text-neutral">Secret</span>
               <span></span>
             </div>
           )}

--- a/libs/domains/variables/feature/src/lib/flow-create-variable/flow-create-variable.tsx
+++ b/libs/domains/variables/feature/src/lib/flow-create-variable/flow-create-variable.tsx
@@ -35,9 +35,11 @@ export function FlowCreateVariable({
         <Heading className="mb-2">Environment variables</Heading>
         <div className="flex items-center gap-2">
           <Button size="md" color="neutral" variant="outline" onClick={() => onAdd(true)}>
+            <Icon iconName="lock-keyhole" iconStyle="regular" />
             Add secret
           </Button>
           <Button size="md" onClick={() => onAdd(false)}>
+            <Icon iconName="key" />
             Add variable
           </Button>
         </div>

--- a/libs/domains/variables/feature/src/lib/flow-create-variable/variable-row/variable-row.tsx
+++ b/libs/domains/variables/feature/src/lib/flow-create-variable/variable-row/variable-row.tsx
@@ -3,7 +3,7 @@ import { type APIVariableScopeEnum } from 'qovery-typescript-axios'
 import { useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { type FlowVariableData } from '@qovery/shared/interfaces'
-import { BlockContent, Button, Icon, InputSelectSmall, InputTextSmall, InputToggle, Tooltip } from '@qovery/shared/ui'
+import { BlockContent, Button, Icon, InputSelectSmall, InputTextSmall, Tooltip } from '@qovery/shared/ui'
 import { generateScopeLabel } from '@qovery/shared/util-js'
 import { CodeEditorVariable } from '../../code-editor-variable/code-editor-variable'
 import { FieldVariableSuggestion } from '../../field-variable-suggestion/field-variable-suggestion'
@@ -141,14 +141,6 @@ export function VariableRow(props: VariableRowProps) {
             />
           )}
         />
-
-        <div className="flex w-14 items-center justify-center">
-          <Controller
-            name={`variables.${index}.isSecret`}
-            control={control}
-            render={({ field }) => <InputToggle small value={field.value} onChange={field.onChange} />}
-          />
-        </div>
 
         <div className="flex items-center">
           <Button type="button" variant="outline" size="md" iconOnly onClick={() => props.onDelete(index)}>

--- a/libs/domains/variables/feature/src/lib/variable-list/variable-list.tsx
+++ b/libs/domains/variables/feature/src/lib/variable-list/variable-list.tsx
@@ -172,7 +172,10 @@ export function VariableList({
     })
   }
 
-  const _onCreateStandaloneVariable = (isFile = false) =>
+  const _onCreateStandaloneVariable = ({
+    isFile = false,
+    isSecret = false,
+  }: { isFile?: boolean; isSecret?: boolean } = {}) =>
     openModal({
       content: (
         <CreateUpdateVariableModal
@@ -181,6 +184,7 @@ export function VariableList({
           mode="CREATE"
           onSubmit={onCreateVariable}
           isFile={isFile}
+          isSecret={isSecret}
           {...props}
         />
       ),
@@ -859,36 +863,26 @@ export function VariableList({
           className="rounded-none border-0 bg-transparent py-12"
         >
           <div className="flex items-center gap-2">
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <Button color="neutral" variant="solid" size="md" className="gap-1.5">
-                  <Icon iconName="circle-plus" iconStyle="regular" />
-                  Add variable
-                  <Icon iconName="angle-down" />
-                </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content>
-                <DropdownMenu.Item onSelect={() => _onCreateStandaloneVariable()} icon={<Icon iconName="key" />}>
-                  Variable
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  onSelect={() => _onCreateStandaloneVariable(true)}
-                  icon={<Icon iconName="file-lines" iconStyle="regular" />}
-                >
-                  Variable as file
-                </DropdownMenu.Item>
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
+            <Button
+              color="neutral"
+              variant="solid"
+              size="md"
+              className="gap-1.5"
+              onClick={() => _onCreateStandaloneVariable()}
+            >
+              <Icon iconName="key" />
+              Add variable
+            </Button>
 
             <Button
               color="neutral"
               variant="outline"
               size="md"
               className="gap-1.5"
-              onClick={() => window.open('https://dashboard.doppler.com', '_blank')}
+              onClick={() => _onCreateStandaloneVariable({ isSecret: true })}
             >
-              <Icon iconName="arrow-up-right-from-square" iconStyle="regular" />
-              Import from Doppler
+              <Icon iconName="lock-keyhole" iconStyle="regular" />
+              Add secret
             </Button>
           </div>
         </EmptyState>

--- a/libs/domains/variables/feature/src/lib/variable-list/variable-list.tsx
+++ b/libs/domains/variables/feature/src/lib/variable-list/variable-list.tsx
@@ -172,10 +172,7 @@ export function VariableList({
     })
   }
 
-  const _onCreateStandaloneVariable = ({
-    isFile = false,
-    isSecret = false,
-  }: { isFile?: boolean; isSecret?: boolean } = {}) =>
+  const _onCreateStandaloneVariable = (isSecret = false) =>
     openModal({
       content: (
         <CreateUpdateVariableModal
@@ -183,7 +180,6 @@ export function VariableList({
           type="VALUE"
           mode="CREATE"
           onSubmit={onCreateVariable}
-          isFile={isFile}
           isSecret={isSecret}
           {...props}
         />
@@ -868,12 +864,7 @@ export function VariableList({
               Add variable
             </Button>
 
-            <Button
-              color="neutral"
-              variant="outline"
-              size="md"
-              onClick={() => _onCreateStandaloneVariable({ isSecret: true })}
-            >
+            <Button color="neutral" variant="outline" size="md" onClick={() => _onCreateStandaloneVariable(true)}>
               <Icon iconName="lock-keyhole" iconStyle="regular" />
               Add secret
             </Button>

--- a/libs/domains/variables/feature/src/lib/variable-list/variable-list.tsx
+++ b/libs/domains/variables/feature/src/lib/variable-list/variable-list.tsx
@@ -863,13 +863,7 @@ export function VariableList({
           className="rounded-none border-0 bg-transparent py-12"
         >
           <div className="flex items-center gap-2">
-            <Button
-              color="neutral"
-              variant="solid"
-              size="md"
-              className="gap-1.5"
-              onClick={() => _onCreateStandaloneVariable()}
-            >
+            <Button color="neutral" variant="solid" size="md" onClick={() => _onCreateStandaloneVariable()}>
               <Icon iconName="key" />
               Add variable
             </Button>
@@ -878,7 +872,6 @@ export function VariableList({
               color="neutral"
               variant="outline"
               size="md"
-              className="gap-1.5"
               onClick={() => _onCreateStandaloneVariable({ isSecret: true })}
             >
               <Icon iconName="lock-keyhole" iconStyle="regular" />

--- a/libs/domains/variables/feature/src/lib/variables-action-toolbar/variables-action-toolbar.tsx
+++ b/libs/domains/variables/feature/src/lib/variables-action-toolbar/variables-action-toolbar.tsx
@@ -40,7 +40,7 @@ export function VariablesActionToolbar({
   const hasImportEnvFile = Boolean(onImportEnvFile)
   const showImportButton = hasImportEnvFile && importEnvFileAccess === 'button'
 
-  const _onCreateVariable = ({ isFile, isSecret = false }: { isFile?: boolean; isSecret?: boolean } = {}) =>
+  const _onCreateVariable = (isSecret = false) =>
     openModal({
       content: (
         <CreateUpdateVariableModal
@@ -48,7 +48,6 @@ export function VariablesActionToolbar({
           type="VALUE"
           mode="CREATE"
           onSubmit={onCreateVariable}
-          isFile={isFile}
           isSecret={isSecret}
           hasClusterSecretManagerConfigured={hasClusterSecretManagerConfigured}
           {...props}
@@ -107,7 +106,7 @@ export function VariablesActionToolbar({
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
-      <Button color="neutral" variant="outline" size="md" onClick={() => _onCreateVariable({ isSecret: true })}>
+      <Button color="neutral" variant="outline" size="md" onClick={() => _onCreateVariable(true)}>
         <Icon iconName="lock-keyhole" iconStyle="regular" />
         Add secret
       </Button>

--- a/libs/domains/variables/feature/src/lib/variables-action-toolbar/variables-action-toolbar.tsx
+++ b/libs/domains/variables/feature/src/lib/variables-action-toolbar/variables-action-toolbar.tsx
@@ -107,18 +107,12 @@ export function VariablesActionToolbar({
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
-      <Button
-        color="neutral"
-        variant="outline"
-        size="md"
-        className="gap-1.5"
-        onClick={() => _onCreateVariable({ isSecret: true })}
-      >
+      <Button color="neutral" variant="outline" size="md" onClick={() => _onCreateVariable({ isSecret: true })}>
         <Icon iconName="lock-keyhole" iconStyle="regular" />
         Add secret
       </Button>
 
-      <Button color="brand" variant="solid" size="md" className="gap-1.5" onClick={() => _onCreateVariable()}>
+      <Button color="brand" variant="solid" size="md" onClick={() => _onCreateVariable()}>
         <Icon iconName="key" />
         Add variable
       </Button>

--- a/libs/domains/variables/feature/src/lib/variables-action-toolbar/variables-action-toolbar.tsx
+++ b/libs/domains/variables/feature/src/lib/variables-action-toolbar/variables-action-toolbar.tsx
@@ -40,7 +40,7 @@ export function VariablesActionToolbar({
   const hasImportEnvFile = Boolean(onImportEnvFile)
   const showImportButton = hasImportEnvFile && importEnvFileAccess === 'button'
 
-  const _onCreateVariable = (isFile?: boolean) =>
+  const _onCreateVariable = ({ isFile, isSecret = false }: { isFile?: boolean; isSecret?: boolean } = {}) =>
     openModal({
       content: (
         <CreateUpdateVariableModal
@@ -49,6 +49,7 @@ export function VariablesActionToolbar({
           mode="CREATE"
           onSubmit={onCreateVariable}
           isFile={isFile}
+          isSecret={isSecret}
           hasClusterSecretManagerConfigured={hasClusterSecretManagerConfigured}
           {...props}
         />
@@ -106,25 +107,21 @@ export function VariablesActionToolbar({
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
-      <DropdownMenu.Root>
-        <DropdownMenu.Trigger asChild>
-          <Button color="brand" variant="solid" size="md">
-            <Icon iconName="circle-plus" iconStyle="regular" />
-            New variable
-          </Button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
-          <DropdownMenu.Item onSelect={() => _onCreateVariable()} icon={<Icon iconName="key" />}>
-            Variable
-          </DropdownMenu.Item>
-          <DropdownMenu.Item
-            onSelect={() => _onCreateVariable(true)}
-            icon={<Icon iconName="file-lines" iconStyle="regular" />}
-          >
-            Variable as file
-          </DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
+      <Button
+        color="neutral"
+        variant="outline"
+        size="md"
+        className="gap-1.5"
+        onClick={() => _onCreateVariable({ isSecret: true })}
+      >
+        <Icon iconName="lock-keyhole" iconStyle="regular" />
+        Add secret
+      </Button>
+
+      <Button color="brand" variant="solid" size="md" className="gap-1.5" onClick={() => _onCreateVariable()}>
+        <Icon iconName="key" />
+        Add variable
+      </Button>
     </div>
   )
 }

--- a/libs/shared/ui/src/lib/components/inputs/input-text-area/input-text-area.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-text-area/input-text-area.tsx
@@ -11,10 +11,11 @@ export interface InputTextAreaProps {
   hint?: ReactNode
   error?: string
   dataTestId?: string
+  maskValue?: boolean
 }
 
 export const InputTextArea = forwardRef<HTMLTextAreaElement, InputTextAreaProps>(function InputTextArea(props, ref) {
-  const { label, value = '', name, onChange, className, hint, error, dataTestId = 'input-textarea' } = props
+  const { label, value = '', name, onChange, className, hint, error, dataTestId = 'input-textarea', maskValue } = props
 
   const [currentValue, setCurrentValue] = useState(value)
   const previousValueRef = useRef(value)
@@ -71,7 +72,10 @@ export const InputTextArea = forwardRef<HTMLTextAreaElement, InputTextAreaProps>
           ref={ref}
           name={name}
           id={label}
-          className="mt-5 min-h-[52px] w-full appearance-none bg-transparent pr-3 text-sm text-neutral outline-0"
+          className={twMerge(
+            'mt-5 min-h-[52px] w-full appearance-none bg-transparent pr-3 text-sm text-neutral outline-0',
+            maskValue && '[-webkit-text-security:disc]'
+          )}
           value={!currentValue ? undefined : currentValue}
           onChange={(e) => {
             if (onChange) onChange(e)

--- a/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
@@ -1,6 +1,5 @@
 import {
   type ChangeEventHandler,
-  type FocusEventHandler,
   type ReactNode,
   forwardRef,
   useEffect,
@@ -26,7 +25,6 @@ export interface InputTextProps {
   placeholder?: string
   autoFocus?: boolean
   autoComplete?: string
-  onFocus?: FocusEventHandler<HTMLInputElement>
 }
 
 export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function InputText(props, ref) {
@@ -45,7 +43,6 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
     placeholder,
     autoFocus,
     autoComplete = 'off',
-    onFocus,
   } = props
 
   const [focused, setFocused] = useState(false)
@@ -131,10 +128,7 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
                 if (onChange) onChange(e)
                 setCurrentValue(e.currentTarget.value)
               }}
-              onFocus={(e) => {
-                setFocused(true)
-                onFocus?.(e)
-              }}
+              onFocus={() => setFocused(true)}
               onBlur={() => setFocused(false)}
             />
             {isInputDate && (

--- a/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
@@ -1,5 +1,6 @@
 import {
   type ChangeEventHandler,
+  type FocusEventHandler,
   type ReactNode,
   forwardRef,
   useEffect,
@@ -25,6 +26,7 @@ export interface InputTextProps {
   placeholder?: string
   autoFocus?: boolean
   autoComplete?: string
+  onFocus?: FocusEventHandler<HTMLInputElement>
 }
 
 export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function InputText(props, ref) {
@@ -43,6 +45,7 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
     placeholder,
     autoFocus,
     autoComplete = 'off',
+    onFocus,
   } = props
 
   const [focused, setFocused] = useState(false)
@@ -128,7 +131,10 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
                 if (onChange) onChange(e)
                 setCurrentValue(e.currentTarget.value)
               }}
-              onFocus={() => setFocused(true)}
+              onFocus={(e) => {
+                setFocused(true)
+                onFocus?.(e)
+              }}
               onBlur={() => setFocused(false)}
             />
             {isInputDate && (


### PR DESCRIPTION
## What changed

- Split custom variable creation into explicit variable and secret entry points.
- Added a dedicated secret creation modal state with hidden value by default and a `Show value` checkbox.
- Moved `Value` / `As file` selection into the creation modal via the shared segmented control.
- Removed file-specific dropdown entries from custom variable empty states and creation flow actions.
- Kept these changes scoped to the Custom variables tab and custom variable creation flows.
- One caveat, the secret value is not hidden when going into the "Value editor" modal
- Simplified experience on file variable on the path input, the first "/" is filled by default

### Screenshots
Two buttons
<img width="1469" height="836" alt="image" src="https://github.com/user-attachments/assets/6a4f2673-70d0-4435-92af-71287840f7ef" />

Secret modal
<img width="513" height="660" alt="image" src="https://github.com/user-attachments/assets/d8554d53-69de-4be7-9e35-490297d43600" />

Secret as a file modal
<img width="511" height="698" alt="image" src="https://github.com/user-attachments/assets/ffaec4c8-20ed-4944-8bf5-3d64e9724fed" />

## Validation

- `yarn jest --config libs/domains/variables/feature/jest.config.ts --runTestsByPath libs/domains/variables/feature/src/lib/create-update-variable-modal/create-update-variable-modal.spec.tsx libs/domains/variables/feature/src/lib/variable-list/variable-list.spec.tsx`
- `yarn jest --config libs/domains/services/feature/jest.config.ts --runTestsByPath libs/domains/services/feature/src/lib/service-creation-flow/application-container/application-container-variables/step-variables/step-variables.spec.tsx libs/domains/services/feature/src/lib/service-variables-tabs/service-variables-custom-tab.spec.tsx`
- `yarn tsc -p libs/domains/services/feature/tsconfig.lib.json --noEmit`
- `git diff --check`

## Known local issue

`yarn tsc -p libs/domains/variables/feature/tsconfig.lib.json --noEmit` currently fails on unrelated pre-existing errors in `libs/domains/clusters/feature/src/lib/cluster-actions/cluster-actions.tsx` for unused `@ts-expect-error` directives.