### PR TITLE
fix(service-terraform): truncate long .tfvars file paths in popover

### DIFF
--- a/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-tfvars-popover/terraform-tfvars-popover.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-tfvars-popover/terraform-tfvars-popover.tsx
@@ -58,7 +58,7 @@ const TfvarItem = ({
       onMouseEnter={() => setHoveredRow(file.source)}
       onMouseLeave={() => setHoveredRow(undefined)}
     >
-      <div className="flex items-center gap-4">
+      <div className="flex min-w-0 items-center gap-4">
         <Checkbox
           name={file.source}
           id={file.source}
@@ -66,8 +66,10 @@ const TfvarItem = ({
           onCheckedChange={onCheckedChange}
           className="ml-1 cursor-pointer"
         />
-        <label className="flex cursor-pointer flex-col gap-0.5 text-sm" htmlFor={file.source}>
-          <span className="text-neutral">{file.source}</span>
+        <label className="flex min-w-0 cursor-pointer flex-col gap-0.5 text-sm" htmlFor={file.source}>
+          <Tooltip content={file.source}>
+            <span className="truncate text-neutral">{file.source}</span>
+          </Tooltip>
           <span className="text-xs text-neutral-subtle">{Object.keys(file.variables).length} variables</span>
         </label>
       </div>


### PR DESCRIPTION
## Summary

**Issue**: <!-- QOV-XXXX -->

Long `.tfvars` file paths in the **"Add and order .tfvars files"** popover were rendered without any truncation, so a long path overflowed its row, broke the grid layout and pushed the order input out of view.

**Changes**
- Add `min-w-0` to the row's flex container and label so flex/grid children can shrink below their content width.
- Apply `truncate` to the file source path.
- Wrap the path in a `Tooltip` so the full path is still readable on hover (consistent with the `SourceCell` pattern in `terraform-variables-table`).

## Screenshots / Recordings

_UI-only change; before/after to be attached by reviewer._

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test`
- [ ] `yarn format`
- [ ] `yarn lint`

> Note: automated checks could not be run in the agent environment (no Node/Yarn toolchain available). Please run `yarn format && yarn lint && yarn test` in CI/locally.

## PR Checklist

- [x] Conventional Commit title with scope
- [x] Self-review performed, diff kept focused
- [ ] Designer validation for UI change
