### PR TITLE
fix(container registries): hide cluster linked

### DIFF
--- a/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.spec.tsx
@@ -38,4 +38,17 @@ describe('SettingsContainerRegistries', () => {
     renderWithProviders(<SettingsContainerRegistries />)
     expect(screen.getByTestId(`registries-list-${mockContainerRegistries[0].id}`)).toBeInTheDocument()
   })
+
+  it('should hide registries linked to a cluster', () => {
+    const [orgRegistry] = containerRegistriesMock(1)
+    const clusterRegistry: ContainerRegistryResponse = {
+      ...containerRegistriesMock(1)[0],
+      id: 'cluster-registry',
+      cluster: { id: '1', name: 'my-cluster' },
+    }
+    mockContainerRegistries = [orgRegistry, clusterRegistry]
+    renderWithProviders(<SettingsContainerRegistries />)
+    expect(screen.getByTestId(`registries-list-${orgRegistry.id}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`registries-list-${clusterRegistry.id}`)).not.toBeInTheDocument()
+  })
 })

--- a/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.tsx
@@ -189,7 +189,6 @@ const ContainerRegistriesList = ({ organizationId }: ContainerRegistriesListProp
     suspense: true,
   })
 
-  // Registries tied to a cluster are managed from the cluster's own settings, not here.
   const organizationRegistries = useMemo(() => {
     return containerRegistries?.filter((registry) => !registry.cluster)
   }, [containerRegistries])

--- a/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.tsx
@@ -189,21 +189,26 @@ const ContainerRegistriesList = ({ organizationId }: ContainerRegistriesListProp
     suspense: true,
   })
 
+  // Registries tied to a cluster are managed from the cluster's own settings, not here.
+  const organizationRegistries = useMemo(() => {
+    return containerRegistries?.filter((registry) => !registry.cluster)
+  }, [containerRegistries])
+
   const usedRegistries = useMemo(() => {
-    return containerRegistries
+    return organizationRegistries
       ?.filter((registry) => (registry.associated_services_count || 0) > 0)
       .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
-  }, [containerRegistries])
+  }, [organizationRegistries])
 
   const unusedRegistries = useMemo(() => {
-    return containerRegistries
+    return organizationRegistries
       ?.filter((registry) => (registry.associated_services_count || 0) === 0)
       .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
-  }, [containerRegistries])
+  }, [organizationRegistries])
 
   const registriesCount = useMemo(() => {
-    return containerRegistries.length
-  }, [containerRegistries])
+    return organizationRegistries.length
+  }, [organizationRegistries])
 
   return registriesCount > 0 ? (
     <>


### PR DESCRIPTION
## Summary

**Issue**: QOV-2172

Container registries auto-provisioned for a cluster (e.g. registry-<cluster-name>) were showing up in /settings/container-registries alongside org-level registries, even though they're managed from the cluster's own settings page. This filters them out of the list (used/unused sections + empty-state count) based on the cluster field returned by the API.

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
