### PR TITLE
chore(release): promote staging to production

### DIFF
--- a/libs/domains/clusters/feature/src/lib/nodepools-resources-settings/nodepools-resources-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/nodepools-resources-settings/nodepools-resources-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
 import { type Cluster, WeekdayEnum } from 'qovery-typescript-axios'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, within } from '@qovery/shared/util-tests'
 import { NodepoolsResourcesSettings, formatTimeRange, formatWeekdays, shortenDay } from './nodepools-resources-settings'
 
 const mockCluster = {
@@ -109,6 +109,7 @@ describe('NodepoolsResourcesSettings', () => {
                     start_time: 'PT20:00',
                     duration: 'PT4H',
                   },
+                  spot_enabled: true,
                 },
               },
             },
@@ -125,6 +126,13 @@ describe('NodepoolsResourcesSettings', () => {
       // Check default nodepool values
       expect(screen.getByText('vCPU limit: 12 vCPU;')).toBeInTheDocument()
       expect(screen.getByText('Memory limit: 24 GiB')).toBeInTheDocument()
+
+      // Check spot instances summary (cards are rendered stable first, default second)
+      const [stableSpotSection, defaultSpotSection] = screen
+        .getAllByText('Spot instances')
+        .map((label) => label.parentElement as HTMLElement)
+      expect(within(stableSpotSection).getByText('Enabled')).toBeInTheDocument()
+      expect(within(defaultSpotSection).getByText('Disabled')).toBeInTheDocument()
     })
 
     it('should display cronjob nodepool values', () => {

--- a/libs/domains/clusters/feature/src/lib/nodepools-resources-settings/nodepools-resources-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/nodepools-resources-settings/nodepools-resources-settings.tsx
@@ -89,6 +89,7 @@ interface NodepoolSummaryData {
   limits?: NodepoolLimits
   consolidation?: NodepoolConsolidation
   consolidate_after?: string
+  spot_enabled?: boolean | null
 }
 
 interface NodepoolCardConfig {
@@ -214,15 +215,19 @@ function NodepoolSummaryCard({
         </Button>
       </div>
       <div className="flex justify-between gap-4">
-        <div className="flex w-1/2 flex-col gap-1">
+        <div className="flex w-1/3 flex-col gap-1">
           <span className={SECTION_TITLE_CLASSNAME}>Consolidation</span>
           <div className="flex flex-col justify-between gap-4 text-sm text-neutral">
             <ConsolidationSummary region={region} nodepool={nodepool} start={start} end={end} alwaysOn={alwaysOn} />
           </div>
         </div>
-        <div className="flex w-1/2 flex-col gap-1">
+        <div className="flex w-1/3 flex-col gap-1">
           <span className={SECTION_TITLE_CLASSNAME}>Resources limit</span>
           <ResourceLimitsSummary limits={nodepool?.limits} showGpuLimit={showGpuLimit} />
+        </div>
+        <div className="flex w-1/3 flex-col gap-1">
+          <span className={SECTION_TITLE_CLASSNAME}>Spot instances</span>
+          <span>{nodepool?.spot_enabled ? 'Enabled' : 'Disabled'}</span>
         </div>
       </div>
     </div>

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
@@ -14,6 +14,7 @@ describe('isBlueprintCompatibleWithCluster', () => {
   it.each([
     ['AWS', 'AWS', true],
     ['SCW', 'AWS', false],
+    ['EXTERNAL', 'AWS', true],
     ['HELM', 'AWS', true],
     ['SCW', undefined, true],
   ])('returns %s for a %s cluster as %s', (blueprintProvider, clusterCloudProvider, expected) => {

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
@@ -8,7 +8,7 @@ const BLUEPRINT_NAME_PARTS: Record<string, string> = {
   s3: 'S3',
 }
 
-const CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS = new Set(['HELM'])
+const CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS = new Set(['EXTERNAL', 'HELM'])
 
 export function formatBlueprintName(name: string): string {
   return name

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/ai-model-cards.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/ai-model-cards.tsx
@@ -20,9 +20,9 @@ export function AIModelCards() {
       >
         <span className="flex items-center gap-2 text-sm font-medium text-neutral">
           <img src="/assets/ai-tools/claude.svg" alt="" aria-hidden="true" className="h-5 w-5" />
-          Claude
+          Anthropic
         </span>
-        <span className="text-xs text-neutral-subtle">Anthropic model used by the workflow agent.</span>
+        <span className="text-xs text-neutral-subtle">Claude models used by the workflow agent.</span>
       </button>
       <button
         type="button"

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from '@tanstack/react-router'
 import posthog from 'posthog-js'
+import { AgenticWorkflowModelType } from 'qovery-typescript-axios'
 import { type ReactNode, useEffect, useRef } from 'react'
 import { useMcpServers } from '@qovery/domains/organizations/feature'
 import { useImportVariables } from '@qovery/domains/variables/feature'
@@ -31,6 +32,14 @@ function formatCount(count: number, singular: string) {
 
 function maskValue(value: string) {
   return value.trim() ? '********' : '-'
+}
+
+const modelProviderLabels: Partial<Record<AgenticWorkflowModelType, string>> = {
+  [AgenticWorkflowModelType.CLAUDE]: 'Anthropic',
+}
+
+function getModelProviderLabel(model: AgenticWorkflowModelType) {
+  return modelProviderLabels[model] ?? model
 }
 
 function hasIncompleteGitRepository(values: AgenticWorkflowFormData) {
@@ -162,7 +171,7 @@ export function AgenticWorkflowSummary() {
           </SummarySection>
 
           <SummarySection title="AI model" onEdit={() => handleEditSection('ai-model')}>
-            <SummaryValue label="Model" value={values.aiModel} />
+            <SummaryValue label="Model provider" value={getModelProviderLabel(values.aiModel)} />
             <SummaryValue label="API key" value={maskValue(values.modelApiKey)} />
             <SummaryValue label="Model settings" value={truncateSummary(values.modelSettingsJson)} />
           </SummarySection>


### PR DESCRIPTION
Opens the production promotion path from staging to main. Merging this PR triggers semantic-release, then the existing production deployment workflow.

Do not squash this PR. Use a merge commit to preserve the original conventional commits for semantic-release.