### PR TITLE
fix(cloud-shell): re-render and disconnect issues

### DIFF
--- a/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.spec.tsx
+++ b/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.spec.tsx
@@ -117,6 +117,24 @@ describe('useReactQueryWsSubscription', () => {
     unmount()
   })
 
+  it('should keep the current socket open when an event handler changes', async () => {
+    const initialOnMessage = jest.fn()
+    const updatedOnMessage = jest.fn()
+    const { rerender, unmount } = renderHook(
+      ({ onMessage }) => useReactQueryWsSubscription({ url: 'ws://localhost:1234', onMessage }),
+      { initialProps: { onMessage: initialOnMessage } }
+    )
+    const connection = await server.connected
+
+    rerender({ onMessage: updatedOnMessage })
+
+    expect(connection.readyState).toBe(WebSocket.OPEN)
+    server.send('message after handler update')
+    expect(updatedOnMessage).toHaveBeenCalledWith(useQueryClient(), 'message after handler update')
+    expect(initialOnMessage).not.toHaveBeenCalled()
+    unmount()
+  })
+
   it('should do nothing when not enabled', async () => {
     const onMessage = jest.fn()
     const { unmount } = renderHook(() =>
@@ -139,5 +157,16 @@ describe('useReactQueryWsSubscription', () => {
     unmount()
 
     expect([WebSocket.CLOSED, WebSocket.CLOSING]).toContain(connection.readyState)
+  })
+
+  it('should not call onClose when the component cleans up its own socket', async () => {
+    const onClose = jest.fn()
+    const { unmount } = renderHook(() => useReactQueryWsSubscription({ url: 'ws://localhost:1234', onClose }))
+    await server.connected
+
+    unmount()
+    await server.closed
+
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.ts
+++ b/libs/state/util-queries/src/lib/use-react-query-ws-subscription/use-react-query-ws-subscription.ts
@@ -78,42 +78,54 @@ export function useReactQueryWsSubscription({
   const searchParams = new URLSearchParams(_urlSearchParams)
   const searchParamsString = searchParams.toString()
   const reconnectCount = useRef<number>(0)
+  const queryClientRef = useRef(queryClient)
+  const getAccessTokenSilentlyRef = useRef(getAccessTokenSilently)
+  const callbacksRef = useRef({ onClose, onError, onMessage, onOpen, onQueryInvalidated })
+
+  queryClientRef.current = queryClient
+  getAccessTokenSilentlyRef.current = getAccessTokenSilently
+  callbacksRef.current = { onClose, onError, onMessage, onOpen, onQueryInvalidated }
 
   useEffect(() => {
     if (!enabled) {
       return
     }
+
     let timeout: ReturnType<typeof setTimeout> | undefined
     const controller = new AbortController()
     let canReconnect = shouldReconnect
 
     async function connect({ signal }: { signal: AbortSignal }) {
-      const token = await getAccessTokenSilently()
+      const token = await getAccessTokenSilentlyRef.current()
       if (signal.aborted) {
-        // signal already aborted do nothing
         return
       }
+
       const websocket = new WebSocket(`${url}?${searchParamsString}`, ['v1', 'auth.bearer.' + token])
 
       websocket.onopen = async (event) => {
-        onOpen?.(queryClient, event)
+        callbacksRef.current.onOpen?.(queryClientRef.current, event)
       }
       websocket.onmessage = async (event) => {
         const data = parseWebSocketMessageData(event.data)
 
         if (isInvalidateOperation(data)) {
           const queryKey = [...data.entity, data.id].filter(Boolean)
-          queryClient.invalidateQueries({ queryKey })
-          onQueryInvalidated?.(queryClient, data)
+          queryClientRef.current.invalidateQueries({ queryKey })
+          callbacksRef.current.onQueryInvalidated?.(queryClientRef.current, data)
         } else {
           // XXX: Don't know how to handle it, let the caller handle it
-          onMessage?.(queryClient, data)
+          callbacksRef.current.onMessage?.(queryClientRef.current, data)
         }
       }
       websocket.onerror = async (event) => {
-        onError?.(queryClient, event)
+        callbacksRef.current.onError?.(queryClientRef.current, event)
       }
       websocket.onclose = async (event) => {
+        if (signal.aborted) {
+          return
+        }
+
         if (canReconnect && reconnectCount.current < MAX_RECONNECT_ATTEMPTS) {
           timeout = setTimeout(
             function () {
@@ -125,7 +137,7 @@ export function useReactQueryWsSubscription({
             Math.min(Math.pow(2, reconnectCount.current) * 5000, 100_000)
           )
         } else {
-          onClose?.(queryClient, event)
+          callbacksRef.current.onClose?.(queryClientRef.current, event)
         }
       }
 
@@ -145,20 +157,7 @@ export function useReactQueryWsSubscription({
     return () => {
       controller.abort()
     }
-  }, [
-    queryClient,
-    getAccessTokenSilently,
-    onOpen,
-    onMessage,
-    onQueryInvalidated,
-    onError,
-    onClose,
-    shouldReconnect,
-    MAX_RECONNECT_ATTEMPTS,
-    url,
-    searchParamsString,
-    enabled,
-  ])
+  }, [shouldReconnect, MAX_RECONNECT_ATTEMPTS, url, searchParamsString, enabled])
 }
 
 export default useReactQueryWsSubscription


### PR DESCRIPTION
## fix(cloud-shell): re-render and disconnect issues

**Issue**: [QOV-2092](https://qovery.atlassian.net/browse/QOV-2092)

This PR fixes issues with re-rendering and disconnecting in the cloud shell. Users sometimes experienced issues where the shell would disconnect unexpectedly or not render correctly (e.g. the Request ID was not visible, or a blank black screen was displayed).
These issues were caused by the useEffect dependency array of the hook responsible for the WebSocket connection. 
This PR fixes the issue by removing the unnecessary variables from the dependency array and using refs.

[Slack thread](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1782910570008669)

## Screenshots / Recordings

### Before
https://github.com/user-attachments/assets/db85eb85-6e5f-48da-b891-238d1d7f6d7c

### After
https://github.com/user-attachments/assets/457e2f7a-4006-4c9e-a4b6-3df7b8bead80

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code


[QOV-2092]: https://qovery.atlassian.net/browse/QOV-2092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ