### PR TITLE
fix(audit-logs): support agentic workflow targets

### DIFF
--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
@@ -77,13 +77,14 @@ describe('RowEvent', () => {
     OrganizationEventTargetType.HELM,
     OrganizationEventTargetType.TERRAFORM,
     OrganizationEventTargetType.DATABASE,
+    'AGENTIC_WORKFLOW',
   ])('should render unified service link for %s target', (targetType) => {
     renderWithProviders(
       <RowEvent
         {...props}
         event={{
           ...props.event,
-          target_type: targetType,
+          target_type: targetType as OrganizationEventTargetType,
           target_id: 'service-1',
           target_name: 'service-name',
           project_id: 'project-1',
@@ -96,6 +97,21 @@ describe('RowEvent', () => {
       'href',
       '/organization/1/project/project-1/environment/environment-1/service/service-1/overview'
     )
+  })
+
+  it('should render an unsupported target type without crashing', () => {
+    renderWithProviders(
+      <RowEvent
+        {...props}
+        event={{
+          ...props.event,
+          target_type: 'NEW_TARGET_TYPE' as OrganizationEventTargetType,
+          target_name: 'unsupported-target',
+        }}
+      />
+    )
+
+    expect(screen.getByText('unsupported-target')).not.toHaveAttribute('href')
   })
 
   it.each([

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
@@ -77,14 +77,14 @@ describe('RowEvent', () => {
     OrganizationEventTargetType.HELM,
     OrganizationEventTargetType.TERRAFORM,
     OrganizationEventTargetType.DATABASE,
-    'AGENTIC_WORKFLOW',
+    OrganizationEventTargetType.AGENTIC_WORKFLOW,
   ])('should render unified service link for %s target', (targetType) => {
     renderWithProviders(
       <RowEvent
         {...props}
         event={{
           ...props.event,
-          target_type: targetType as OrganizationEventTargetType,
+          target_type: targetType,
           target_id: 'service-1',
           target_name: 'service-name',
           project_id: 'project-1',

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
@@ -70,13 +70,15 @@ const containerRegistriesSettingsUrl = (organizationId: string) =>
 const helmRepositoriesSettingsUrl = (organizationId: string) =>
   `${organizationSettingsUrl(organizationId)}/helm-repositories`
 
+const AGENTIC_WORKFLOW_TARGET_TYPE = 'AGENTIC_WORKFLOW'
+
 export function RowEvent(props: RowEventProps) {
   const { event, expanded, setExpanded, isPlaceholder, columnsWidth, validTargetIds } = props
   const { organizationId = '' } = useParams({ strict: false })
   const [diffStats, setDiffStats] = useState<DiffStats>({ additions: 0, deletions: 0 })
 
   // Check if target still exists
-  const checkTargetExists = (targetType: OrganizationEventTargetType): boolean => {
+  const checkTargetExists = (targetType: string): boolean => {
     const { target_id } = event
 
     if (!validTargetIds || !target_id) return true // If no validation data, assume exists
@@ -88,6 +90,7 @@ export function RowEvent(props: RowEventProps) {
       case OrganizationEventTargetType.HELM:
       case OrganizationEventTargetType.TERRAFORM:
       case OrganizationEventTargetType.DATABASE:
+      case AGENTIC_WORKFLOW_TARGET_TYPE:
         return validTargetIds.services.has(target_id)
       case OrganizationEventTargetType.PROJECT:
         return validTargetIds.projects.has(target_id)
@@ -98,7 +101,7 @@ export function RowEvent(props: RowEventProps) {
     }
   }
 
-  const renderLink = (targetType: OrganizationEventTargetType) => {
+  const renderLink = (targetType: string) => {
     const { event_type, target_name, project_id, environment_id, target_id } = event
 
     const targetExists = checkTargetExists(targetType)
@@ -117,12 +120,13 @@ export function RowEvent(props: RowEventProps) {
     const generateServiceLink = () =>
       customLink(serviceOverviewUrl(organizationId, project_id!, environment_id!, target_id!))
 
-    const linkConfig: { [key in OrganizationEventTargetType]: () => JSX.Element } = {
+    const linkConfig: Record<string, () => JSX.Element> = {
       [OrganizationEventTargetType.APPLICATION]: generateServiceLink,
       [OrganizationEventTargetType.CONTAINER]: generateServiceLink,
       [OrganizationEventTargetType.JOB]: generateServiceLink,
       [OrganizationEventTargetType.HELM]: generateServiceLink,
       [OrganizationEventTargetType.TERRAFORM]: generateServiceLink,
+      [AGENTIC_WORKFLOW_TARGET_TYPE]: generateServiceLink,
       [OrganizationEventTargetType.ORGANIZATION]: () => customLink(organizationSettingsUrl(organizationId)),
       [OrganizationEventTargetType.MEMBERS_AND_ROLES]: () => customLink(membersSettingsUrl(organizationId)),
       [OrganizationEventTargetType.PROJECT]: () => customLink(projectSettingsUrl(organizationId, target_id!)),
@@ -137,11 +141,12 @@ export function RowEvent(props: RowEventProps) {
       [OrganizationEventTargetType.HELM_REPOSITORY]: () => customLink(helmRepositoriesSettingsUrl(organizationId)),
     }
 
-    if (event_type !== OrganizationEventType.DELETE && targetExists) {
-      return linkConfig[targetType]()
-    } else {
-      return <span className="truncate">{target_name}</span>
+    const renderTargetLink = linkConfig[targetType]
+    if (event_type !== OrganizationEventType.DELETE && targetExists && renderTargetLink) {
+      return renderTargetLink()
     }
+
+    return <span className="truncate">{target_name}</span>
   }
 
   const isEventTypeFailed = event.event_type?.toLowerCase().includes('fail')

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
@@ -70,15 +70,13 @@ const containerRegistriesSettingsUrl = (organizationId: string) =>
 const helmRepositoriesSettingsUrl = (organizationId: string) =>
   `${organizationSettingsUrl(organizationId)}/helm-repositories`
 
-const AGENTIC_WORKFLOW_TARGET_TYPE = 'AGENTIC_WORKFLOW'
-
 export function RowEvent(props: RowEventProps) {
   const { event, expanded, setExpanded, isPlaceholder, columnsWidth, validTargetIds } = props
   const { organizationId = '' } = useParams({ strict: false })
   const [diffStats, setDiffStats] = useState<DiffStats>({ additions: 0, deletions: 0 })
 
   // Check if target still exists
-  const checkTargetExists = (targetType: string): boolean => {
+  const checkTargetExists = (targetType: OrganizationEventTargetType): boolean => {
     const { target_id } = event
 
     if (!validTargetIds || !target_id) return true // If no validation data, assume exists
@@ -90,7 +88,7 @@ export function RowEvent(props: RowEventProps) {
       case OrganizationEventTargetType.HELM:
       case OrganizationEventTargetType.TERRAFORM:
       case OrganizationEventTargetType.DATABASE:
-      case AGENTIC_WORKFLOW_TARGET_TYPE:
+      case OrganizationEventTargetType.AGENTIC_WORKFLOW:
         return validTargetIds.services.has(target_id)
       case OrganizationEventTargetType.PROJECT:
         return validTargetIds.projects.has(target_id)
@@ -101,7 +99,7 @@ export function RowEvent(props: RowEventProps) {
     }
   }
 
-  const renderLink = (targetType: string) => {
+  const renderLink = (targetType: OrganizationEventTargetType) => {
     const { event_type, target_name, project_id, environment_id, target_id } = event
 
     const targetExists = checkTargetExists(targetType)
@@ -120,13 +118,13 @@ export function RowEvent(props: RowEventProps) {
     const generateServiceLink = () =>
       customLink(serviceOverviewUrl(organizationId, project_id!, environment_id!, target_id!))
 
-    const linkConfig: Record<string, () => JSX.Element> = {
+    const linkConfig: Partial<Record<OrganizationEventTargetType, () => JSX.Element>> = {
       [OrganizationEventTargetType.APPLICATION]: generateServiceLink,
       [OrganizationEventTargetType.CONTAINER]: generateServiceLink,
       [OrganizationEventTargetType.JOB]: generateServiceLink,
       [OrganizationEventTargetType.HELM]: generateServiceLink,
       [OrganizationEventTargetType.TERRAFORM]: generateServiceLink,
-      [AGENTIC_WORKFLOW_TARGET_TYPE]: generateServiceLink,
+      [OrganizationEventTargetType.AGENTIC_WORKFLOW]: generateServiceLink,
       [OrganizationEventTargetType.ORGANIZATION]: () => customLink(organizationSettingsUrl(organizationId)),
       [OrganizationEventTargetType.MEMBERS_AND_ROLES]: () => customLink(membersSettingsUrl(organizationId)),
       [OrganizationEventTargetType.PROJECT]: () => customLink(projectSettingsUrl(organizationId, target_id!)),

--- a/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.spec.ts
+++ b/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.spec.ts
@@ -1,0 +1,87 @@
+import { OrganizationEventApi, OrganizationEventTargetType } from 'qovery-typescript-axios'
+import { type SelectedItem } from '@qovery/shared/ui'
+import { computeMenusToDisplay } from './target-type-selection-utils'
+
+const mockGetOrganizationEventTargets = jest.spyOn(OrganizationEventApi.prototype, 'getOrganizationEventTargets')
+
+const targetTypeItem: SelectedItem = {
+  filterKey: 'target_type',
+  item: {
+    value: OrganizationEventTargetType.AGENTIC_WORKFLOW,
+    name: 'Agentic workflow',
+  },
+}
+
+describe('computeMenusToDisplay', () => {
+  beforeEach(() => {
+    mockGetOrganizationEventTargets.mockResolvedValue({
+      data: { targets: [{ id: 'target-1', name: 'Target 1' }] },
+    } as never)
+  })
+
+  it('loads the project, environment, and workflow levels for agentic workflows', async () => {
+    const projects = await computeMenusToDisplay('organization-1', [targetTypeItem], {})
+
+    expect(projects).toEqual({
+      items: [{ value: 'target-1', name: 'Target 1' }],
+      shouldDrillDown: false,
+      filterKey: 'project_id',
+    })
+    expect(mockGetOrganizationEventTargets).toHaveBeenLastCalledWith(
+      'organization-1',
+      undefined,
+      undefined,
+      undefined,
+      OrganizationEventTargetType.AGENTIC_WORKFLOW,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      OrganizationEventTargetType.PROJECT
+    )
+
+    const projectItem: SelectedItem = {
+      filterKey: 'project_id',
+      item: { value: 'project-1', name: 'Project 1' },
+    }
+    const environments = await computeMenusToDisplay('organization-1', [targetTypeItem, projectItem], {})
+
+    expect(environments?.filterKey).toBe('environment_id')
+    expect(mockGetOrganizationEventTargets).toHaveBeenLastCalledWith(
+      'organization-1',
+      undefined,
+      undefined,
+      undefined,
+      OrganizationEventTargetType.AGENTIC_WORKFLOW,
+      undefined,
+      undefined,
+      'project-1',
+      undefined,
+      OrganizationEventTargetType.ENVIRONMENT
+    )
+
+    const environmentItem: SelectedItem = {
+      filterKey: 'environment_id',
+      item: { value: 'environment-1', name: 'Environment 1' },
+    }
+    const workflows = await computeMenusToDisplay('organization-1', [targetTypeItem, projectItem, environmentItem], {})
+
+    expect(workflows).toEqual({
+      items: [{ value: 'target-1', name: 'Target 1', isLeaf: true }],
+      shouldDrillDown: false,
+      filterKey: 'target_id',
+    })
+    expect(mockGetOrganizationEventTargets).toHaveBeenLastCalledWith(
+      'organization-1',
+      undefined,
+      undefined,
+      undefined,
+      OrganizationEventTargetType.AGENTIC_WORKFLOW,
+      undefined,
+      undefined,
+      'project-1',
+      'environment-1',
+      undefined
+    )
+  })
+})

--- a/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.tsx
@@ -7,16 +7,17 @@ import {
   type SelectedItem,
 } from '@qovery/shared/ui'
 
-const SERVICE_TARGET_TYPES: ReadonlySet<string> = new Set([
-  'APPLICATION',
-  'DATABASE',
-  'CONTAINER',
-  'HELM',
-  'JOB',
-  'TERRAFORM',
+const SERVICE_TARGET_TYPES: ReadonlySet<OrganizationEventTargetType> = new Set([
+  OrganizationEventTargetType.AGENTIC_WORKFLOW,
+  OrganizationEventTargetType.APPLICATION,
+  OrganizationEventTargetType.DATABASE,
+  OrganizationEventTargetType.CONTAINER,
+  OrganizationEventTargetType.HELM,
+  OrganizationEventTargetType.JOB,
+  OrganizationEventTargetType.TERRAFORM,
 ])
 
-function getTargetTypeSelected(selectedItems: SelectedItem[]): string | undefined {
+function getTargetTypeSelected(selectedItems: SelectedItem[]): OrganizationEventTargetType | undefined {
   const selectedTargetType = selectedItems.find((selectedItem) => {
     return selectedItem.filterKey === 'target_type'
   })?.item?.value
@@ -24,7 +25,7 @@ function getTargetTypeSelected(selectedItems: SelectedItem[]): string | undefine
   if (selectedTargetType === 'ALL') {
     return undefined
   }
-  return selectedTargetType
+  return selectedTargetType as OrganizationEventTargetType
 }
 
 function getProjectIdSelected(selectedItems: SelectedItem[]): string | undefined {
@@ -128,7 +129,7 @@ export async function computeMenusToDisplay(
     return null
   }
 
-  const isServiceTypeSelected = SERVICE_TARGET_TYPES.has(targetTypeSelected ?? '')
+  const isServiceTypeSelected = SERVICE_TARGET_TYPES.has(targetTypeSelected)
   const projectIdSelected = getProjectIdSelected(selectedItems)
   const environmentIdSelected = getEnvironmentIdSelected(selectedItems)
   const targetIdSelected = getTargetIdSelected(selectedItems)
@@ -136,7 +137,7 @@ export async function computeMenusToDisplay(
   if (isServiceTypeSelected) {
     // Fetch projects if no project selected
     if (!projectIdSelected) {
-      const targetTypeToSearch = targetTypeSelected as OrganizationEventTargetType
+      const targetTypeToSearch = targetTypeSelected
       const projects = await fetchTargetProjects(organizationId, targetTypeToSearch, queryParams)
       return {
         items: projects.map((p) => {
@@ -151,7 +152,7 @@ export async function computeMenusToDisplay(
     }
     // Fetch environments if no environment selected
     if (!environmentIdSelected) {
-      const targetTypeToSearch = targetTypeSelected as OrganizationEventTargetType
+      const targetTypeToSearch = targetTypeSelected
       const environments = await fetchTargetEnvironments(
         organizationId,
         projectIdSelected,
@@ -171,7 +172,7 @@ export async function computeMenusToDisplay(
     }
 
     if (!targetIdSelected) {
-      const targetTypeToSearch = targetTypeSelected as OrganizationEventTargetType
+      const targetTypeToSearch = targetTypeSelected
       const targets = await fetchTargetsAsync(
         organizationId,
         targetTypeToSearch,
@@ -199,7 +200,7 @@ export async function computeMenusToDisplay(
 
   const isEnvironmentSelected = targetTypeSelected === 'ENVIRONMENT'
   if (isEnvironmentSelected) {
-    const targetTypeToSearch = targetTypeSelected as OrganizationEventTargetType
+    const targetTypeToSearch = targetTypeSelected
     if (!projectIdSelected) {
       const projects = await fetchTargetProjects(organizationId, targetTypeToSearch, queryParams)
       return {
@@ -237,7 +238,7 @@ export async function computeMenusToDisplay(
 
   // Global case (selected target type + target id)
   if (targetTypeSelected && !targetIdSelected) {
-    const targetTypeToSearch = targetTypeSelected as OrganizationEventTargetType
+    const targetTypeToSearch = targetTypeSelected
     const targets = await fetchTargetsAsync(organizationId, targetTypeToSearch, queryParams, '')
     return {
       items: targets.map((p) => {
@@ -294,11 +295,7 @@ export async function initializeSelectedItemsFromQueryParams(
     selectedItems.push({ filterKey: 'target_type', item: targetTypeItem })
 
     // Always fetch projects for service types (to show available options at level 1)
-    const projects = await fetchTargetProjects(
-      organizationId,
-      targetTypeValue as OrganizationEventTargetType,
-      queryParams
-    )
+    const projects = await fetchTargetProjects(organizationId, targetTypeValue, queryParams)
 
     // Add projects to navigation stack
     navigationStack.push({ items: projects, filterKey: 'project_id' })
@@ -312,12 +309,7 @@ export async function initializeSelectedItemsFromQueryParams(
         selectedItems.push({ filterKey: 'project_id', item: projectItem })
 
         // Fetch environments (to show available options at level 2)
-        const environments = await fetchTargetEnvironments(
-          organizationId,
-          projectIdValue,
-          targetTypeValue as OrganizationEventTargetType,
-          queryParams
-        )
+        const environments = await fetchTargetEnvironments(organizationId, projectIdValue, targetTypeValue, queryParams)
 
         // Add environments to navigation stack
         navigationStack.push({ items: environments, filterKey: 'environment_id' })
@@ -333,7 +325,7 @@ export async function initializeSelectedItemsFromQueryParams(
             // Fetch targets (to show available options at level 3)
             const targets = await fetchTargetsAsync(
               organizationId,
-              targetTypeValue as OrganizationEventTargetType,
+              targetTypeValue,
               queryParams,
               '',
               projectIdValue,
@@ -368,11 +360,7 @@ export async function initializeSelectedItemsFromQueryParams(
     selectedItems.push({ filterKey: 'target_type', item: targetTypeItem })
 
     // Always fetch projects for service types (to show available options at level 1)
-    const projects = await fetchTargetProjects(
-      organizationId,
-      targetTypeValue as OrganizationEventTargetType,
-      queryParams
-    )
+    const projects = await fetchTargetProjects(organizationId, targetTypeValue, queryParams)
 
     // Add projects to navigation stack
     navigationStack.push({ items: projects, filterKey: 'project_id' })
@@ -386,12 +374,7 @@ export async function initializeSelectedItemsFromQueryParams(
         selectedItems.push({ filterKey: 'project_id', item: projectItem })
 
         // Fetch environments (to show available options at level 2)
-        const environments = await fetchTargetEnvironments(
-          organizationId,
-          projectIdValue,
-          targetTypeValue as OrganizationEventTargetType,
-          queryParams
-        )
+        const environments = await fetchTargetEnvironments(organizationId, projectIdValue, targetTypeValue, queryParams)
 
         // Add environments to navigation stack
         navigationStack.push({ items: environments, filterKey: 'environment_id' })
@@ -416,12 +399,7 @@ export async function initializeSelectedItemsFromQueryParams(
     selectedItems.push({ filterKey: 'target_type', item: targetTypeItem })
   }
 
-  const targets = await fetchTargetsAsync(
-    organizationId,
-    targetTypeValue as OrganizationEventTargetType,
-    queryParams,
-    ''
-  )
+  const targets = await fetchTargetsAsync(organizationId, targetTypeValue, queryParams, '')
 
   // Add targets to navigation stack
   navigationStack.push({ items: targets, filterKey: 'target_id' })

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "mermaid": "11.6.0",
     "monaco-editor": "0.53.0",
     "posthog-js": "1.345.1",
-    "qovery-typescript-axios": "1.1.946",
+    "qovery-typescript-axios": "1.1.947",
     "react": "18.3.1",
     "react-country-flag": "3.0.2",
     "react-datepicker": "4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6343,7 +6343,7 @@ __metadata:
     prettier: 3.2.5
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
-    qovery-typescript-axios: 1.1.946
+    qovery-typescript-axios: 1.1.947
     qovery-ws-typescript-axios: 0.1.644
     react: 18.3.1
     react-country-flag: 3.0.2
@@ -25863,12 +25863,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:1.1.946":
-  version: 1.1.946
-  resolution: "qovery-typescript-axios@npm:1.1.946"
+"qovery-typescript-axios@npm:1.1.947":
+  version: 1.1.947
+  resolution: "qovery-typescript-axios@npm:1.1.947"
   dependencies:
     axios: 1.18.1
-  checksum: cf2fc34d60ae84e38e375e0397417837cc8ea52182f162ba086a4e5403546ea6cbc8bc1ccc4daa0f97cd262fa08bb9cd69cbe21bbc1de96ff922398de56dd119
+  checksum: c3d79edd0cc90645f34e7a38f761a75240536ebd1e9bbd69954ff2cc848dee4b0838eead9f8f2531c0f6982151bef86b658ce0568675fc584b8ff87872b3b2ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

**Issue**: N/A — regression found on AWS tests

Fix the organization audit log view and target filter when agentic workflow events are returned.

- Update `qovery-typescript-axios` to `1.1.947`, which exposes `OrganizationEventTargetType.AGENTIC_WORKFLOW`.
- Treat agentic workflow targets as typed services and link them to their service overview.
- Add agentic workflows to the hierarchical target dropdown: project → environment → workflow.
- Gracefully render unsupported future target types as plain text instead of crashing the entire audit log view.
- Add regression coverage for agentic workflow rendering, unknown target types, and dropdown navigation.

Root cause: the backend returned `AGENTIC_WORKFLOW` audit targets before that value was available in the generated TypeScript client enum. The row renderer assumed every runtime target type existed in its link-renderer map, while the hierarchical dropdown did not classify agentic workflows as services.

## Screenshots / Recordings

Not applicable — behavior-only crash and filter fix.

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

Validation details:
- Row event tests: 22 passed.
- Agentic workflow dropdown hierarchy test: passed.
- Audit logs feature: 37 tests passed, 38 skipped before the dropdown follow-up.
- ESLint: no errors; existing warnings only.
- `git diff --check`: passed.

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code