### PR TITLE
fix(mcp): simplify organization MCP settings

### DIFF
--- a/libs/domains/organizations/feature/src/lib/hooks/use-create-mcp-server/use-create-mcp-server.ts
+++ b/libs/domains/organizations/feature/src/lib/hooks/use-create-mcp-server/use-create-mcp-server.ts
@@ -13,7 +13,7 @@ export function useCreateMcpServer() {
     },
     meta: {
       notifyOnSuccess: {
-        title: 'Your MCP connector has been created',
+        title: 'Your MCP has been created',
       },
       notifyOnError: true,
     },

--- a/libs/domains/organizations/feature/src/lib/hooks/use-delete-mcp-server/use-delete-mcp-server.ts
+++ b/libs/domains/organizations/feature/src/lib/hooks/use-delete-mcp-server/use-delete-mcp-server.ts
@@ -13,7 +13,7 @@ export function useDeleteMcpServer() {
     },
     meta: {
       notifyOnSuccess: {
-        title: 'Your MCP connector has been deleted',
+        title: 'Your MCP has been deleted',
       },
       notifyOnError: true,
     },

--- a/libs/domains/organizations/feature/src/lib/hooks/use-edit-mcp-server/use-edit-mcp-server.ts
+++ b/libs/domains/organizations/feature/src/lib/hooks/use-edit-mcp-server/use-edit-mcp-server.ts
@@ -13,7 +13,7 @@ export function useEditMcpServer() {
     },
     meta: {
       notifyOnSuccess: {
-        title: 'Your MCP connector has been updated',
+        title: 'Your MCP has been updated',
       },
       notifyOnError: true,
     },

--- a/libs/domains/organizations/feature/src/lib/mcp-server-create-edit-modal/mcp-server-create-edit-modal.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/mcp-server-create-edit-modal/mcp-server-create-edit-modal.spec.tsx
@@ -28,7 +28,7 @@ describe('McpServerCreateEditModal', () => {
     useEditMcpServerMock.mockReturnValue({ mutateAsync: editMcpServer, isLoading: false })
   })
 
-  it('should create an MCP connector with headers', async () => {
+  it('should create an MCP with headers', async () => {
     const { userEvent } = renderWithProviders(<McpServerCreateEditModal {...props} />)
 
     await userEvent.type(screen.getByLabelText('Name'), 'GitHub')
@@ -37,7 +37,7 @@ describe('McpServerCreateEditModal', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Add header' }))
     await userEvent.type(screen.getByLabelText('Header 1 name'), 'Authorization')
     await userEvent.type(screen.getByLabelText('Header 1 value'), 'Bearer secret')
-    await userEvent.click(screen.getByRole('button', { name: 'Add connector' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add MCP' }))
 
     await waitFor(() =>
       expect(createMcpServer).toHaveBeenCalledWith({
@@ -60,7 +60,7 @@ describe('McpServerCreateEditModal', () => {
     await userEvent.tab()
 
     expect(await screen.findByText('Please enter a valid HTTPS URL.')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Add connector' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Add MCP' })).toBeDisabled()
   })
 
   it('should reject duplicate header names', async () => {
@@ -93,10 +93,10 @@ describe('McpServerCreateEditModal', () => {
 
     expect(screen.getByText('Re-enter every header value')).toBeInTheDocument()
     expect(screen.getByLabelText('Header 1 value')).toHaveAttribute('type', 'password')
-    expect(screen.getByRole('button', { name: 'Save connector' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save MCP' })).toBeDisabled()
 
     await userEvent.type(screen.getByLabelText('Header 1 value'), 'Bearer new-secret')
-    await userEvent.click(screen.getByRole('button', { name: 'Save connector' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Save MCP' }))
 
     await waitFor(() =>
       expect(editMcpServer).toHaveBeenCalledWith({

--- a/libs/domains/organizations/feature/src/lib/mcp-server-create-edit-modal/mcp-server-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/mcp-server-create-edit-modal/mcp-server-create-edit-modal.tsx
@@ -79,21 +79,21 @@ export function McpServerCreateEditModal({ onClose, mcpServer }: McpServerCreate
   return (
     <FormProvider {...methods}>
       <ModalCrud
-        title={isEdit ? 'Edit MCP connector' : 'Add MCP connector'}
+        title={isEdit ? 'Edit MCP' : 'Add MCP'}
         description="Connect a remote HTTPS MCP server to Qovery Agent."
         onClose={onClose}
         onSubmit={onSubmit}
         loading={isCreating || isEditing}
         isEdit={isEdit}
-        submitLabel={isEdit ? 'Save connector' : 'Add connector'}
+        submitLabel={isEdit ? 'Save MCP' : 'Add MCP'}
       >
         <div className="space-y-4">
           <Controller
             name="name"
             control={methods.control}
             rules={{
-              required: 'Please enter a connector name.',
-              validate: (value) => Boolean(value.trim()) || 'Please enter a connector name.',
+              required: 'Please enter an MCP name.',
+              validate: (value) => Boolean(value.trim()) || 'Please enter an MCP name.',
             }}
             render={({ field, fieldState: { error } }) => (
               <InputText

--- a/libs/domains/organizations/feature/src/lib/mcp-server-setting/mcp-server-setting.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/mcp-server-setting/mcp-server-setting.spec.tsx
@@ -25,13 +25,13 @@ describe('McpServerSetting', () => {
     useModalMock.mockReturnValue({ openModal, closeModal })
   })
 
-  it('should create an organization connector and select it', () => {
+  it('should create an organization MCP and select it', () => {
     const onChange = jest.fn()
     renderWithProviders(
       <McpServerSetting mcpServers={[]} organizationId="organization-1" value={[]} onChange={onChange} />
     )
 
-    selectEvent.openMenu(screen.getByLabelText('Organization MCP connectors'))
+    selectEvent.openMenu(screen.getByLabelText('Organization MCPs'))
     screen.getByTestId('input-menu-list-button').click()
 
     expect(openModal).toHaveBeenCalledWith(expect.objectContaining({ options: { fakeModal: true, width: 680 } }))

--- a/libs/domains/organizations/feature/src/lib/mcp-server-setting/mcp-server-setting.tsx
+++ b/libs/domains/organizations/feature/src/lib/mcp-server-setting/mcp-server-setting.tsx
@@ -41,17 +41,17 @@ export function McpServerSetting({ isLoading, mcpServers, organizationId, value,
 
   return (
     <InputSelect
-      label="Organization MCP connectors"
+      label="Organization MCPs"
       value={value}
       options={availableMcpServers.map(({ id, name, url }) => ({ value: id, label: name, description: url }))}
       isMulti
       isSearchable
       isLoading={isLoading}
-      placeholder="Select MCP connectors"
+      placeholder="Select MCPs"
       hint={
         mcpServers.length === 0 && !isLoading ? (
           <span>
-            No connector is configured. Create one here or manage connectors in{' '}
+            No MCP is configured. Create one here or manage MCPs in{' '}
             <a
               className="font-medium text-brand hover:underline"
               href={`/organization/${organizationId}/settings/agents`}
@@ -61,12 +61,12 @@ export function McpServerSetting({ isLoading, mcpServers, organizationId, value,
             .
           </span>
         ) : (
-          'Select the organization connectors this workflow can use.'
+          'Select the organization MCPs this workflow can use.'
         )
       }
       menuListButton={{
-        title: 'Select connectors',
-        label: 'New MCP connector',
+        title: 'Select MCPs',
+        label: 'New MCP',
         onClick: openCreateModal,
       }}
       onChange={(nextValue) => onChange(nextValue as string[])}

--- a/libs/domains/organizations/feature/src/lib/settings-agent-personalization/settings-agent-personalization.spec.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-agent-personalization/settings-agent-personalization.spec.tsx
@@ -60,13 +60,11 @@ describe('SettingsAgentPersonalization', () => {
 
     expect(screen.getByRole('heading', { name: 'Agent personalization' })).toBeInTheDocument()
     expect(screen.getByText('Your personal settings for Qovery Agent')).toBeInTheDocument()
-    expect(
-      screen.getByText('MCP connectors are shared with every Qovery Agent in this organization.')
-    ).toBeInTheDocument()
-    expect(screen.getByText('No MCP connectors')).toBeInTheDocument()
+    expect(screen.getByText('MCPs are shared with every Qovery Agent in this organization.')).toBeInTheDocument()
+    expect(screen.getByText('No MCPs')).toBeInTheDocument()
   })
 
-  it('should render MCP connectors alphabetically with their metadata and actions', () => {
+  it('should render MCPs alphabetically with their URL, description tooltip, and actions', () => {
     useMcpServersMock.mockReturnValue({ data: mcpServers })
 
     renderWithProviders(<SettingsAgentPersonalization />)
@@ -75,7 +73,9 @@ describe('SettingsAgentPersonalization', () => {
     expect(rows[0]).toHaveAttribute('data-testid', 'mcp-server-mcp-alpha')
     expect(rows[1]).toHaveAttribute('data-testid', 'mcp-server-mcp-zulu')
     expect(screen.getByText('https://zulu.example.com/mcp')).toBeInTheDocument()
-    expect(screen.getByText('Authorization')).toBeInTheDocument()
+    expect(screen.queryByText('Authorization')).not.toBeInTheDocument()
+    expect(screen.queryByText('Second connector')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('About Zulu')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Edit Zulu' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Delete Zulu' })).toBeInTheDocument()
   })
@@ -84,7 +84,7 @@ describe('SettingsAgentPersonalization', () => {
     useMcpServersMock.mockReturnValue({ data: mcpServers })
     const { userEvent } = renderWithProviders(<SettingsAgentPersonalization />)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add connector' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add MCP' }))
     await userEvent.click(screen.getByRole('button', { name: 'Edit Zulu' }))
 
     expect(openModal).toHaveBeenCalledTimes(2)
@@ -100,7 +100,7 @@ describe('SettingsAgentPersonalization', () => {
     const confirmation = openModalConfirmation.mock.calls[0][0]
     await confirmation.action()
 
-    expect(confirmation).toEqual(expect.objectContaining({ title: 'Delete MCP connector', name: 'Zulu' }))
+    expect(confirmation).toEqual(expect.objectContaining({ title: 'Delete MCP', name: 'Zulu' }))
     expect(deleteMcpServer).toHaveBeenCalledWith({ organizationId: 'org-1', mcpServerId: 'mcp-zulu' })
   })
 })

--- a/libs/domains/organizations/feature/src/lib/settings-agent-personalization/settings-agent-personalization.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-agent-personalization/settings-agent-personalization.tsx
@@ -6,6 +6,7 @@ import {
   BlockContent,
   Button,
   EmptyState,
+  Heading,
   Icon,
   Section,
   Skeleton,
@@ -58,11 +59,11 @@ function McpServerRow({ organizationId, mcpServer }: McpServerRowProps) {
       data-testid={`mcp-server-${mcpServer.id}`}
       className="flex items-start justify-between gap-4 border-b border-neutral p-4 last:border-0"
     >
-      <div className="min-w-0 space-y-1">
+      <Section className="min-w-0 space-y-1">
         <div className="flex items-center gap-2">
-          <h3 className="min-w-0 text-sm font-medium text-neutral">
+          <Heading level={3} className="min-w-0">
             <Truncate truncateLimit={60} text={mcpServer.name} />
-          </h3>
+          </Heading>
           {mcpServer.description ? (
             <Tooltip content={mcpServer.description}>
               <span className="cursor-pointer" aria-label={`About ${mcpServer.name}`}>
@@ -72,7 +73,7 @@ function McpServerRow({ organizationId, mcpServer }: McpServerRowProps) {
           ) : null}
         </div>
         <p className="break-all font-mono text-xs text-neutral-subtle">{mcpServer.url}</p>
-      </div>
+      </Section>
       <div className="flex shrink-0 gap-2">
         <Button
           size="md"

--- a/libs/domains/organizations/feature/src/lib/settings-agent-personalization/settings-agent-personalization.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-agent-personalization/settings-agent-personalization.tsx
@@ -3,18 +3,17 @@ import { type McpServerResponse } from 'qovery-typescript-axios'
 import { Suspense, useMemo } from 'react'
 import { SettingsHeading } from '@qovery/shared/console-shared'
 import {
-  Badge,
   BlockContent,
   Button,
   EmptyState,
   Icon,
   Section,
   Skeleton,
+  Tooltip,
   Truncate,
   useModal,
   useModalConfirmation,
 } from '@qovery/shared/ui'
-import { dateMediumLocalFormat, dateUTCString, timeAgo } from '@qovery/shared/util-dates'
 import { useDocumentTitle } from '@qovery/shared/util-hooks'
 import { useDeleteMcpServer } from '../hooks/use-delete-mcp-server/use-delete-mcp-server'
 import { useMcpServers } from '../hooks/use-mcp-servers/use-mcp-servers'
@@ -29,8 +28,6 @@ function McpServerRow({ organizationId, mcpServer }: McpServerRowProps) {
   const { openModal, closeModal } = useModal()
   const { openModalConfirmation } = useModalConfirmation()
   const { mutateAsync: deleteMcpServer } = useDeleteMcpServer()
-  const headerNames = Array.from(mcpServer.header_names ?? []).sort((a, b) => a.localeCompare(b))
-
   const onEdit = () => {
     openModal({
       content: <McpServerCreateEditModal mcpServer={mcpServer} onClose={closeModal} />,
@@ -43,7 +40,7 @@ function McpServerRow({ organizationId, mcpServer }: McpServerRowProps) {
 
   const onDelete = () => {
     openModalConfirmation({
-      title: 'Delete MCP connector',
+      title: 'Delete MCP',
       confirmationMethod: 'action',
       name: mcpServer.name,
       action: async () => {
@@ -61,32 +58,20 @@ function McpServerRow({ organizationId, mcpServer }: McpServerRowProps) {
       data-testid={`mcp-server-${mcpServer.id}`}
       className="flex items-start justify-between gap-4 border-b border-neutral p-4 last:border-0"
     >
-      <div className="flex min-w-0 items-start gap-4">
-        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded border border-neutral bg-surface-neutral-subtle">
-          <Icon iconName="plug" iconStyle="regular" className="text-sm text-neutral-subtle" />
-        </span>
-        <div className="min-w-0 space-y-1">
-          <h3 className="text-sm font-medium text-neutral">
+      <div className="min-w-0 space-y-1">
+        <div className="flex items-center gap-2">
+          <h3 className="min-w-0 text-sm font-medium text-neutral">
             <Truncate truncateLimit={60} text={mcpServer.name} />
           </h3>
-          {mcpServer.description ? <p className="text-sm text-neutral-subtle">{mcpServer.description}</p> : null}
-          <p className="break-all font-mono text-xs text-neutral-subtle">{mcpServer.url}</p>
-          {headerNames.length > 0 ? (
-            <div className="flex flex-wrap gap-2 pt-1" aria-label="Configured headers">
-              {headerNames.map((headerName) => (
-                <Badge key={headerName} size="sm" variant="surface" color="neutral" className="font-mono">
-                  {headerName}
-                </Badge>
-              ))}
-            </div>
+          {mcpServer.description ? (
+            <Tooltip content={mcpServer.description}>
+              <span className="cursor-pointer" aria-label={`About ${mcpServer.name}`}>
+                <Icon iconName="circle-info" iconStyle="regular" className="text-neutral-subtle" />
+              </span>
+            </Tooltip>
           ) : null}
-          <p className="pt-1 text-xs text-neutral-subtle">
-            <span title={dateUTCString(mcpServer.updated_at)}>Updated {timeAgo(new Date(mcpServer.updated_at))}</span>
-            <span className="ml-3" title={dateUTCString(mcpServer.created_at)}>
-              Created {dateMediumLocalFormat(mcpServer.created_at)}
-            </span>
-          </p>
         </div>
+        <p className="break-all font-mono text-xs text-neutral-subtle">{mcpServer.url}</p>
       </div>
       <div className="flex shrink-0 gap-2">
         <Button
@@ -116,15 +101,12 @@ function McpServerRow({ organizationId, mcpServer }: McpServerRowProps) {
 
 function McpServersSkeleton() {
   return (
-    <BlockContent title="MCP connectors" classNameContent="p-0">
+    <BlockContent title="MCPs" classNameContent="p-0">
       {[0, 1, 2].map((index) => (
         <div key={index} className="flex items-center justify-between gap-4 border-b border-neutral p-4 last:border-0">
-          <div className="flex items-center gap-4">
-            <Skeleton width={32} height={32} show />
-            <div className="space-y-2">
-              <Skeleton width={180} height={14} show />
-              <Skeleton width={320} height={12} show />
-            </div>
+          <div className="space-y-2">
+            <Skeleton width={180} height={14} show />
+            <Skeleton width={320} height={12} show />
           </div>
           <div className="flex gap-2">
             <Skeleton width={32} height={32} show />
@@ -148,7 +130,7 @@ function McpServersList({ organizationId }: McpServersListProps) {
   )
 
   return sortedMcpServers.length > 0 ? (
-    <BlockContent title="MCP connectors" classNameContent="p-0">
+    <BlockContent title="MCPs" classNameContent="p-0">
       <ul>
         {sortedMcpServers.map((mcpServer) => (
           <McpServerRow key={mcpServer.id} organizationId={organizationId} mcpServer={mcpServer} />
@@ -158,8 +140,8 @@ function McpServersList({ organizationId }: McpServersListProps) {
   ) : (
     <EmptyState
       icon="plug"
-      title="No MCP connectors"
-      description="Add a connector to give Qovery Agent access to tools shared across your organization."
+      title="No MCPs"
+      description="Add an MCP to give Qovery Agent access to tools shared across your organization."
     />
   )
 }
@@ -186,14 +168,12 @@ export function SettingsAgentPersonalization() {
           <SettingsHeading title="Agent personalization" description="Your personal settings for Qovery Agent" />
           <Button className="absolute right-0 top-0" size="md" onClick={onAdd}>
             <Icon iconName="circle-plus" iconStyle="regular" />
-            Add connector
+            Add MCP
           </Button>
         </div>
 
         <div className="max-w-content-with-navigation-left space-y-4">
-          <p className="text-sm text-neutral-subtle">
-            MCP connectors are shared with every Qovery Agent in this organization.
-          </p>
+          <p className="text-sm text-neutral-subtle">MCPs are shared with every Qovery Agent in this organization.</p>
           <Suspense fallback={<McpServersSkeleton />}>
             <McpServersList organizationId={organizationId} />
           </Suspense>

--- a/libs/domains/organizations/feature/src/lib/settings-agent-personalization/settings-agent-personalization.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-agent-personalization/settings-agent-personalization.tsx
@@ -57,7 +57,7 @@ function McpServerRow({ organizationId, mcpServer }: McpServerRowProps) {
   return (
     <li
       data-testid={`mcp-server-${mcpServer.id}`}
-      className="flex items-start justify-between gap-4 border-b border-neutral p-4 last:border-0"
+      className="flex items-center justify-between gap-4 border-b border-neutral p-4 last:border-0"
     >
       <Section className="min-w-0 space-y-1">
         <div className="flex items-center gap-2">

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.spec.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.spec.tsx
@@ -195,7 +195,7 @@ describe('AgenticWorkflowSettings views', () => {
     expect(screen.getByRole('textbox', { name: 'Dockerfile fragment' })).toHaveValue('RUN apt-get update')
   })
 
-  it('links to organization Agent settings when no MCP connector exists', () => {
+  it('links to organization Agent settings when no MCP exists', () => {
     useMcpServersSpy.mockReturnValue({ data: [], isLoading: false })
 
     renderWithProviders(<AgenticWorkflowSettings page="connections" />)

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
@@ -169,7 +169,7 @@ export function AgenticWorkflowSummary() {
 
           <SummarySection title="MCPs" onEdit={() => handleEditSection('connectors')}>
             <SummaryValue
-              label="Organization connectors"
+              label="Organization MCPs"
               value={
                 mcpServers
                   .filter(({ id }) => values.mcpServerIds.includes(id))

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -166,7 +166,7 @@ export function ServiceNew({
         ? [
             {
               title: 'Agentic workflow',
-              description: 'Run an AI workflow with webhooks, MCP connectors, governance, and configured outputs.',
+              description: 'Run an AI workflow with webhooks, MCPs, governance, and configured outputs.',
               icon: <Icon name="AGENTIC_WORKFLOW" width={32} height={32} />,
               link: getServicesPath(organizationId, projectId, environmentId, '/service/create/agentic-workflow'),
               cloud_provider: cloudProvider,


### PR DESCRIPTION
## Summary

**Issue**: N/A

- Rename user-facing “MCP connector” wording to “MCP” across organization settings and Agentic Workflow surfaces.
- Simplify organization MCP rows to show only the name and URL.
- Move optional descriptions into an info tooltip and remove generic MCP icons and secondary metadata.

## Screenshots / Recordings

<img width="1978" height="1119" alt="Screenshot 2026-08-20 at 11 59 11" src="https://github.com/user-attachments/assets/01959a10-a9f1-4818-b3a4-d7d4b6dffe4d" />

<img width="1982" height="1119" alt="Screenshot 2026-08-20 at 11 59 23" src="https://github.com/user-attachments/assets/4b8f84ba-c9c7-4cec-84d9-433bb6a8b892" />


## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [x] Focused Jest tests (9 tests)
- [x] `yarn format`
- [x] ESLint on changed files

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
