### PR TITLE
fix: project filter was not properly saved in webhook modal

### DIFF
--- a/libs/domains/organizations/feature/src/lib/settings-webhook/webhook-crud-modal/webhook-crud-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-webhook/webhook-crud-modal/webhook-crud-modal.spec.tsx
@@ -156,6 +156,33 @@ describe('WebhookCrudModal', () => {
     })
   })
 
+  it('should commit a project filter typed but not confirmed with Enter when submitting', async () => {
+    const { userEvent } = renderWithProviders(<WebhookCrudModal {...props} webhook={mockWebhook} />)
+    const url = screen.getByLabelText('URL')
+    const kind = screen.getByLabelText('Kind')
+    const tags = screen.getByTestId('input-tags-field')
+
+    await userEvent.clear(url)
+    await userEvent.type(url, 'https://test.com')
+
+    await selectEvent.select(kind, ['Standard'], {
+      container: document.body,
+    })
+
+    await userEvent.type(tags, 'test')
+
+    const button = screen.getByTestId('submit-button')
+    await userEvent.click(button)
+
+    expect(editWebhookMock).toHaveBeenCalledWith({
+      organizationId: '000-000-000',
+      webhookId: mockWebhook.id,
+      webhookRequest: expect.objectContaining({
+        project_names_filter: ['test'],
+      }),
+    })
+  })
+
   it('should trim URL with trailing whitespace on create', async () => {
     const { userEvent } = renderWithProviders(<WebhookCrudModal {...props} />)
 

--- a/libs/shared/ui/src/lib/components/inputs/input-tags/input-tags.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-tags/input-tags.tsx
@@ -55,6 +55,17 @@ export function InputTags(props: InputTagsProps) {
     isLabelTransitionDisabled && '!transition-none'
   )
 
+  const commitTag = (rawValue: string) => {
+    const value = rawValue.trim()
+    if (!value) return
+    if (currentTags.find((v) => value.toLowerCase() === v.toLowerCase())) return
+
+    const newTags = [...currentTags, value]
+    setCurrentTags(newTags)
+    setInputValue('')
+    onChange && onChange(newTags)
+  }
+
   const handleKeyDown = (event: FormEvent<HTMLInputElement>) => {
     const key = (event as KeyboardEvent<HTMLInputElement>).key
     const target = event.target as HTMLInputElement
@@ -69,14 +80,7 @@ export function InputTags(props: InputTagsProps) {
     if (key === 'Enter') {
       event.preventDefault()
       event.stopPropagation()
-
-      if (!value.trim()) return
-      if (currentTags.find((v) => value.toLowerCase() === v.toLowerCase())) return
-
-      const newTags = [...currentTags, value]
-      setCurrentTags(newTags)
-      setInputValue('')
-      onChange && onChange(newTags)
+      commitTag(value)
     }
   }
 
@@ -116,6 +120,7 @@ export function InputTags(props: InputTagsProps) {
           ref={ref}
           data-testid="input-tags-field"
           onKeyDown={handleKeyDown}
+          onBlur={(e) => commitTag(e.currentTarget.value)}
           type="text"
           className={twMerge(
             'bg-transparent',


### PR DESCRIPTION
Issue reported in Pylon ticket 4551
**Root cause:** in libs/shared/ui/src/lib/components/inputs/input-tags/input-tags.tsx, the InputTags component (used for the webhook "Project name filter" and the settings "Contact emails" field) only committed typed text into the tags array when the user pressed Enter. There was no commit on blur or before submit. So if you typed a project name and clicked Save directly (a very natural thing to do — the "press Enter" hint is easy to miss), the text sitting in the input was silently discarded, and the value never made it into project_names_filter. The saved webhook came back with an empty (or unchanged) filter, which looked like the value "disappeared."

Confirmed by tracing the whole path (form defaults, submit handler, API payload, cache invalidation) — everything else was correct; the existing passing tests only ever simulated pressing Enter, which is why this never surfaced.

**Fix:** added an onBlur handler on the tag input that commits any pending typed value (same logic as Enter, factored into a shared commitTag helper) in input-tags.tsx:58-88,128. Since blur fires on mousedown before the Save button's click handler runs, this covers exactly the "type then click Save" flow.

Added a regression test in webhook-crud-modal.spec.tsx that types a project filter without pressing Enter and asserts it's still included in the edit payload. All 17 webhook tests and the 6 InputTags unit tests pass.