### PR TITLE
feat(QOV-2126): add cluster troubleshooting buttons

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-card/cluster-card.tsx
@@ -1,9 +1,13 @@
 import { Link, useRouter } from '@tanstack/react-router'
+import posthog from 'posthog-js'
 import { type Cluster, type ClusterStatus } from 'qovery-typescript-axios'
+import { useContext } from 'react'
 import { match } from 'ts-pattern'
+import { DevopsCopilotContext } from '@qovery/shared/devops-copilot/feature'
 import {
   AnimatedGradientText,
   Badge,
+  Button,
   Icon,
   Indicator,
   Link as LinkUI,
@@ -20,6 +24,20 @@ import { ClusterRunningStatusIndicator } from '../cluster-running-status-indicat
 import { useClusterRunningStatusSocket } from '../hooks/use-cluster-running-status-socket/use-cluster-running-status-socket'
 
 function Subtitle({ cluster, clusterDeploymentStatus }: { cluster: Cluster; clusterDeploymentStatus?: ClusterStatus }) {
+  const { setDevopsCopilotOpen, sendMessageRef } = useContext(DevopsCopilotContext)
+
+  const handleLaunchDiagnostic = () => {
+    posthog.capture('ai-copilot-troubleshoot-triggered', {
+      source: 'cluster-card',
+      cluster_id: cluster.id,
+      trigger_reason: 'error',
+    })
+
+    const message = `Why did my cluster deployment fail? (cluster id: ${cluster.id})`
+    setDevopsCopilotOpen(true)
+    sendMessageRef?.current?.(message)
+  }
+
   return match(clusterDeploymentStatus?.status)
     .with('DEPLOYMENT_QUEUED', 'DELETE_QUEUED', 'STOP_QUEUED', 'RESTART_QUEUED', (s) => (
       <span className="text-ssm font-normal text-neutral-subtle">{upperCaseFirstLetter(s).replace('_', ' ')}...</span>
@@ -46,21 +64,46 @@ function Subtitle({ cluster, clusterDeploymentStatus }: { cluster: Cluster; clus
       </LinkUI>
     ))
     .with('BUILD_ERROR', 'DELETE_ERROR', 'DEPLOYMENT_ERROR', 'STOP_ERROR', 'RESTART_ERROR', () => (
-      <LinkUI
-        to="/organization/$organizationId/cluster/$clusterId/cluster-logs"
-        params={{
-          organizationId: cluster.organization.id,
-          clusterId: cluster.id,
-        }}
-        color="red"
-        underline
-        size="sm"
-        className="truncate"
-        onClick={(e) => e.stopPropagation()}
+      <Tooltip
+        classNameContent="group rounded-full cursor-pointer pl-3 pr-1.5"
+        side="bottom"
+        align="center"
+        content={
+          <div
+            className="flex items-center gap-1.5"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              handleLaunchDiagnostic()
+            }}
+          >
+            <Icon iconName="sparkles" iconStyle="solid" className="text-brand" />
+            <span className="text-ssm">Ask for diagnostic</span>
+            <Button
+              size="xs"
+              variant="surface"
+              iconOnly
+              radius="full"
+              className="ml-0.5 group-hover:bg-surface-neutral-componentHover"
+            >
+              <Icon iconName="arrow-right" />
+            </Button>
+          </div>
+        }
       >
-        Last deployment failed
-        <Icon iconName="arrow-up-right" />
-      </LinkUI>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            handleLaunchDiagnostic()
+          }}
+          className="flex max-w-max items-center gap-0.5 text-sm font-medium text-negative transition hover:text-negative-hover hover:underline"
+        >
+          Last deployment failed
+          <Icon iconName="arrow-up-right" />
+        </button>
+      </Tooltip>
     ))
     .with('INVALID_CREDENTIALS', () => (
       <LinkUI

--- a/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.tsx
@@ -1,6 +1,8 @@
 import download from 'downloadjs'
+import posthog from 'posthog-js'
 import { type Cluster, type ClusterLogs, type ClusterStatus } from 'qovery-typescript-axios'
-import { type RefObject } from 'react'
+import { type RefObject, useContext } from 'react'
+import { DevopsCopilotContext } from '@qovery/shared/devops-copilot/feature'
 import { Badge, Button, CopyToClipboardButtonIcon, Icon, Tooltip } from '@qovery/shared/ui'
 import { trimId } from '@qovery/shared/util-js'
 
@@ -12,6 +14,17 @@ export interface ClusterHeaderLogsProps {
 }
 
 export function ClusterHeaderLogs({ cluster, clusterStatus, refScrollSection, data }: ClusterHeaderLogsProps) {
+  const { setDevopsCopilotOpen, sendMessageRef } = useContext(DevopsCopilotContext)
+
+  const hasDeploymentError = [
+    'BUILD_ERROR',
+    'DELETE_ERROR',
+    'DEPLOYMENT_ERROR',
+    'STOP_ERROR',
+    'RESTART_ERROR',
+    'INVALID_CREDENTIALS',
+  ].includes(clusterStatus.status ?? '')
+
   const downloadJSON = () => {
     download(JSON.stringify(data), `data-${Date.now()}.json`, 'text/json;charset=utf-8')
   }
@@ -62,7 +75,25 @@ export function ClusterHeaderLogs({ cluster, clusterStatus, refScrollSection, da
           </span>
         </Tooltip>
       </div>
-      <div>
+      <div className="flex items-center gap-2">
+        {hasDeploymentError && (
+          <Button
+            color="brand"
+            variant="surface"
+            onClick={() => {
+              posthog.capture('ai-copilot-troubleshoot-triggered', {
+                source: 'cluster-logs',
+                cluster_id: cluster.id,
+              })
+              const message = `Why did my cluster deployment fail? (cluster id: ${cluster.id})`
+              setDevopsCopilotOpen(true)
+              sendMessageRef?.current?.(message)
+            }}
+          >
+            <Icon iconName="sparkles" iconStyle="solid" />
+            Launch diagnostic for this error
+          </Button>
+        )}
         <Button
           data-testid="scroll-up-button"
           className="rounded-br-none rounded-tr-none border-r-0"


### PR DESCRIPTION
## Summary

**Issue**: QOV-2126

Add triggers for cluster troubleshooting with the copilot:
- Cluster card: "Last deployment failed" now opens the AI Copilot instead of navigating to logs, with an "Ask for diagnostic" tooltip on hover
- Cluster logs header: "Launch diagnostic for this error" button when cluster has a deployment error

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="1509" height="954" alt="image" src="https://github.com/user-attachments/assets/fd956f3c-f0fd-479c-90eb-5206b20de287" /> | <img width="1509" height="950" alt="image" src="https://github.com/user-attachments/assets/77cba43e-9ebc-41ad-99ef-7350c05d433c" /> <img width="1506" height="952" alt="image" src="https://github.com/user-attachments/assets/2eaf955b-c9a9-46bd-9628-aadd97ad1242" /> |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
