### PR TITLE
feat(serviceCatalog): add support for EXTERNAL provider type

### DIFF
--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
@@ -14,6 +14,7 @@ describe('isBlueprintCompatibleWithCluster', () => {
   it.each([
     ['AWS', 'AWS', true],
     ['SCW', 'AWS', false],
+    ['EXTERNAL', 'AWS', true],
     ['HELM', 'AWS', true],
     ['SCW', undefined, true],
   ])('returns %s for a %s cluster as %s', (blueprintProvider, clusterCloudProvider, expected) => {

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
@@ -8,7 +8,7 @@ const BLUEPRINT_NAME_PARTS: Record<string, string> = {
   s3: 'S3',
 }
 
-const CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS = new Set(['HELM'])
+const CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS = new Set(['EXTERNAL', 'HELM'])
 
 export function formatBlueprintName(name: string): string {
   return name


### PR DESCRIPTION
## Summary

This PR adds the support for the `EXTERNAL` provider type for the Service catalog's Blueprints.
When a blueprint has an `EXTERNAL` provider, it will be displayed regardless of the cluster's cloud provider the env is associated to.

Side note: We already have an exception for Helm. Once this PR will be merged, we will update the Helm blueprints so they move from the `HELM` provider to `EXTERNAL`.

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code
