### PR TITLE
feat(clusters): display spot instances status on nodepool summary card

### DIFF
--- a/libs/domains/clusters/feature/src/lib/nodepools-resources-settings/nodepools-resources-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/nodepools-resources-settings/nodepools-resources-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
 import { type Cluster, WeekdayEnum } from 'qovery-typescript-axios'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, within } from '@qovery/shared/util-tests'
 import { NodepoolsResourcesSettings, formatTimeRange, formatWeekdays, shortenDay } from './nodepools-resources-settings'
 
 const mockCluster = {
@@ -109,6 +109,7 @@ describe('NodepoolsResourcesSettings', () => {
                     start_time: 'PT20:00',
                     duration: 'PT4H',
                   },
+                  spot_enabled: true,
                 },
               },
             },
@@ -125,6 +126,13 @@ describe('NodepoolsResourcesSettings', () => {
       // Check default nodepool values
       expect(screen.getByText('vCPU limit: 12 vCPU;')).toBeInTheDocument()
       expect(screen.getByText('Memory limit: 24 GiB')).toBeInTheDocument()
+
+      // Check spot instances summary (cards are rendered stable first, default second)
+      const [stableSpotSection, defaultSpotSection] = screen
+        .getAllByText('Spot instances')
+        .map((label) => label.parentElement as HTMLElement)
+      expect(within(stableSpotSection).getByText('Enabled')).toBeInTheDocument()
+      expect(within(defaultSpotSection).getByText('Disabled')).toBeInTheDocument()
     })
 
     it('should display cronjob nodepool values', () => {

--- a/libs/domains/clusters/feature/src/lib/nodepools-resources-settings/nodepools-resources-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/nodepools-resources-settings/nodepools-resources-settings.tsx
@@ -89,6 +89,7 @@ interface NodepoolSummaryData {
   limits?: NodepoolLimits
   consolidation?: NodepoolConsolidation
   consolidate_after?: string
+  spot_enabled?: boolean | null
 }
 
 interface NodepoolCardConfig {
@@ -214,15 +215,19 @@ function NodepoolSummaryCard({
         </Button>
       </div>
       <div className="flex justify-between gap-4">
-        <div className="flex w-1/2 flex-col gap-1">
+        <div className="flex w-1/3 flex-col gap-1">
           <span className={SECTION_TITLE_CLASSNAME}>Consolidation</span>
           <div className="flex flex-col justify-between gap-4 text-sm text-neutral">
             <ConsolidationSummary region={region} nodepool={nodepool} start={start} end={end} alwaysOn={alwaysOn} />
           </div>
         </div>
-        <div className="flex w-1/2 flex-col gap-1">
+        <div className="flex w-1/3 flex-col gap-1">
           <span className={SECTION_TITLE_CLASSNAME}>Resources limit</span>
           <ResourceLimitsSummary limits={nodepool?.limits} showGpuLimit={showGpuLimit} />
+        </div>
+        <div className="flex w-1/3 flex-col gap-1">
+          <span className={SECTION_TITLE_CLASSNAME}>Spot instances</span>
+          <span>{nodepool?.spot_enabled ? 'Enabled' : 'Disabled'}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

**Issue**: [QOV-2157](https://qovery.atlassian.net/browse/QOV-2157) — follow-up to #2885

#2885 added the per-pool "Enable spot instances" toggle inside the nodepool edit modal, but the read-only nodepool summary card (Consolidation / Resources limit) did not surface the spot status — you had to open the modal to see it.

The summary card now shows a third **Spot instances** section displaying **Enabled** / **Disabled**, on all four nodepool cards (stable, default, GPU, cronjob — matching the modal, where the toggle exists on every pool). The three sections share the row evenly (`w-1/3` each).

### Key implementation details

- `NodepoolSummaryData.spot_enabled` is typed `boolean | null` to match the generated API types, where per-pool `spot_enabled` is nullable (`null`/absent means "inherits the deprecated top-level flag").
- A nullish value renders as **Disabled**, consistent with the modal's `?? false`. This is safe in practice: the settings route pre-normalizes per-pool values from the deprecated global flag via `normalizeKarpenterSpot` before the form mounts, so the card only ever sees concrete booleans.
- The card reads the same watched form values the modal writes, so it updates immediately after Confirm — no extra wiring.
- Spec assertions are scoped per card with `within()` (the consolidation summary renders an identical bare "Disabled" span, so unscoped queries would be fragile).

## Screenshots / Recordings

<img width="702" height="455" alt="image" src="https://github.com/user-attachments/assets/bf9f51a8-19c4-4f98-a781-3ab6e545100a" />

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots) — 31 passed on the nodepools-resources-settings suites
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code


[QOV-2157]: https://qovery.atlassian.net/browse/QOV-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ