### PR TITLE
fix(keda): clarify autoscaling label and add doc links

### DIFF
--- a/libs/domains/services/feature/src/lib/application-settings-resources/application-settings-resources.tsx
+++ b/libs/domains/services/feature/src/lib/application-settings-resources/application-settings-resources.tsx
@@ -351,7 +351,7 @@ export function ApplicationSettingsResources({
                 ]
 
                 if ((cloudProvider === 'AWS' || cloudProvider === 'GCP') && isKedaCluster) {
-                  options.push({ label: 'KEDA (Event-driven autoscaling)', value: 'KEDA' })
+                  options.push({ label: 'Event-driven autoscaling (KEDA)', value: 'KEDA' })
                 }
 
                 return (
@@ -369,7 +369,21 @@ export function ApplicationSettingsResources({
                       }
                     }}
                     value={field.value || 'NONE'}
-                    hint="Choose how instances should scale"
+                    hint={
+                      field.value === 'KEDA' ? (
+                        <>
+                          Choose how instances should scale.{' '}
+                          <ExternalLink
+                            size="xs"
+                            href="https://www.qovery.com/docs/configuration/application#keda-event-driven"
+                          >
+                            Learn more about event-driven autoscaling
+                          </ExternalLink>
+                        </>
+                      ) : (
+                        'Choose how instances should scale'
+                      )
+                    }
                   />
                 )
               }}

--- a/libs/domains/services/feature/src/lib/keda/components/keda-scalers-fields.tsx
+++ b/libs/domains/services/feature/src/lib/keda/components/keda-scalers-fields.tsx
@@ -1,6 +1,6 @@
 import posthog from 'posthog-js'
 import { type Control, Controller, type UseFieldArrayReturn, useFormContext } from 'react-hook-form'
-import { Button, CodeEditor, InputText } from '@qovery/shared/ui'
+import { Button, CodeEditor, ExternalLink, InputText } from '@qovery/shared/ui'
 
 export interface KedaScalersFieldsProps {
   control: Control
@@ -83,6 +83,12 @@ export function KedaScalersFields({
             Add scaler
           </Button>
         </div>
+
+        <p className="text-xs text-neutral-subtle">
+          <ExternalLink size="xs" href="https://www.qovery.com/docs/configuration/application#scaler-configuration">
+            Learn more about scaler configuration
+          </ExternalLink>
+        </p>
 
         {scalers.length === 0 && (
           <p className="text-xs text-neutral-subtle">No scalers configured. Click "Add scaler" to get started.</p>


### PR DESCRIPTION
## Summary

Rename "KEDA (Event-driven autoscaling)" to "Event-driven autoscaling (KEDA)" since users are unfamiliar with the KEDA name, and link to the relevant docs for event-driven autoscaling and scaler configuration.

**Issue**: QOV-2167

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
