### PR TITLE
chore(api-token): rename "API Token" wording to "API Tokens" (QOV-2135)

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/settings/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/settings/route.tsx
@@ -87,7 +87,7 @@ function RouteComponent() {
   }
 
   const apiTokenLink = {
-    title: 'API token',
+    title: 'API Tokens',
     to: `${pathSettings}/api-token`,
     icon: 'rectangle-api' as const,
   }

--- a/libs/domains/organizations/feature/src/lib/settings-api-token/settings-api-token.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-api-token/settings-api-token.tsx
@@ -126,7 +126,7 @@ export function SettingsApiToken() {
       <Section className="px-8 pb-8 pt-6">
         <div className="relative">
           <SettingsHeading
-            title="API Token"
+            title="API Tokens"
             description="API token allows third-party applications or script to access your organization via the Qovery API (CI/CD,
               Terraform script, Pulumi etc..). A role can be assigned to limit the Token permission."
           />


### PR DESCRIPTION
## Summary

**Issue**: QOV-2135 — <https://qovery.atlassian.net/browse/QOV-2135>

The API Token settings page displays a **list** of tokens, so the singular wording "API Token" was misleading. This PR pluralizes the page wording to "API Tokens".

Changes:
- Page heading (`SettingsHeading` title) on the API tokens settings page: `API Token` → `API Tokens`
- Settings sidebar navigation label for the same page: `API token` → `API Tokens`

Scope was intentionally kept minimal: unrelated occurrences (the "Policy API Token" beta sub-section, the create/delete token modals and toasts, and other features such as Cloudflare / ArgoCD / MCP API tokens) were left untouched.

## Testing

- [ ] `yarn test` — not run: no Node.js runtime / package manager available in the automation environment.
- [ ] `yarn lint` / `yarn format` — not run for the same reason.

Static verification performed instead:
- Grepped all `*.spec.tsx` / `*.snap` files — no test assertion or snapshot references the two changed strings, so no tests are impacted by this wording change.
- The diff only changes string-literal contents (quoting and indentation preserved).

## PR Checklist

- [x] Conventional Commits title with scope (`chore(api-token): ...`)
- [x] Self-review: diff inspected, change limited to 2 lines across 2 files
- [ ] `yarn test` / `yarn lint` — see Testing note above (toolchain unavailable in agent environment)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)