### PR TITLE
chore(ci): remove legacy S3 deploy after CloudFront cutover (QOV-2108)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -22,12 +22,8 @@ jobs:
       aws-region: ${{ secrets.AWS_REGION }}
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      s3-bucket-name: 'console.qovery.com'
-      # CloudFront migration (QOV-2108): dual-target until the DNS cutover
-      s3-bucket-name-with-cloudfront: 'qovery-console-prod'
+      s3-bucket-name: 'qovery-console-prod'
       cloudfront-distribution-id: 'E28PPG1VH7VZ9R'
-      cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}
-      cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
       nx-cloud-access-token: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,12 +22,8 @@ jobs:
       aws-region: ${{ secrets.AWS_REGION }}
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      s3-bucket-name: 'console-staging.qovery.com'
-      # CloudFront migration (QOV-2108): dual-target until the DNS cutover
-      s3-bucket-name-with-cloudfront: 'qovery-console-staging'
+      s3-bucket-name: 'qovery-console-staging'
       cloudfront-distribution-id: 'EN3DKJ81R0NBQ'
-      cloudflare-zone: ${{ secrets.CLOUDFLARE_ZONE }}
-      cloudflare-token: ${{ secrets.CLOUDFLARE_TOKEN }}
       nx-cloud-access-token: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
       e2e-auth-token: ${{ secrets.E2E_AUTH_TOKEN }}

--- a/.github/workflows/test-build-and-deploy.yml
+++ b/.github/workflows/test-build-and-deploy.yml
@@ -33,17 +33,10 @@ on:
         required: false
       aws-secret-access-key:
         required: false
+      # S3 origin bucket behind CloudFront
       s3-bucket-name:
         required: false
-      # CloudFront migration (QOV-2108): origin bucket behind CloudFront.
-      # When set, builds are also deployed there and index.html is invalidated.
-      s3-bucket-name-with-cloudfront:
-        required: false
       cloudfront-distribution-id:
-        required: false
-      cloudflare-zone:
-        required: false
-      cloudflare-token:
         required: false
       nx-cloud-access-token:
         required: true
@@ -215,7 +208,7 @@ jobs:
     needs: [nx-main]
     if: ${{ inputs.flow != 'pull-request' }}
     env:
-      S3_BUCKET_NAME_WITH_CLOUDFRONT: ${{ secrets.s3-bucket-name-with-cloudfront }}
+      S3_BUCKET_NAME: ${{ secrets.s3-bucket-name }}
       CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.cloudfront-distribution-id }}
     steps:
       - name: Git clone the repository
@@ -227,24 +220,11 @@ jobs:
           merge-multiple: true
       - name: Copy assets to S3
         run: |
-          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/ s3://${{ secrets.s3-bucket-name }}/  --recursive --exclude "index.html"
+          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/ s3://$S3_BUCKET_NAME/  --recursive --exclude "index.html"
       - name: Copy index.html to S3 last
         run: |
-          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/index.html s3://${{ secrets.s3-bucket-name }}/
-      # Dual-target during the CloudFront migration (QOV-2108): the bucket
-      # below is the OAC origin behind CloudFront; the legacy bucket above
-      # keeps serving the live site until the DNS cutover. Remove the legacy
-      # steps once the migration is complete.
-      - name: Copy assets to CloudFront origin bucket
-        if: env.S3_BUCKET_NAME_WITH_CLOUDFRONT != ''
-        run: |
-          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/ s3://$S3_BUCKET_NAME_WITH_CLOUDFRONT/  --recursive --exclude "index.html"
-      - name: Copy index.html to CloudFront origin bucket last
-        if: env.S3_BUCKET_NAME_WITH_CLOUDFRONT != ''
-        run: |
-          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/index.html s3://$S3_BUCKET_NAME_WITH_CLOUDFRONT/
+          AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws s3 cp ./dist/dist/apps/console/index.html s3://$S3_BUCKET_NAME/
       - name: Invalidate CloudFront cached index.html
-        if: env.CLOUDFRONT_DISTRIBUTION_ID != ''
         run: |
           AWS_REGION=${{ secrets.aws-region }} AWS_ACCESS_KEY_ID=${{ secrets.aws-access-key-id }} AWS_SECRET_ACCESS_KEY=${{ secrets.aws-secret-access-key }} aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/index.html" "/"
 


### PR DESCRIPTION
## Summary

Cleanup after the CloudFront migration (QOV-2108, follow-up to #2839 and #2841). The dual-target deploy scaffolding is removed now that CloudFront serves the sites:

- **Legacy bucket deploy removed**: the copy steps targeting `console-staging.qovery.com` / `console.qovery.com` buckets are gone. The CloudFront origin buckets (`qovery-console-staging` / `qovery-console-prod`) are now the only deploy target, passed as plain `s3-bucket-name` (the `s3-bucket-name-with-cloudfront` indirection is dropped).
- **Guards removed**: the `if: env.X != ''` conditions on the CloudFront steps are gone — both deploy flows always set the bucket and distribution.
- **Dead secrets removed**: `cloudflare-zone` / `cloudflare-token` were declared and passed but never used by any step.

## Test plan

- YAML validated locally
- Staging deploy on merge exercises the workflow end to end (smoke test covers `console-staging.qovery.com`)