### PR TITLE
feat(ci): deploy staging to CloudFront origin bucket (QOV-2108)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,6 +23,9 @@ jobs:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       s3-bucket-name: 'console-staging.qovery.com'
+      # CloudFront migration (QOV-2108): dual-target until the DNS cutover
+      s3-bucket-name-with-cloudfront: 'qovery-console-staging'
+      cloudfront-distribution-id: 'EN3DKJ81R0NBQ'
       cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}
       cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
       nx-cloud-access-token: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}

--- a/.github/workflows/test-build-and-deploy.yml
+++ b/.github/workflows/test-build-and-deploy.yml
@@ -35,6 +35,12 @@ on:
         required: false
       s3-bucket-name:
         required: false
+      # CloudFront migration (QOV-2108): origin bucket behind CloudFront.
+      # When set, builds are also deployed there and index.html is invalidated.
+      s3-bucket-name-with-cloudfront:
+        required: false
+      cloudfront-distribution-id:
+        required: false
       cloudflare-zone:
         required: false
       cloudflare-token:
@@ -208,6 +214,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [nx-main]
     if: ${{ inputs.flow != 'pull-request' }}
+    env:
+      S3_BUCKET_NAME_WITH_CLOUDFRONT: ${{ secrets.s3-bucket-name-with-cloudfront }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.cloudfront-distribution-id }}
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v4
@@ -222,6 +231,22 @@ jobs:
       - name: Copy index.html to S3 last
         run: |
           AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/index.html s3://${{ secrets.s3-bucket-name }}/
+      # Dual-target during the CloudFront migration (QOV-2108): the bucket
+      # below is the OAC origin behind CloudFront; the legacy bucket above
+      # keeps serving the live site until the DNS cutover. Remove the legacy
+      # steps once the migration is complete.
+      - name: Copy assets to CloudFront origin bucket
+        if: env.S3_BUCKET_NAME_WITH_CLOUDFRONT != ''
+        run: |
+          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/ s3://$S3_BUCKET_NAME_WITH_CLOUDFRONT/  --recursive --exclude "index.html"
+      - name: Copy index.html to CloudFront origin bucket last
+        if: env.S3_BUCKET_NAME_WITH_CLOUDFRONT != ''
+        run: |
+          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/index.html s3://$S3_BUCKET_NAME_WITH_CLOUDFRONT/
+      - name: Invalidate CloudFront cached index.html
+        if: env.CLOUDFRONT_DISTRIBUTION_ID != ''
+        run: |
+          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/index.html" "/"
 
   staging-smoke-test:
     name: Staging smoke test


### PR DESCRIPTION
Dual-target deploy during the CloudFront migration: staging builds now also publish to qovery-console-staging (the OAC origin behind CloudFront) and invalidate the cached index.html. The legacy bucket keeps serving console-staging.qovery.com until the DNS cutover.

Production is intentionally unchanged; it opts in later by passing s3-bucket-name-with-cloudfront and cloudfront-distribution-id.

I have updated the frontend-code-push IAM policy to allow pushing to the new buckets (s3:PutObject on the new bucket + cloudfront:CreateInvalidation).

<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: <!-- QOV-2108 -->

<!-- Brief description of what this PR does -->
Deploying in both staging bucket (with the new one using cloudfront)
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
