### PR TITLE
fix(clusters): use warning color for status chevron

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-running-status-indicator/cluster-running-status-indicator.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-running-status-indicator/cluster-running-status-indicator.spec.tsx
@@ -1,11 +1,16 @@
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
 import { type Cluster } from 'qovery-typescript-axios'
 import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
 import { useClusterRunningStatus } from '../hooks/use-cluster-running-status/use-cluster-running-status'
 import { ClusterRunningStatusIndicator } from './cluster-running-status-indicator'
 
 jest.mock('../hooks/use-cluster-running-status/use-cluster-running-status')
+jest.mock('posthog-js/react', () => ({
+  useFeatureFlagVariantKey: jest.fn(),
+}))
 
 const mockUseClusterRunningStatus = useClusterRunningStatus as jest.MockedFunction<typeof useClusterRunningStatus>
+const mockUseFeatureFlagVariantKey = useFeatureFlagVariantKey as jest.MockedFunction<typeof useFeatureFlagVariantKey>
 
 const mockCluster = {
   id: 'cluster-id',
@@ -158,6 +163,25 @@ describe('ClusterRunningStatusIndicator', () => {
 
     expect(screen.getByText('warning')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('should use the warning color for the warning badge chevron', () => {
+    mockUseFeatureFlagVariantKey.mockReturnValue('test')
+    mockUseClusterRunningStatus.mockReturnValue({
+      data: {
+        computed_status: {
+          global_status: 'WARNING',
+          node_warnings: {
+            'node-1': [],
+          },
+        },
+      },
+      isLoading: false,
+    })
+
+    const { container } = renderWithProviders(<ClusterRunningStatusIndicator cluster={mockCluster} />)
+
+    expect(container.querySelector('.text-surface-warning-solid')).toBeInTheDocument()
   })
 
   it.skip('should render "Error" badge with count when global status is ERROR', () => {

--- a/libs/domains/clusters/feature/src/lib/cluster-running-status-indicator/cluster-running-status-indicator.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-running-status-indicator/cluster-running-status-indicator.tsx
@@ -151,7 +151,7 @@ export function ClusterRunningStatusIndicator({
               {Object.entries(s.node_warnings).length === 0 ? (
                 <span className="block h-2 w-2 rounded-full bg-surface-positive-solid" />
               ) : isFeatureFlag ? (
-                <Icon iconName="chevron-down" className="text-surface-positive-solid" />
+                <Icon iconName="chevron-down" className="text-surface-warning-solid" />
               ) : (
                 <span className="block h-2 w-2 rounded-full bg-surface-positive-solid" />
               )}


### PR DESCRIPTION
### Motivation

- The status badge chevron for WARNING state was using a positive/green token which visually contradicted the badge state and design tokens.
- The change ensures the chevron uses the semantic warning color and prevents future regressions with a targeted test.

### Description

- Replace the chevron icon color from `text-surface-positive-solid` to `text-surface-warning-solid` in `ClusterRunningStatusIndicator` (`libs/domains/clusters/feature/src/lib/cluster-running-status-indicator/cluster-running-status-indicator.tsx`).
- Add a regression test that mocks `useFeatureFlagVariantKey` and verifies the warning chevron uses the warning color in `cluster-running-status-indicator.spec.tsx` (`libs/domains/clusters/feature/src/lib/cluster-running-status-indicator/cluster-running-status-indicator.spec.tsx`).
- Add a small test harness mock for `posthog-js/react` and update the assertion to check for the `text-surface-warning-solid` class.

### Testing

- Ran `yarn prettier --write` on the modified files which completed successfully.
- Ran `NX_NO_CLOUD=true yarn nx test domains-clusters-feature --runInBand --testPathPatterns=cluster-running-status-indicator.spec.tsx --skip-nx-cache` and the test suite passed (`3 passed, 9 skipped`).
- Ran `NX_NO_CLOUD=true yarn nx lint domains-clusters-feature --skip-nx-cache` which completed successfully with pre-existing warnings but no errors.
- Verified `git diff --check` (no issues found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6b03dfccd8832bb06a27c954cd2b62)