### PR TITLE
chore(release): promote staging to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "mermaid": "11.6.0",
     "monaco-editor": "0.53.0",
     "posthog-js": "1.345.1",
-    "qovery-typescript-axios": "1.1.950",
+    "qovery-typescript-axios": "1.1.952",
     "react": "18.3.1",
     "react-country-flag": "3.0.2",
     "react-datepicker": "4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6343,7 +6343,7 @@ __metadata:
     prettier: 3.2.5
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
-    qovery-typescript-axios: 1.1.950
+    qovery-typescript-axios: 1.1.952
     qovery-ws-typescript-axios: 0.1.644
     react: 18.3.1
     react-country-flag: 3.0.2
@@ -25863,12 +25863,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:1.1.950":
-  version: 1.1.950
-  resolution: "qovery-typescript-axios@npm:1.1.950"
+"qovery-typescript-axios@npm:1.1.952":
+  version: 1.1.952
+  resolution: "qovery-typescript-axios@npm:1.1.952"
   dependencies:
     axios: 1.18.1
-  checksum: aa5f9902a9c3783abfb291bd41485b57e9f6d4520bb2e8bfb35aaaf90f47325a9c8864079e39a8a2b9d371ae8ca48217625b83c3d337c1f0587fca9c6501e628
+  checksum: b959527736b0ce76f8c009708b04f5b74cc6c1f7103f02469346a861c4769a1ddb5bc1370ca922aa613703fdeefed9fc08ee6b8cbcdfa70b1a82717476b0c64c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Opens the production promotion path from staging to main. Merging this PR triggers semantic-release, then the existing production deployment workflow.

Do not squash this PR. Use a merge commit to preserve the original conventional commits for semantic-release.