### PR TITLE
fix(support): preserve Pylon chat session after reload

### DIFF
--- a/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.spec.tsx
+++ b/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.spec.tsx
@@ -68,6 +68,7 @@ describe('useSupportChat', () => {
     expect(window.pylon?.chat_settings).not.toHaveProperty('account_id')
     expect(document.getElementById('pylon-script')).not.toBeNull()
     expect(window.Pylon?.q).toEqual([])
+    expect(window.Pylon?.e).toEqual(expect.any(Function))
   })
 
   it('queues show calls until the pylon script is loaded', () => {

--- a/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.spec.tsx
+++ b/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.spec.tsx
@@ -1,0 +1,80 @@
+import { useAuth0 } from '@auth0/auth0-react'
+import { useMatches, useParams } from '@tanstack/react-router'
+import { renderHook } from '@testing-library/react'
+import { useIntercom } from 'react-use-intercom'
+import { useSupportChat } from './use-support-chat'
+
+jest.mock('@auth0/auth0-react', () => ({
+  useAuth0: jest.fn(),
+}))
+
+jest.mock('@tanstack/react-router', () => ({
+  useMatches: jest.fn(),
+  useParams: jest.fn(),
+}))
+
+jest.mock('react-use-intercom', () => ({
+  useIntercom: jest.fn(),
+}))
+
+describe('useSupportChat', () => {
+  const mockUseAuth0 = jest.mocked(useAuth0)
+  const mockUseMatches = jest.mocked(useMatches)
+  const mockUseParams = jest.mocked(useParams)
+  const mockUseIntercom = jest.mocked(useIntercom)
+  const mockUpdateIntercom = jest.fn()
+  const mockShutdownIntercom = jest.fn()
+  const mockShowIntercomMessenger = jest.fn()
+
+  beforeEach(() => {
+    mockUseAuth0.mockReturnValue({
+      user: {
+        email: 'user@qovery.com',
+        name: 'Qovery User',
+        picture: 'https://example.com/avatar.png',
+        sub: 'auth0|user-123',
+        'https://qovery.com/pylon_hash': 'secure-hash',
+        'https://qovery.com/intercom_hash': 'intercom-hash',
+      },
+    } as ReturnType<typeof useAuth0>)
+
+    mockUseMatches.mockReturnValue([{ routeId: '/_authenticated/organization/$organizationId' }] as ReturnType<
+      typeof useMatches
+    >)
+    mockUseParams.mockReturnValue({ organizationId: 'org_123' } as ReturnType<typeof useParams>)
+    mockUseIntercom.mockReturnValue({
+      update: mockUpdateIntercom,
+      shutdown: mockShutdownIntercom,
+      showMessages: mockShowIntercomMessenger,
+    } as ReturnType<typeof useIntercom>)
+
+    document.body.innerHTML = '<script id="main-script"></script>'
+    delete window.pylon
+    delete window.Pylon
+    jest.clearAllMocks()
+  })
+
+  it('bootstraps pylon with verified user settings and no external account id misuse', () => {
+    renderHook(() => useSupportChat())
+
+    expect(window.pylon?.chat_settings).toEqual({
+      app_id: process.env.NX_PUBLIC_PYLON_APP_ID,
+      email: 'user@qovery.com',
+      name: 'Qovery User',
+      email_hash: 'secure-hash',
+      avatar_url: 'https://example.com/avatar.png',
+      account_external_id: 'org_123',
+    })
+    expect(window.pylon?.chat_settings).not.toHaveProperty('account_id')
+    expect(document.getElementById('pylon-script')).not.toBeNull()
+    expect(window.Pylon?.q).toEqual([])
+  })
+
+  it('queues show calls until the pylon script is loaded', () => {
+    const { result } = renderHook(() => useSupportChat())
+
+    result.current.showChat()
+
+    expect(window.Pylon?.q).toEqual([['show']])
+  })
+})

--- a/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.spec.tsx
+++ b/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.spec.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
-import { useMatches, useParams } from '@tanstack/react-router'
+import { useMatches } from '@tanstack/react-router'
 import { renderHook } from '@testing-library/react'
 import { useIntercom } from 'react-use-intercom'
 import { useSupportChat } from './use-support-chat'
@@ -10,7 +10,6 @@ jest.mock('@auth0/auth0-react', () => ({
 
 jest.mock('@tanstack/react-router', () => ({
   useMatches: jest.fn(),
-  useParams: jest.fn(),
 }))
 
 jest.mock('react-use-intercom', () => ({
@@ -20,7 +19,6 @@ jest.mock('react-use-intercom', () => ({
 describe('useSupportChat', () => {
   const mockUseAuth0 = jest.mocked(useAuth0)
   const mockUseMatches = jest.mocked(useMatches)
-  const mockUseParams = jest.mocked(useParams)
   const mockUseIntercom = jest.mocked(useIntercom)
   const mockUpdateIntercom = jest.fn()
   const mockShutdownIntercom = jest.fn()
@@ -41,7 +39,6 @@ describe('useSupportChat', () => {
     mockUseMatches.mockReturnValue([{ routeId: '/_authenticated/organization/$organizationId' }] as ReturnType<
       typeof useMatches
     >)
-    mockUseParams.mockReturnValue({ organizationId: 'org_123' } as ReturnType<typeof useParams>)
     mockUseIntercom.mockReturnValue({
       update: mockUpdateIntercom,
       shutdown: mockShutdownIntercom,
@@ -54,7 +51,7 @@ describe('useSupportChat', () => {
     jest.clearAllMocks()
   })
 
-  it('bootstraps pylon with verified user settings and no external account id misuse', () => {
+  it('bootstraps pylon with verified user settings and no account override', () => {
     renderHook(() => useSupportChat())
 
     expect(window.pylon?.chat_settings).toEqual({
@@ -63,9 +60,9 @@ describe('useSupportChat', () => {
       name: 'Qovery User',
       email_hash: 'secure-hash',
       avatar_url: 'https://example.com/avatar.png',
-      account_external_id: 'org_123',
     })
     expect(window.pylon?.chat_settings).not.toHaveProperty('account_id')
+    expect(window.pylon?.chat_settings).not.toHaveProperty('account_external_id')
     expect(document.getElementById('pylon-script')).not.toBeNull()
     expect(window.Pylon?.q).toEqual([])
     expect(window.Pylon?.e).toEqual(expect.any(Function))

--- a/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.ts
+++ b/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.ts
@@ -18,6 +18,7 @@ type ChatSettings = IntercomChatSettings | PylonChatSettings
 type PylonCommand = {
   (cmd: 'showTicketForm', formSlug: string): void
   (cmd: 'show' | 'hide'): void
+  e?: (args: unknown[]) => void
   q?: unknown[][]
 }
 
@@ -109,11 +110,10 @@ export function useSupportChat() {
     setPylonChatSettings(settings)
 
     if (!window.Pylon) {
-      const pylonQueue: PylonCommand = ((...args: Parameters<PylonCommand>) => {
-        pylonQueue.q = [...(pylonQueue.q ?? []), args]
-      }) as PylonCommand
+      const pylonQueue = ((...args: unknown[]) => pylonQueue.e?.(args)) as PylonCommand
 
       pylonQueue.q = []
+      pylonQueue.e = (args) => pylonQueue.q?.push(args)
       window.Pylon = pylonQueue
     }
 

--- a/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.ts
+++ b/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.ts
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
-import { useMatches, useParams } from '@tanstack/react-router'
+import { useMatches } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo } from 'react'
 import { type IntercomProps, useIntercom } from 'react-use-intercom'
 
@@ -11,7 +11,6 @@ type PylonChatSettings = {
   email_hash?: string
   name?: string
   avatar_url?: string
-  account_external_id?: string
 }
 
 type ChatSettings = IntercomChatSettings | PylonChatSettings
@@ -33,7 +32,6 @@ declare global {
 
 export function useSupportChat() {
   const { user } = useAuth0()
-  const { organizationId } = useParams({ strict: false })
 
   const { update: updateIntercom, shutdown: shutdownIntercom, showMessages: showIntercomMessenger } = useIntercom()
   const matches = useMatches()
@@ -54,7 +52,6 @@ export function useSupportChat() {
         name: user.name,
         email_hash: user['https://qovery.com/pylon_hash'],
         avatar_url: user.picture,
-        account_external_id: organizationId,
       }
     } else {
       defaultChatParams = {
@@ -66,7 +63,7 @@ export function useSupportChat() {
     }
 
     return defaultChatParams
-  }, [service, user, organizationId])
+  }, [service, user])
 
   const initChat = () => {
     if (service === 'pylon') {

--- a/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.ts
+++ b/libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.ts
@@ -10,22 +10,23 @@ type PylonChatSettings = {
   email?: string
   email_hash?: string
   name?: string
-  account_id?: string
   avatar_url?: string
   account_external_id?: string
 }
 
 type ChatSettings = IntercomChatSettings | PylonChatSettings
+type PylonCommand = {
+  (cmd: 'showTicketForm', formSlug: string): void
+  (cmd: 'show' | 'hide'): void
+  q?: unknown[][]
+}
 
 declare global {
   interface Window {
     pylon?: {
       chat_settings: ChatSettings
     }
-    Pylon?: {
-      (cmd: 'showTicketForm', formSlug: string): void
-      (cmd: 'show' | 'hide'): void
-    }
+    Pylon?: PylonCommand
   }
 }
 
@@ -50,7 +51,6 @@ export function useSupportChat() {
         app_id: process.env.NX_PUBLIC_PYLON_APP_ID,
         email: user.email,
         name: user.name,
-        account_id: user.sub,
         email_hash: user['https://qovery.com/pylon_hash'],
         avatar_url: user.picture,
         account_external_id: organizationId,
@@ -69,18 +69,18 @@ export function useSupportChat() {
 
   const initChat = () => {
     if (service === 'pylon') {
-      insertPylonScriptTag()
+      bootstrapPylon(defaultChatParams)
     }
   }
 
   const whenPylonReady = (callback: () => void) => {
-    if (window.Pylon) {
+    if (isPylonReady()) {
       callback()
       return
     }
 
-    insertPylonScriptTag()
-    document.getElementById('pylon-script')?.addEventListener('load', callback, { once: true })
+    bootstrapPylon(defaultChatParams)
+    callback()
   }
 
   const showChat = () => {
@@ -93,6 +93,31 @@ export function useSupportChat() {
 
   const showPylonForm = (formSlug: string) => {
     whenPylonReady(() => window.Pylon?.('showTicketForm', formSlug))
+  }
+
+  const isPylonReady = () => Boolean(window.Pylon && !window.Pylon.q)
+
+  const setPylonChatSettings = (settings?: ChatSettings) => {
+    if (!settings) return
+
+    window.pylon = {
+      chat_settings: { ...window.pylon?.chat_settings, ...settings },
+    }
+  }
+
+  const bootstrapPylon = (settings?: ChatSettings) => {
+    setPylonChatSettings(settings)
+
+    if (!window.Pylon) {
+      const pylonQueue: PylonCommand = ((...args: Parameters<PylonCommand>) => {
+        pylonQueue.q = [...(pylonQueue.q ?? []), args]
+      }) as PylonCommand
+
+      pylonQueue.q = []
+      window.Pylon = pylonQueue
+    }
+
+    insertPylonScriptTag()
   }
 
   const insertPylonScriptTag = () => {
@@ -115,9 +140,7 @@ export function useSupportChat() {
 
       if (service === 'pylon') {
         shutdownIntercom()
-        window.pylon = {
-          chat_settings: { ...defaultChatParams, ...settings },
-        }
+        setPylonChatSettings({ ...defaultChatParams, ...settings })
       } else {
         window.Pylon?.('hide')
         updateIntercom({ ...defaultChatParams, ...settings })
@@ -128,7 +151,8 @@ export function useSupportChat() {
 
   useEffect(() => {
     if (service === 'pylon') {
-      insertPylonScriptTag()
+      bootstrapPylon(defaultChatParams)
+      return
     }
 
     updateUserInfo(defaultChatParams)


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

- Initialize `window.pylon.chat_settings` before loading the Pylon widget so the authenticated user context is restored after a page reload.
- Queue widget commands while the Pylon script is loading, following Pylon's official bootstrap contract.
- Remove the Pylon account overrides and rely on the verified user identity.
- Add regression tests for the authenticated bootstrap and queued `show` calls.

### Root cause

The widget was initialized with two incompatible account identifiers:

- `account_id` contained the Auth0 user ID instead of a Pylon account ID.
- `account_external_id` forced the Qovery organization ID even when it was not mapped to the user's Pylon account.

This forced the widget into the wrong account context after a hard reload, hiding the user's existing conversations. The script was also loaded without first restoring `window.pylon.chat_settings`.

### Local verification

Tested with the real Pylon widget on localhost:

- Before removing the account override, a hard reload returned an empty chat home.
- After removing it, existing conversations such as `#4584` and `#4583` appeared again.
- The same conversations remained visible after a second hard reload.
- The support widget also reopens correctly after reload.

## Screenshots / Recordings

Not applicable: no visual change.

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console page
- [x] Chat history remains accessible after consecutive hard reloads
- [x] Targeted Jest tests pass
- [x] Changed files formatted with Prettier
- [x] Changed files linted with ESLint (one existing `react-hooks/exhaustive-deps` warning)
- [x] Library TypeScript check passes

Commands:

```bash
yarn jest --runInBand --config libs/shared/util-hooks/jest.config.ts libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.spec.tsx --verbose
yarn eslint libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.ts libs/shared/util-hooks/src/lib/use-support-chat/use-support-chat.spec.tsx
yarn tsc --noEmit -p libs/shared/util-hooks/tsconfig.lib.json
```

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
