### PR TITLE
fix(organizations): [QOV-2148] rename API Token settings page to "API Tokens"

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/settings/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/settings/route.tsx
@@ -87,7 +87,7 @@ function RouteComponent() {
   }
 
   const apiTokenLink = {
-    title: 'API token',
+    title: 'API tokens',
     to: `${pathSettings}/api-token`,
     icon: 'rectangle-api' as const,
   }

--- a/libs/domains/organizations/feature/src/lib/settings-api-token/settings-api-token.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-api-token/settings-api-token.tsx
@@ -126,7 +126,7 @@ export function SettingsApiToken() {
       <Section className="px-8 pb-8 pt-6">
         <div className="relative">
           <SettingsHeading
-            title="API Token"
+            title="API Tokens"
             description="API token allows third-party applications or script to access your organization via the Qovery API (CI/CD,
               Terraform script, Pulumi etc..). A role can be assigned to limit the Token permission."
           />


### PR DESCRIPTION
## Summary

Fixes a wording typo on the organization **API Tokens** settings page (Jira **QOV-2148** — _[Console] Typo on API Token page_). The page manages a list of API tokens, so the singular "API Token" was replaced with the plural "API Tokens".

- `libs/domains/organizations/feature/src/lib/settings-api-token/settings-api-token.tsx` — page heading `title="API Token"` → `title="API Tokens"`.
- `apps/console/src/routes/_authenticated/organization/$organizationId/settings/route.tsx` — settings navigation label `'API token'` → `'API tokens'`, so the sidebar entry stays consistent with the renamed page (the spotlight already used the plural "API tokens").

## Verification

- ⚠️ Automated checks (`nx format` / `test` / `lint`) could not be run: the agent environment has no Node.js runtime, Yarn, or installed `node_modules`.
- Static verification performed instead:
  - Confirmed the change is a pure string-literal edit (no structural/JSX/TS changes).
  - Confirmed no Jest snapshot references the old `"API Token"` heading.
  - Confirmed the `settings-api-token` test suite does not assert on the changed strings (its assertions — `No Api Token found` and `Delete API token` — are untouched).

## Assumptions

- Scope kept minimal to the page name: only the page heading and its navigation label were pluralized.
- Intentionally **not** changed, as they are not the page title and pluralizing them would alter meaning/grammar: the post-creation modal heading `Your API Token!` (refers to a single token), the create-modal description prose, and the separate `Policy API Token` sub-section.

## Follow-ups

- Please run `nx format`, `nx test`, and `nx lint` in CI to confirm the checks that could not be executed in the agent environment.

## Jira

https://qovery.atlassian.net/browse/QOV-2148