### PR TITLE
chore(release): promote staging to production

### DIFF
--- a/libs/domains/organizations/feature/src/lib/organization-overview/section-open-policy-highlight/section-open-policy-highlight.tsx
+++ b/libs/domains/organizations/feature/src/lib/organization-overview/section-open-policy-highlight/section-open-policy-highlight.tsx
@@ -54,7 +54,7 @@ export function SectionOpenPolicyHighlight() {
 
           <Link
             as="button"
-            to="/organization/$organizationId/settings/api-token"
+            to="/organization/$organizationId/settings/policy-api-token"
             params={{ organizationId }}
             color="brand"
             variant="solid"

--- a/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.spec.tsx
@@ -38,4 +38,17 @@ describe('SettingsContainerRegistries', () => {
     renderWithProviders(<SettingsContainerRegistries />)
     expect(screen.getByTestId(`registries-list-${mockContainerRegistries[0].id}`)).toBeInTheDocument()
   })
+
+  it('should hide registries linked to a cluster', () => {
+    const [orgRegistry] = containerRegistriesMock(1)
+    const clusterRegistry: ContainerRegistryResponse = {
+      ...containerRegistriesMock(1)[0],
+      id: 'cluster-registry',
+      cluster: { id: '1', name: 'my-cluster' },
+    }
+    mockContainerRegistries = [orgRegistry, clusterRegistry]
+    renderWithProviders(<SettingsContainerRegistries />)
+    expect(screen.getByTestId(`registries-list-${orgRegistry.id}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`registries-list-${clusterRegistry.id}`)).not.toBeInTheDocument()
+  })
 })

--- a/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-container-registries/settings-container-registries.tsx
@@ -189,21 +189,25 @@ const ContainerRegistriesList = ({ organizationId }: ContainerRegistriesListProp
     suspense: true,
   })
 
+  const organizationRegistries = useMemo(() => {
+    return containerRegistries?.filter((registry) => !registry.cluster)
+  }, [containerRegistries])
+
   const usedRegistries = useMemo(() => {
-    return containerRegistries
+    return organizationRegistries
       ?.filter((registry) => (registry.associated_services_count || 0) > 0)
       .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
-  }, [containerRegistries])
+  }, [organizationRegistries])
 
   const unusedRegistries = useMemo(() => {
-    return containerRegistries
+    return organizationRegistries
       ?.filter((registry) => (registry.associated_services_count || 0) === 0)
       .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
-  }, [containerRegistries])
+  }, [organizationRegistries])
 
   const registriesCount = useMemo(() => {
-    return containerRegistries.length
-  }, [containerRegistries])
+    return organizationRegistries.length
+  }, [organizationRegistries])
 
   return registriesCount > 0 ? (
     <>


### PR DESCRIPTION
Opens the production promotion path from staging to main. Merging this PR triggers semantic-release, then the existing production deployment workflow.

Do not squash this PR. Use a merge commit to preserve the original conventional commits for semantic-release.