### PR TITLE
feat(devops-copilot): add copy button on each message

### DIFF
--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.spec.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.spec.tsx
@@ -1,4 +1,4 @@
-import { render, renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
 import type { Message, PlanStep } from '../devops-copilot-panel'
 import { AssistantMessage } from './assistant-message'
 
@@ -50,7 +50,7 @@ describe('AssistantMessage', () => {
 
   describe('rendering', () => {
     it('should render assistant message text', () => {
-      render(<AssistantMessage {...defaultProps} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} />)
 
       expect(screen.getByTestId('render-markdown')).toBeInTheDocument()
       expect(screen.getByTestId('render-markdown')).toHaveTextContent('This is an assistant message')
@@ -65,19 +65,19 @@ describe('AssistantMessage', () => {
     ]
 
     it('should show plan toggle when message has plan steps', () => {
-      render(<AssistantMessage {...defaultProps} plan={mockPlan} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} plan={mockPlan} />)
 
       expect(screen.getByText('Plan steps')).toBeInTheDocument()
     })
 
     it('should not show plan toggle when message has no plan steps', () => {
-      render(<AssistantMessage {...defaultProps} plan={[]} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} plan={[]} />)
 
       expect(screen.queryByText('Plan steps')).not.toBeInTheDocument()
     })
 
     it('should filter plan steps by message ID', () => {
-      render(<AssistantMessage {...defaultProps} plan={mockPlan} showPlans={{ 'msg-1': true }} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} plan={mockPlan} showPlans={{ 'msg-1': true }} />)
 
       expect(screen.getByText('Step 1')).toBeInTheDocument()
       expect(screen.getByText('Step 2')).toBeInTheDocument()
@@ -99,21 +99,21 @@ describe('AssistantMessage', () => {
     })
 
     it('should show plan steps when visible', () => {
-      render(<AssistantMessage {...defaultProps} plan={mockPlan} showPlans={{ 'msg-1': true }} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} plan={mockPlan} showPlans={{ 'msg-1': true }} />)
 
       expect(screen.getByText('Step 1')).toBeInTheDocument()
       expect(screen.getByText('Step 2')).toBeInTheDocument()
     })
 
     it('should hide plan steps when not visible', () => {
-      render(<AssistantMessage {...defaultProps} plan={mockPlan} showPlans={{ 'msg-1': false }} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} plan={mockPlan} showPlans={{ 'msg-1': false }} />)
 
       expect(screen.queryByText('Step 1')).not.toBeInTheDocument()
       expect(screen.queryByText('Step 2')).not.toBeInTheDocument()
     })
 
     it('should display step status', () => {
-      render(<AssistantMessage {...defaultProps} plan={mockPlan} showPlans={{ 'msg-1': true }} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} plan={mockPlan} showPlans={{ 'msg-1': true }} />)
 
       expect(screen.getByText('completed')).toBeInTheDocument()
       expect(screen.getByText('in progress')).toBeInTheDocument()
@@ -122,7 +122,7 @@ describe('AssistantMessage', () => {
 
   describe('voting', () => {
     it('should render voting buttons', () => {
-      render(<AssistantMessage {...defaultProps} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} />)
 
       const buttons = screen.getAllByRole('button')
       expect(buttons.length).toBeGreaterThan(0)
@@ -131,7 +131,7 @@ describe('AssistantMessage', () => {
 
   describe('styling', () => {
     it('should apply group class for hover effects', () => {
-      const { container } = render(<AssistantMessage {...defaultProps} />)
+      const { container } = renderWithProviders(<AssistantMessage {...defaultProps} />)
 
       const messageContainer = container.querySelector('.group')
       expect(messageContainer).toBeInTheDocument()
@@ -142,7 +142,7 @@ describe('AssistantMessage', () => {
         { messageId: 'msg-1', description: 'Completed step', toolName: 'tool1', status: 'completed' },
       ]
 
-      render(<AssistantMessage {...defaultProps} plan={completedPlan} showPlans={{ 'msg-1': true }} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} plan={completedPlan} showPlans={{ 'msg-1': true }} />)
 
       const completedDescription = screen.getByText('Completed step')
       expect(completedDescription).toHaveClass('text-neutral-subtle')
@@ -153,7 +153,7 @@ describe('AssistantMessage', () => {
         { messageId: 'msg-1', description: 'In progress step', toolName: 'tool1', status: 'in_progress' },
       ]
 
-      render(<AssistantMessage {...defaultProps} plan={inProgressPlan} showPlans={{ 'msg-1': true }} />)
+      renderWithProviders(<AssistantMessage {...defaultProps} plan={inProgressPlan} showPlans={{ 'msg-1': true }} />)
 
       const inProgressDescription = screen.getByText('In progress step')
       expect(inProgressDescription).not.toHaveClass('text-neutral-subtle')
@@ -166,7 +166,7 @@ describe('AssistantMessage', () => {
         { messageId: 'msg-1', description: 'Step 1', toolName: 'tool1', status: 'completed' },
       ]
 
-      const { container } = render(<AssistantMessage {...defaultProps} plan={mockPlan} />)
+      const { container } = renderWithProviders(<AssistantMessage {...defaultProps} plan={mockPlan} />)
 
       const planToggle = container.querySelector('.plan-toggle')
       expect(planToggle).toHaveClass('cursor-pointer')

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx'
+import { marked } from 'marked'
 import { useThumbSurvey } from 'posthog-js/react/surveys'
-import { useMemo } from 'react'
-import { Button, Icon } from '@qovery/shared/ui'
+import { useCallback, useMemo, useState } from 'react'
+import { Button, Icon, Tooltip } from '@qovery/shared/ui'
 import { RenderMarkdown } from '../../devops-render-markdown/devops-render-markdown'
 import { getIconClass, getIconName } from '../../utils/icon-utils/icon-utils'
 import type { Message, PlanStep } from '../devops-copilot-panel'
@@ -16,7 +17,39 @@ interface AssistantMessageProps {
   threadId?: string
 }
 
-function VoteButtons({ messageId, threadId }: { messageId: string; threadId?: string }) {
+function CopyRichTextButton({ text }: { text: string }) {
+  const [icon, setIcon] = useState<'copy' | 'check'>('copy')
+
+  const handleCopy = useCallback(async () => {
+    const html = await marked.parse(text)
+    const htmlBlob = new Blob([html], { type: 'text/html' })
+    const plainBlob = new Blob([text], { type: 'text/plain' })
+    await navigator.clipboard.write([new ClipboardItem({ 'text/html': htmlBlob, 'text/plain': plainBlob })])
+    setIcon('check')
+    setTimeout(() => setIcon('copy'), 1000)
+  }, [text])
+
+  return (
+    <Tooltip content="Copy message">
+      <span
+        onClick={handleCopy}
+        className="flex cursor-pointer items-center rounded-md bg-surface-neutral-component px-2 py-1 text-neutral hover:bg-surface-neutral-componentHover"
+      >
+        <Icon iconName={icon} />
+      </span>
+    </Tooltip>
+  )
+}
+
+function MessageActions({
+  messageId,
+  messageText,
+  threadId,
+}: {
+  messageId: string
+  messageText: string
+  threadId?: string
+}) {
   const { respond, response, triggerRef } = useThumbSurvey({
     surveyId: POSTHOG_SURVEY_ID,
     properties: {
@@ -27,6 +60,7 @@ function VoteButtons({ messageId, threadId }: { messageId: string; threadId?: st
 
   return (
     <div ref={triggerRef} className="mt-2 flex gap-2 text-xs text-neutral-400">
+      <CopyRichTextButton text={messageText} />
       <Button
         type="button"
         variant="surface"
@@ -89,7 +123,7 @@ export function AssistantMessage({ message, plan, showPlans, setShowPlans, threa
         </div>
       )}
       {renderedMarkdown}
-      <VoteButtons messageId={message.id} threadId={threadId} />
+      <MessageActions messageId={message.id} messageText={message.text} threadId={threadId} />
     </div>
   )
 }

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx'
-import { marked } from 'marked'
 import { useThumbSurvey } from 'posthog-js/react/surveys'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { Button, Icon, Tooltip } from '@qovery/shared/ui'
 import { RenderMarkdown } from '../../devops-render-markdown/devops-render-markdown'
 import { getIconClass, getIconName } from '../../utils/icon-utils/icon-utils'
@@ -17,17 +16,17 @@ interface AssistantMessageProps {
   threadId?: string
 }
 
-function CopyRichTextButton({ text }: { text: string }) {
+function CopyRichTextButton({ text, contentRef }: { text: string; contentRef: React.RefObject<HTMLDivElement | null> }) {
   const [icon, setIcon] = useState<'copy' | 'check'>('copy')
 
   const handleCopy = useCallback(async () => {
-    const html = await marked.parse(text)
+    const html = contentRef.current?.innerHTML ?? text
     const htmlBlob = new Blob([html], { type: 'text/html' })
     const plainBlob = new Blob([text], { type: 'text/plain' })
     await navigator.clipboard.write([new ClipboardItem({ 'text/html': htmlBlob, 'text/plain': plainBlob })])
     setIcon('check')
     setTimeout(() => setIcon('copy'), 1000)
-  }, [text])
+  }, [text, contentRef])
 
   return (
     <Tooltip content="Copy message">
@@ -44,10 +43,12 @@ function CopyRichTextButton({ text }: { text: string }) {
 function MessageActions({
   messageId,
   messageText,
+  contentRef,
   threadId,
 }: {
   messageId: string
   messageText: string
+  contentRef: React.RefObject<HTMLDivElement | null>
   threadId?: string
 }) {
   const { respond, response, triggerRef } = useThumbSurvey({
@@ -60,7 +61,7 @@ function MessageActions({
 
   return (
     <div ref={triggerRef} className="mt-2 flex gap-2 text-xs text-neutral-400">
-      <CopyRichTextButton text={messageText} />
+      <CopyRichTextButton text={messageText} contentRef={contentRef} />
       <Button
         type="button"
         variant="surface"
@@ -90,6 +91,7 @@ export function AssistantMessage({ message, plan, showPlans, setShowPlans, threa
   const hasPlan = messagePlans.length > 0
   const isPlanVisible = showPlans[message.id]
 
+  const contentRef = useRef<HTMLDivElement>(null)
   const renderedMarkdown = useMemo(() => <RenderMarkdown>{message.text}</RenderMarkdown>, [message.text])
 
   return (
@@ -122,8 +124,8 @@ export function AssistantMessage({ message, plan, showPlans, setShowPlans, threa
           ))}
         </div>
       )}
-      {renderedMarkdown}
-      <MessageActions messageId={message.id} messageText={message.text} threadId={threadId} />
+      <div ref={contentRef}>{renderedMarkdown}</div>
+      <MessageActions messageId={message.id} messageText={message.text} contentRef={contentRef} threadId={threadId} />
     </div>
   )
 }

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
@@ -43,7 +43,6 @@ function CopyRichTextButton({
       onClick={handleCopy}
       className="cursor-pointer font-sans font-medium"
     >
-      Copy
       <Icon iconName={icon} className="text-xs" />
     </Button>
   )

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
@@ -16,7 +16,13 @@ interface AssistantMessageProps {
   threadId?: string
 }
 
-function CopyRichTextButton({ text, contentRef }: { text: string; contentRef: React.RefObject<HTMLDivElement | null> }) {
+function CopyRichTextButton({
+  text,
+  contentRef,
+}: {
+  text: string
+  contentRef: React.RefObject<HTMLDivElement | null>
+}) {
   const [icon, setIcon] = useState<'copy' | 'check'>('copy')
 
   const handleCopy = useCallback(async () => {

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/assistant-message/assistant-message.tsx
@@ -1,7 +1,8 @@
+import { type IconName } from '@fortawesome/fontawesome-common-types'
 import clsx from 'clsx'
 import { useThumbSurvey } from 'posthog-js/react/surveys'
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { Button, Icon, Tooltip } from '@qovery/shared/ui'
+import { Button, Icon } from '@qovery/shared/ui'
 import { RenderMarkdown } from '../../devops-render-markdown/devops-render-markdown'
 import { getIconClass, getIconName } from '../../utils/icon-utils/icon-utils'
 import type { Message, PlanStep } from '../devops-copilot-panel'
@@ -23,7 +24,7 @@ function CopyRichTextButton({
   text: string
   contentRef: React.RefObject<HTMLDivElement | null>
 }) {
-  const [icon, setIcon] = useState<'copy' | 'check'>('copy')
+  const [icon, setIcon] = useState<IconName>('copy')
 
   const handleCopy = useCallback(async () => {
     const html = contentRef.current?.innerHTML ?? text
@@ -35,14 +36,16 @@ function CopyRichTextButton({
   }, [text, contentRef])
 
   return (
-    <Tooltip content="Copy message">
-      <span
-        onClick={handleCopy}
-        className="flex cursor-pointer items-center rounded-md bg-surface-neutral-component px-2 py-1 text-neutral hover:bg-surface-neutral-componentHover"
-      >
-        <Icon iconName={icon} />
-      </span>
-    </Tooltip>
+    <Button
+      type="button"
+      color="neutral"
+      variant="surface"
+      onClick={handleCopy}
+      className="cursor-pointer font-sans font-medium"
+    >
+      Copy
+      <Icon iconName={icon} className="text-xs" />
+    </Button>
   )
 }
 

--- a/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/header/header.tsx
+++ b/libs/shared/devops-copilot/feature/src/lib/devops-copilot-panel/header/header.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { type MutableRefObject } from 'react'
 import { Badge, Button, DropdownMenu, Icon, Tooltip } from '@qovery/shared/ui'
-import { QOVERY_FEEDBACK_URL, QOVERY_FORUM_URL } from '@qovery/shared/util-const'
+import { QOVERY_FEEDBACK_URL } from '@qovery/shared/util-const'
 import type { Message, PlanStep } from '../devops-copilot-panel'
 
 interface HeaderProps {
@@ -82,11 +82,6 @@ export function Header({
                 Show history
               </DropdownMenu.Item>
             )}
-            <DropdownMenu.Item asChild icon={<Icon iconName="user-group" />}>
-              <a href={QOVERY_FORUM_URL} target="_blank" rel="noopener noreferrer">
-                Community forum
-              </a>
-            </DropdownMenu.Item>
             <DropdownMenu.Item asChild icon={<Icon iconName="comment-lines" />}>
               <a href={QOVERY_FEEDBACK_URL} target="_blank" rel="noopener noreferrer">
                 Feedback

--- a/libs/shared/devops-copilot/feature/src/lib/types/marked.d.ts
+++ b/libs/shared/devops-copilot/feature/src/lib/types/marked.d.ts
@@ -1,5 +1,0 @@
-declare module 'marked' {
-  export const marked: {
-    parse(src: string): Promise<string>
-  }
-}

--- a/libs/shared/devops-copilot/feature/src/lib/types/marked.d.ts
+++ b/libs/shared/devops-copilot/feature/src/lib/types/marked.d.ts
@@ -1,0 +1,5 @@
+declare module 'marked' {
+  export const marked: {
+    parse(src: string): Promise<string>
+  }
+}


### PR DESCRIPTION
## Summary

**Issue**: QOV-2141

- Add rich text copy button for copilot messages
- Remove useless "Community forum" link to the header dropdown

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="658" height="766" alt="image" src="https://github.com/user-attachments/assets/445988f4-4428-4f31-8dfc-a180a860321f" /> | <img width="688" height="720" alt="image" src="https://github.com/user-attachments/assets/f840a906-22bb-459f-bf1b-22945ba5a342" /> |

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
