### PR TITLE
fix(agentic-workflow): label AI model choice as provider (Anthropic)

### DIFF
--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/ai-model-cards.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/ai-model-cards.tsx
@@ -20,9 +20,9 @@ export function AIModelCards() {
       >
         <span className="flex items-center gap-2 text-sm font-medium text-neutral">
           <img src="/assets/ai-tools/claude.svg" alt="" aria-hidden="true" className="h-5 w-5" />
-          Claude
+          Anthropic
         </span>
-        <span className="text-xs text-neutral-subtle">Anthropic model used by the workflow agent.</span>
+        <span className="text-xs text-neutral-subtle">Claude models used by the workflow agent.</span>
       </button>
       <button
         type="button"

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from '@tanstack/react-router'
 import posthog from 'posthog-js'
+import { AgenticWorkflowModelType } from 'qovery-typescript-axios'
 import { type ReactNode, useEffect, useRef } from 'react'
 import { useMcpServers } from '@qovery/domains/organizations/feature'
 import { useImportVariables } from '@qovery/domains/variables/feature'
@@ -31,6 +32,14 @@ function formatCount(count: number, singular: string) {
 
 function maskValue(value: string) {
   return value.trim() ? '********' : '-'
+}
+
+const modelProviderLabels: Partial<Record<AgenticWorkflowModelType, string>> = {
+  [AgenticWorkflowModelType.CLAUDE]: 'Anthropic',
+}
+
+function getModelProviderLabel(model: AgenticWorkflowModelType) {
+  return modelProviderLabels[model] ?? model
 }
 
 function hasIncompleteGitRepository(values: AgenticWorkflowFormData) {
@@ -162,7 +171,7 @@ export function AgenticWorkflowSummary() {
           </SummarySection>
 
           <SummarySection title="AI model" onEdit={() => handleEditSection('ai-model')}>
-            <SummaryValue label="Model" value={values.aiModel} />
+            <SummaryValue label="Model provider" value={getModelProviderLabel(values.aiModel)} />
             <SummaryValue label="API key" value={maskValue(values.modelApiKey)} />
             <SummaryValue label="Model settings" value={truncateSummary(values.modelSettingsJson)} />
           </SummarySection>


### PR DESCRIPTION
## Summary

**Issue**: N/A — design feedback on the agentic workflow creation flow.

The model selection should read as the **provider**, not the model name.

- `ai-model-cards.tsx`: provider card renamed `Claude` → `Anthropic`; subtitle now `Claude models used by the workflow agent.` (icon and `AgenticWorkflowModelType.CLAUDE` enum unchanged).
- `agentic-workflow-summary.tsx`: summary field label `Model` → `Model provider`, value now displays `Anthropic` via a small enum→provider mapping.

## Testing

- [ ] Changes tested locally in the relevant Console pages and Storybooks
- [ ] `yarn test`
- [ ] `yarn format`
- [ ] `yarn lint`

> Note: JS toolchain (node/yarn) is unavailable in the agent environment, so format/test/lint were not run here. Existing specs assert the enum value (`CLAUDE`) and the `Edit AI model` label, both unchanged; the Anthropic card still matches `/claude/i` via its subtitle.

## PR Checklist

- [x] Conventional Commits title with scope
- [x] Self-review performed (diff inspected)
- [x] Comments kept minimal, in English
- [ ] Designer validation of UI copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)