### PR TITLE
feat(opa): Add blocked called in audit logs

### DIFF
--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
@@ -1,4 +1,8 @@
-import { type OrganizationEventResponse, OrganizationEventTargetType } from 'qovery-typescript-axios'
+import {
+  type OrganizationEventResponse,
+  OrganizationEventTargetType,
+  OrganizationEventType,
+} from 'qovery-typescript-axios'
 import { type ReactNode } from 'react'
 import { eventsFactoryMock } from '@qovery/shared/factories'
 import { dateFullFormat } from '@qovery/shared/util-dates'
@@ -146,5 +150,25 @@ describe('RowEvent', () => {
     )
 
     expect(screen.getByText('target-name')).toHaveAttribute('href', href)
+  })
+
+  it.each([
+    [OrganizationEventType.STOP_FAILED, 'Stop Failed'],
+    [OrganizationEventType.DEPLOY_FAILED, 'Deploy Failed'],
+    // Rejected has no `fail` in its name but is a failure: a policy token refused by its policy.
+    [OrganizationEventType.REJECTED, 'Rejected'],
+  ])('should style %s as a failure', (eventType, label) => {
+    renderWithProviders(<RowEvent {...props} event={{ ...props.event, event_type: eventType }} />)
+
+    expect(screen.getByText(label)).toHaveClass('text-negative')
+  })
+
+  it.each([
+    [OrganizationEventType.DEPLOYED, 'Deployed'],
+    [OrganizationEventType.STOPPED, 'Stopped'],
+  ])('should not style %s as a failure', (eventType, label) => {
+    renderWithProviders(<RowEvent {...props} event={{ ...props.event, event_type: eventType }} />)
+
+    expect(screen.getByText(label)).toHaveClass('text-brand')
   })
 })

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
@@ -147,7 +147,10 @@ export function RowEvent(props: RowEventProps) {
     return <span className="truncate">{target_name}</span>
   }
 
-  const isEventTypeFailed = event.event_type?.toLowerCase().includes('fail')
+  // REJECTED carries no `fail` in its name but is one: a policy token whose policy refused the
+  // request. It gets the same negative icon, label colour and diff theme as STOP_FAILED and friends.
+  const isEventTypeFailed =
+    event.event_type?.toLowerCase().includes('fail') || event.event_type === OrganizationEventType.REJECTED
 
   const eventIcon = match(event.event_type)
     .with(

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "mermaid": "11.6.0",
     "monaco-editor": "0.53.0",
     "posthog-js": "1.345.1",
-    "qovery-typescript-axios": "1.1.950",
+    "qovery-typescript-axios": "1.1.951",
     "react": "18.3.1",
     "react-country-flag": "3.0.2",
     "react-datepicker": "4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6343,7 +6343,7 @@ __metadata:
     prettier: 3.2.5
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
-    qovery-typescript-axios: 1.1.950
+    qovery-typescript-axios: 1.1.951
     qovery-ws-typescript-axios: 0.1.644
     react: 18.3.1
     react-country-flag: 3.0.2
@@ -25863,12 +25863,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:1.1.950":
-  version: 1.1.950
-  resolution: "qovery-typescript-axios@npm:1.1.950"
+"qovery-typescript-axios@npm:1.1.951":
+  version: 1.1.951
+  resolution: "qovery-typescript-axios@npm:1.1.951"
   dependencies:
     axios: 1.18.1
-  checksum: aa5f9902a9c3783abfb291bd41485b57e9f6d4520bb2e8bfb35aaaf90f47325a9c8864079e39a8a2b9d371ae8ca48217625b83c3d337c1f0587fca9c6501e628
+  checksum: 378fca2e6d0f1711f55633c4ce8527964bce18be582fc3914f0ee56862ac4c7244185f9bb9b2d3db32e18d14f39a2426271a65058e7c8624f54540a84853edb9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Support REJECTED audit log event type as a "failed" event in the audit logs.