### PR TITLE
feat(terraform): move variables to service variables tab

### DIFF
--- a/apps/console/src/routeTree.gen.ts
+++ b/apps/console/src/routeTree.gen.ts
@@ -167,11 +167,11 @@ import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnviron
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugPortsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/ports'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugHealthChecksRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/health-checks'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugGeneralRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/general'
+import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesBuiltInRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/built-in'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideFileRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-file'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-arguments'
-import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformConfigurationRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformArgumentsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-arguments'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsStorageRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/storage'
@@ -1490,6 +1490,15 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
         AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugRouteRoute,
     } as any,
   )
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRoute =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRouteImport.update(
+    {
+      id: '/terraform',
+      path: '/terraform',
+      getParentRoute: () =>
+        AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesRouteRoute,
+    } as any,
+  )
 const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRoute =
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRouteImport.update(
     {
@@ -1522,15 +1531,6 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
     {
       id: '/values-override-arguments',
       path: '/values-override-arguments',
-      getParentRoute: () =>
-        AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsRouteRoute,
-    } as any,
-  )
-const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRoute =
-  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRouteImport.update(
-    {
-      id: '/terraform-variables',
-      path: '/terraform-variables',
       getParentRoute: () =>
         AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsRouteRoute,
     } as any,
@@ -1958,11 +1958,11 @@ export interface FileRoutesByFullPath {
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/storage': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsStorageRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-arguments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformArgumentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformConfigurationRoute
-  '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-arguments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-file': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideFileRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/built-in': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesBuiltInRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/general': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugGeneralRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/health-checks': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugHealthChecksRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/ports': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugPortsRoute
@@ -2133,11 +2133,11 @@ export interface FileRoutesByTo {
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/storage': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsStorageRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-arguments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformArgumentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformConfigurationRoute
-  '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-arguments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-file': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideFileRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/built-in': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesBuiltInRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/general': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugGeneralRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/health-checks': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugHealthChecksRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/ports': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugPortsRoute
@@ -2330,11 +2330,11 @@ export interface FileRoutesById {
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/storage': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsStorageRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-arguments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformArgumentsRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformConfigurationRoute
-  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-arguments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-file': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideFileRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/built-in': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesBuiltInRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRoute
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/general': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugGeneralRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/health-checks': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugHealthChecksRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/ports': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugPortsRoute
@@ -2528,11 +2528,11 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/storage'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-arguments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration'
-    | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-arguments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-file'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/built-in'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/general'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/health-checks'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/ports'
@@ -2703,11 +2703,11 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/storage'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-arguments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration'
-    | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-arguments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-file'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/built-in'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/general'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/health-checks'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/ports'
@@ -2899,11 +2899,11 @@ export interface FileRouteTypes {
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/storage'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-arguments'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration'
-    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-arguments'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-file'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/built-in'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets'
+    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/general'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/health-checks'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/$slug/ports'
@@ -4074,6 +4074,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugGeneralRouteImport
       parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateSlugRouteRoute
     }
+    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform': {
+      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform'
+      path: '/terraform'
+      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesRouteRoute
+    }
     '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets': {
       id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/external-secrets'
       path: '/external-secrets'
@@ -4100,13 +4107,6 @@ declare module '@tanstack/react-router' {
       path: '/values-override-arguments'
       fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/values-override-arguments'
       preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRouteImport
-      parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsRouteRoute
-    }
-    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables': {
-      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables'
-      path: '/terraform-variables'
-      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables'
-      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRouteImport
       parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsRouteRoute
     }
     '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-configuration': {
@@ -4661,7 +4661,6 @@ interface AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvi
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsStorageRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsStorageRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformArgumentsRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformArgumentsRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformConfigurationRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformConfigurationRoute
-  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideFileRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideFileRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsIndexRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsIndexRoute
@@ -4705,8 +4704,6 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
       AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformArgumentsRoute,
     AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformConfigurationRoute:
       AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformConfigurationRoute,
-    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRoute:
-      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsTerraformVariablesRoute,
     AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRoute:
       AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideArgumentsRoute,
     AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdSettingsValuesOverrideFileRoute:
@@ -4723,6 +4720,7 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
 interface AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesRouteRouteChildren {
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesBuiltInRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesBuiltInRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRoute
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesIndexRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesIndexRoute
 }
 
@@ -4732,6 +4730,8 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
       AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesBuiltInRoute,
     AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRoute:
       AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesExternalSecretsRoute,
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRoute:
+      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesTerraformRoute,
     AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesIndexRoute:
       AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdVariablesIndexRoute,
   }

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/route.tsx
@@ -116,6 +116,7 @@ function RouteComponent() {
               </Suspense>
             </div>
           </div>
+          <div id="service-variables-actions" className="mt-6 flex justify-end empty:hidden" />
         </div>
       </Section>
     </div>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/route.tsx
@@ -36,6 +36,14 @@ const tabs = [
   },
 ]
 
+const terraformTab = {
+  id: 'terraform',
+  label: 'Terraform variables',
+  iconName: 'key' as IconName,
+  routeId:
+    '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform',
+}
+
 const OutletLoader = () => (
   <div className="flex h-64 items-center justify-center">
     <LoaderSpinner className="w-6" />
@@ -74,7 +82,8 @@ function RouteComponent() {
 
   if (shouldRedirect) return null
 
-  const activeTabId = tabs.find((tab) => matchRoute({ to: tab.routeId }))?.id
+  const serviceTabs = service?.serviceType === 'TERRAFORM' ? [...tabs, terraformTab] : tabs
+  const activeTabId = serviceTabs.find((tab) => matchRoute({ to: tab.routeId }))?.id
 
   return (
     <div className="container mx-auto flex min-h-page-container flex-col pb-16 pt-6">
@@ -90,7 +99,7 @@ function RouteComponent() {
           <div className="relative overflow-hidden rounded-t-lg border-x border-t border-neutral bg-surface-neutral-subtle">
             <div className="bg-surface-neutral-subtle px-4 pb-2">
               <Navbar.Root activeId={activeTabId} className="relative">
-                {tabs.map((tab) => (
+                {serviceTabs.map((tab) => (
                   <Navbar.Item key={tab.id} id={tab.id} to={tab.routeId}>
                     <Icon iconName={tab.iconName} iconStyle="regular" />
                     <TabLabel label={tab.label} isNew={tab.id === 'external-secrets'} />

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/route.tsx
@@ -99,12 +99,21 @@ function RouteComponent() {
           <div className="relative overflow-hidden rounded-t-lg border-x border-t border-neutral bg-surface-neutral-subtle">
             <div className="bg-surface-neutral-subtle px-4 pb-2">
               <Navbar.Root activeId={activeTabId} className="relative">
-                {serviceTabs.map((tab) => (
+                {tabs.map((tab) => (
                   <Navbar.Item key={tab.id} id={tab.id} to={tab.routeId}>
                     <Icon iconName={tab.iconName} iconStyle="regular" />
                     <TabLabel label={tab.label} isNew={tab.id === 'external-secrets'} />
                   </Navbar.Item>
                 ))}
+                {service?.serviceType === 'TERRAFORM' && (
+                  <>
+                    <div aria-hidden className="mx-4 h-5 border-l border-neutral" />
+                    <Navbar.Item id={terraformTab.id} to={terraformTab.routeId}>
+                      <Icon iconName={terraformTab.iconName} iconStyle="regular" />
+                      <TabLabel label={terraformTab.label} />
+                    </Navbar.Item>
+                  </>
+                )}
               </Navbar.Root>
             </div>
           </div>
@@ -116,7 +125,6 @@ function RouteComponent() {
               </Suspense>
             </div>
           </div>
-          <div id="service-variables-actions" className="mt-6 flex justify-end empty:hidden" />
         </div>
       </Section>
     </div>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
@@ -61,7 +61,7 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
   return (
     <>
       <div className="bg-background">
-        <TerraformVariablesTable embedded />
+        <TerraformVariablesTable className="rounded-none border-0" />
       </div>
       {actionsContainer &&
         createPortal(

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
@@ -61,7 +61,7 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
   return (
     <>
       <div className="bg-background">
-        <TerraformVariablesTable className="rounded-none border-0" />
+        <TerraformVariablesTable embedded />
       </div>
       {actionsContainer &&
         createPortal(

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useParams } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { FormProvider, useForm, useFormContext } from 'react-hook-form'
 import { match } from 'ts-pattern'
@@ -9,39 +9,33 @@ import {
 } from '@qovery/domains/service-terraform/feature'
 import { type Terraform } from '@qovery/domains/services/data-access'
 import { type TerraformGeneralData, useEditService, useService } from '@qovery/domains/services/feature'
-import { SettingsHeading } from '@qovery/shared/console-shared'
-import { Button, LoaderSpinner, Section } from '@qovery/shared/ui'
+import { Button, LoaderSpinner } from '@qovery/shared/ui'
+import { useDocumentTitle } from '@qovery/shared/util-hooks'
 import { buildEditServicePayload } from '@qovery/shared/util-services'
 
 export const Route = createFileRoute(
-  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/settings/terraform-variables'
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform'
 )({
   component: RouteComponent,
 })
 
 const TerraformVariablesLoader = () => (
-  <div className="flex min-h-page-container items-center justify-center">
-    <LoaderSpinner />
+  <div className="flex h-64 items-center justify-center">
+    <LoaderSpinner className="w-6" />
   </div>
 )
 
-const TerraformVariablesSettingsForm = ({ service }: { service: Terraform }) => {
-  const { organizationId = '', projectId = '', environmentId = '' } = Route.useParams()
+const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
+  const { organizationId, projectId, environmentId } = Route.useParams()
   const { handleSubmit } = useFormContext<TerraformGeneralData>()
   const { serializeForApi, tfVarFiles, errors } = useTerraformVariablesContext()
-
   const { mutate: editService, isLoading: isLoadingEditService } = useEditService({
     organizationId,
     projectId,
     environmentId,
   })
 
-  if (service?.serviceType !== 'TERRAFORM') {
-    return null
-  }
-
   const onSubmit = handleSubmit(() => {
-    // Edit the service with the updated variables and the updated order of tfvars files
     const payload = buildEditServicePayload({
       service,
       request: {
@@ -59,14 +53,14 @@ const TerraformVariablesSettingsForm = ({ service }: { service: Terraform }) => 
   })
 
   return (
-    <>
+    <div className="bg-background p-6">
       <TerraformVariablesTable />
-      <div className="mt-10 flex justify-end">
+      <div className="mt-6 flex justify-end">
         <Button type="submit" size="lg" onClick={onSubmit} loading={isLoadingEditService} disabled={errors.size > 0}>
           Save
         </Button>
       </div>
-    </>
+    </div>
   )
 }
 
@@ -74,42 +68,31 @@ const TerraformVariablesContent = ({ service }: { service: Terraform }) => {
   const methods = useForm<TerraformGeneralData>({
     mode: 'onChange',
     defaultValues: match(service)
-      .with({ serviceType: 'TERRAFORM' }, (s) => s)
+      .with({ serviceType: 'TERRAFORM' }, (terraformService) => terraformService)
       .otherwise(() => ({})),
   })
 
   return (
-    <Section className="px-8 pb-8 pt-6">
-      <SettingsHeading
-        title="Terraform variables"
-        description="Select .tfvars files and configure variable values for your Terraform deployment"
-      />
-      <div className="w-full">
-        <FormProvider {...methods}>
-          <TerraformVariablesProvider>
-            <TerraformVariablesSettingsForm service={service} />
-          </TerraformVariablesProvider>
-        </FormProvider>
-      </div>
-    </Section>
+    <FormProvider {...methods}>
+      <TerraformVariablesProvider>
+        <TerraformVariablesForm service={service} />
+      </TerraformVariablesProvider>
+    </FormProvider>
   )
 }
 
-const TerraformVariablesWrapper = () => {
-  const { serviceId } = useParams({ strict: false })
-  const { data: service } = useService({ serviceId })
+function RouteComponent() {
+  const { environmentId, serviceId } = Route.useParams()
+  const { data: service } = useService({ environmentId, serviceId, suspense: true })
+  useDocumentTitle('Terraform variables - Service')
 
   if (service?.serviceType !== 'TERRAFORM') {
     return null
   }
 
-  return <TerraformVariablesContent service={service} />
-}
-
-function RouteComponent() {
   return (
     <Suspense fallback={<TerraformVariablesLoader />}>
-      <TerraformVariablesWrapper />
+      <TerraformVariablesContent service={service} />
     </Suspense>
   )
 }

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
@@ -53,9 +53,9 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
   })
 
   return (
-    <div className="bg-background p-6">
-      <TerraformVariablesTable />
-      <div className="mt-6 flex justify-end">
+    <div className="bg-background">
+      <TerraformVariablesTable className="rounded-none border-0" />
+      <div className="flex justify-end border-t border-neutral p-4">
         <Button type="submit" size="lg" onClick={onSubmit} loading={isLoadingEditService} disabled={errors.size > 0}>
           Save
         </Button>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { Suspense, useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { Suspense } from 'react'
 import { FormProvider, useForm, useFormContext } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import {
@@ -35,12 +34,6 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
     projectId,
     environmentId,
   })
-  const [actionsContainer, setActionsContainer] = useState<HTMLElement | null>(null)
-
-  useEffect(() => {
-    setActionsContainer(document.getElementById('service-variables-actions'))
-  }, [])
-
   const onSubmit = handleSubmit(() => {
     const payload = buildEditServicePayload({
       service,
@@ -59,19 +52,16 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
   })
 
   return (
-    <>
-      <div className="bg-background">
-        <TerraformVariablesTable className="rounded-none border-0" />
-      </div>
-      {/* Render the form action in the parent layout so it remains outside the bordered variables panel. */}
-      {actionsContainer &&
-        createPortal(
-          <Button type="submit" size="lg" onClick={onSubmit} loading={isLoadingEditService} disabled={errors.size > 0}>
+    <div className="bg-background">
+      <TerraformVariablesTable
+        className="rounded-none border-0"
+        headerActions={
+          <Button type="submit" size="md" onClick={onSubmit} loading={isLoadingEditService} disabled={errors.size > 0}>
             Save
-          </Button>,
-          actionsContainer
-        )}
-    </>
+          </Button>
+        }
+      />
+    </div>
   )
 }
 

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { Suspense } from 'react'
+import { Suspense, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { FormProvider, useForm, useFormContext } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import {
@@ -34,6 +35,11 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
     projectId,
     environmentId,
   })
+  const [actionsContainer, setActionsContainer] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setActionsContainer(document.getElementById('service-variables-actions'))
+  }, [])
 
   const onSubmit = handleSubmit(() => {
     const payload = buildEditServicePayload({
@@ -53,14 +59,18 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
   })
 
   return (
-    <div className="bg-background">
-      <TerraformVariablesTable className="rounded-none border-0" />
-      <div className="flex justify-end border-t border-neutral p-4">
-        <Button type="submit" size="lg" onClick={onSubmit} loading={isLoadingEditService} disabled={errors.size > 0}>
-          Save
-        </Button>
+    <>
+      <div className="bg-background">
+        <TerraformVariablesTable className="rounded-none border-0" />
       </div>
-    </div>
+      {actionsContainer &&
+        createPortal(
+          <Button type="submit" size="lg" onClick={onSubmit} loading={isLoadingEditService} disabled={errors.size > 0}>
+            Save
+          </Button>,
+          actionsContainer
+        )}
+    </>
   )
 }
 

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
@@ -63,6 +63,7 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
       <div className="bg-background">
         <TerraformVariablesTable className="rounded-none border-0" />
       </div>
+      {/* Render the form action in the parent layout so it remains outside the bordered variables panel. */}
       {actionsContainer &&
         createPortal(
           <Button type="submit" size="lg" onClick={onSubmit} loading={isLoadingEditService} disabled={errors.size > 0}>

--- a/libs/domains/service-settings/feature/src/lib/service-settings-layout/service-settings-layout.tsx
+++ b/libs/domains/service-settings/feature/src/lib/service-settings-layout/service-settings-layout.tsx
@@ -110,12 +110,6 @@ export function ServiceSettingsLayout({ children }: ServiceSettingsLayoutProps) 
     'play-circle',
     'regular'
   )
-  const terraformVariablesLink = linkItem(
-    'Terraform variables',
-    toSettingsPath(pathSettings, '/terraform-variables'),
-    'key'
-  )
-
   const aiConfigurationLink = linkItem('AI configuration', toSettingsPath(pathSettings, '/ai-configuration'), 'brain')
   const connectionsLink = linkItem('Connections', toSettingsPath(pathSettings, '/connections'), 'plug')
   const outputsLink = linkItem('Outputs', toSettingsPath(pathSettings, '/outputs'), 'paper-plane')
@@ -158,7 +152,6 @@ export function ServiceSettingsLayout({ children }: ServiceSettingsLayoutProps) 
           .with({ serviceType: 'TERRAFORM' }, () => [
             generalLink,
             terraformConfigurationLink,
-            terraformVariablesLink,
             terraformArgumentsLink,
             resourcesLink,
             deploymentRestrictionsLink,

--- a/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-tfvars-popover/terraform-tfvars-popover.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-tfvars-popover/terraform-tfvars-popover.tsx
@@ -164,7 +164,7 @@ export const TfvarsFilesPopover = () => {
               </Button>
             </Indicator>
           ) : (
-            <Button size="md" variant="solid" type="button" data-testid="open-tfvars-files-button">
+            <Button size="md" variant="outline" type="button" data-testid="open-tfvars-files-button">
               <Icon iconName="file-lines" iconStyle="regular" />
               .tfvars files
             </Button>

--- a/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-variables-table/terraform-variables-table.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-variables-table/terraform-variables-table.tsx
@@ -375,7 +375,11 @@ const TerraformVariablesEmptyState = () => {
   )
 }
 
-export const TerraformVariablesTable = ({ className }: { className?: string }) => {
+export interface TerraformVariablesTableProps {
+  embedded?: boolean
+}
+
+export const TerraformVariablesTable = ({ embedded = false }: TerraformVariablesTableProps) => {
   const { addVariable, fetchTfVarsFiles, areTfVarsFilesLoading, vars, newPath, selectedRows, deleteSelectedRows } =
     useTerraformVariablesContext()
 
@@ -388,8 +392,13 @@ export const TerraformVariablesTable = ({ className }: { className?: string }) =
   }, [addVariable])
 
   return (
-    <div className={twMerge('flex flex-col rounded-lg border border-neutral bg-surface-neutral', className)}>
-      <div className="flex items-center justify-between px-4 py-3">
+    <div
+      className={twMerge(
+        'flex flex-col rounded-lg border border-neutral bg-surface-neutral',
+        embedded && 'rounded-none border-0'
+      )}
+    >
+      <div className="flex items-center justify-between px-4 py-2">
         <span className="text-sm font-medium text-neutral">Variable configuration</span>
         <TfvarsFilesPopover />
       </div>

--- a/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-variables-table/terraform-variables-table.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-variables-table/terraform-variables-table.tsx
@@ -1,6 +1,6 @@
 import { useParams } from '@tanstack/react-router'
 import { clsx } from 'clsx'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { DropdownVariable } from '@qovery/domains/variables/feature'
 import { Badge, Button, Checkbox, Icon, LoaderSpinner, Tooltip, truncateText } from '@qovery/shared/ui'
 import { twMerge } from '@qovery/shared/util-js'
@@ -375,7 +375,13 @@ const TerraformVariablesEmptyState = () => {
   )
 }
 
-export const TerraformVariablesTable = ({ className }: { className?: string }) => {
+export const TerraformVariablesTable = ({
+  className,
+  headerActions,
+}: {
+  className?: string
+  headerActions?: ReactNode
+}) => {
   const { addVariable, fetchTfVarsFiles, areTfVarsFilesLoading, vars, newPath, selectedRows, deleteSelectedRows } =
     useTerraformVariablesContext()
 
@@ -391,7 +397,10 @@ export const TerraformVariablesTable = ({ className }: { className?: string }) =
     <div className={twMerge('flex flex-col rounded-lg border border-neutral bg-surface-neutral', className)}>
       <div className="flex items-center justify-between px-4 py-2">
         <span className="text-sm font-medium text-neutral">Variable configuration</span>
-        <TfvarsFilesPopover />
+        <div className="flex items-center gap-2">
+          <TfvarsFilesPopover />
+          {headerActions}
+        </div>
       </div>
 
       {areTfVarsFilesLoading && newPath.length === 0 ? (

--- a/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-variables-table/terraform-variables-table.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-variables-table/terraform-variables-table.tsx
@@ -375,7 +375,7 @@ const TerraformVariablesEmptyState = () => {
   )
 }
 
-export const TerraformVariablesTable = () => {
+export const TerraformVariablesTable = ({ className }: { className?: string }) => {
   const { addVariable, fetchTfVarsFiles, areTfVarsFilesLoading, vars, newPath, selectedRows, deleteSelectedRows } =
     useTerraformVariablesContext()
 
@@ -388,7 +388,7 @@ export const TerraformVariablesTable = () => {
   }, [addVariable])
 
   return (
-    <div className="flex flex-col rounded-lg border border-neutral bg-surface-neutral">
+    <div className={twMerge('flex flex-col rounded-lg border border-neutral bg-surface-neutral', className)}>
       <div className="flex items-center justify-between px-4 py-3">
         <span className="text-sm font-medium text-neutral">Variable configuration</span>
         <TfvarsFilesPopover />

--- a/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-variables-table/terraform-variables-table.tsx
+++ b/libs/domains/service-terraform/feature/src/lib/terraform-variables-settings/terraform-variables-table/terraform-variables-table.tsx
@@ -375,11 +375,7 @@ const TerraformVariablesEmptyState = () => {
   )
 }
 
-export interface TerraformVariablesTableProps {
-  embedded?: boolean
-}
-
-export const TerraformVariablesTable = ({ embedded = false }: TerraformVariablesTableProps) => {
+export const TerraformVariablesTable = ({ className }: { className?: string }) => {
   const { addVariable, fetchTfVarsFiles, areTfVarsFilesLoading, vars, newPath, selectedRows, deleteSelectedRows } =
     useTerraformVariablesContext()
 
@@ -392,12 +388,7 @@ export const TerraformVariablesTable = ({ embedded = false }: TerraformVariables
   }, [addVariable])
 
   return (
-    <div
-      className={twMerge(
-        'flex flex-col rounded-lg border border-neutral bg-surface-neutral',
-        embedded && 'rounded-none border-0'
-      )}
-    >
+    <div className={twMerge('flex flex-col rounded-lg border border-neutral bg-surface-neutral', className)}>
       <div className="flex items-center justify-between px-4 py-2">
         <span className="text-sm font-medium text-neutral">Variable configuration</span>
         <TfvarsFilesPopover />

--- a/libs/shared/assistant/feature/src/lib/hooks/use-contextual-doc-links/use-contextual-doc-links.spec.ts
+++ b/libs/shared/assistant/feature/src/lib/hooks/use-contextual-doc-links/use-contextual-doc-links.spec.ts
@@ -43,6 +43,17 @@ describe('useContextualDocLinks', () => {
     })
   })
 
+  it('should match the Terraform variables service route', () => {
+    setPathname('/organization/org-123/project/project-123/environment/env-123/service/service-123/variables/terraform')
+
+    const { result } = renderHook(() => useContextualDocLinks())
+
+    expect(result.current).toContainEqual({
+      link: 'https://developer.hashicorp.com/terraform/cli/commands',
+      label: 'Terraform CLI documentation',
+    })
+  })
+
   it('should react to navigation events driven by the browser history api', () => {
     setPathname('/organization/org-123/settings/general')
 

--- a/libs/shared/assistant/feature/src/lib/hooks/use-contextual-doc-links/use-contextual-doc-links.ts
+++ b/libs/shared/assistant/feature/src/lib/hooks/use-contextual-doc-links/use-contextual-doc-links.ts
@@ -910,7 +910,7 @@ const tanstackRouteAliases: Array<{ pattern: string; target: MappingPath }> = [
   },
   {
     pattern:
-      '/organization/:organizationId/project/:projectId/environment/:environmentId/service/:serviceId/settings/terraform-variables',
+      '/organization/:organizationId/project/:projectId/environment/:environmentId/service/:serviceId/variables/terraform',
     target:
       '/organization/:organizationId/project/:projectId/environment/:environmentId/application/:applicationId/settings/terraform-arguments',
   },


### PR DESCRIPTION
## Summary

**Issue**: [Pylon #4679 follow-up](https://qovery.slack.com/archives/C0A4CDDJBRQ/p1786697129898159)

- Adds a Terraform variables tab next to Custom, External secrets, and Built-in for Terraform services
- Moves the existing Terraform variables table and save behavior out of Settings
- Keeps `.tfvars` selection, ordering, variable editing, and persistence unchanged
- Removes the Terraform variables entry from the Settings sidebar

## Screenshots / Recordings

https://www.loom.com/share/76b87e7e5f2f4772a70103c5b58b098f

## Testing

- [ ] Changes tested locally in the relevant Console pages and Storybooks
- [x] Targeted tests: `domains-service-terraform-feature` and `domains-service-settings-feature`
- [x] `yarn format`
- [x] Targeted lint: `console` and `domains-service-settings-feature`
- [x] Console development build

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-a-scope-when-possible-e-g-feat-service-add-new-terraform-service) with a scope when possible - required for semantic-release
- [x] I only kept necessary comments, written in English
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] No new business logic was introduced; existing Terraform variable tests pass
- [ ] I confirmed CI is green (Codecov red can be accepted)