### PR TITLE
fix(organizations): correct casing in Git token empty state copy

### DIFF
--- a/libs/domains/organizations/feature/src/lib/git-token-list/git-token-list.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-list/git-token-list.tsx
@@ -150,7 +150,7 @@ export function GitTokenList() {
         <div className="p-4 text-center">
           <Icon iconName="wave-pulse" className="text-neutral-subtle" />
           <p className="mt-1 text-xs font-medium text-neutral-subtle">
-            No Git Tokens found. <br /> Please add one.
+            No Git tokens found. <br /> Please add one.
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary

**Issue**: trivial copy fix

Corrects the casing of the Git token list empty-state message so "Tokens" follows sentence case, matching the surrounding UI copy.

- `libs/domains/organizations/feature/src/lib/git-token-list/git-token-list.tsx`: change "No Git Tokens found." to "No Git tokens found." in the empty state.

## Screenshots / Recordings

N/A — text-only change.

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

> Note: the Node/Yarn toolchain is not available in the agent environment, so `yarn format`/`yarn test`/`yarn lint` could not be executed. This is a single-word copy change in a JSX string literal; it does not affect the existing `git-token-list` snapshot (which renders the populated list, not the empty state).

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code
