### PR TITLE
feat(serviceCatalog): support agentic workflow blueprints (QOV-2181)

### DIFF
--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
@@ -14,6 +14,7 @@ describe('isBlueprintCompatibleWithCluster', () => {
   it.each([
     ['AWS', 'AWS', true],
     ['SCW', 'AWS', false],
+    ['AGENTIC_WORKFLOW', 'AWS', true],
     ['EXTERNAL', 'AWS', true],
     ['HELM', 'AWS', true],
     ['SCW', undefined, true],

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
@@ -8,7 +8,8 @@ const BLUEPRINT_NAME_PARTS: Record<string, string> = {
   s3: 'S3',
 }
 
-const CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS = new Set(['EXTERNAL', 'HELM'])
+// Providers not tied to a specific cloud: their blueprints (e.g. agentic workflows) run on any cluster.
+const CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS = new Set(['AGENTIC_WORKFLOW', 'EXTERNAL', 'HELM'])
 
 export function formatBlueprintName(name: string): string {
   return name


### PR DESCRIPTION
## Summary

Adds support for **agentic workflow blueprints** in the service catalog (Jira QOV-2181).

Agentic workflow blueprints are cloud-agnostic — they are not tied to a specific cloud provider. The catalog's `isBlueprintCompatibleWithCluster` filter only surfaces a blueprint when its provider matches the cluster's cloud provider **or** the provider is on the cloud-agnostic allow-list (`EXTERNAL`, `HELM`). As a result, agentic workflow blueprints were hidden on any cluster bound to a specific cloud (AWS/GCP/SCW/…).

This change adds `AGENTIC_WORKFLOW` to `CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS`, so these blueprints are offered on any cluster — mirroring the existing `EXTERNAL`/`HELM` handling introduced in #2895.

**Files changed**
- `libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts` — add `AGENTIC_WORKFLOW` to the cloud-agnostic provider allow-list.
- `libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts` — add the matching `it.each` row.

## Verification

⚠️ No JS toolchain (node/yarn) was available in the execution environment, so `yarn test` / lint / typecheck could **not** be run here. The change was verified by inspection:
- `isBlueprintCompatibleWithCluster('AGENTIC_WORKFLOW', 'AWS')` now returns `true` via the allow-list; other providers are unaffected.
- A parametrized test row was added to lock in the behavior; please let CI run the suite.

## Assumptions
- The blueprint `provider` token for agentic workflows is `AGENTIC_WORKFLOW`, consistent with `ServiceTypeEnum.AGENTIC_WORKFLOW` and the `Icon name="AGENTIC_WORKFLOW"` usage across the console. The comparison is case-insensitive (`.toUpperCase()`), so any casing of `agentic_workflow` matches. **Please confirm the exact provider string used in the `Qovery/service-catalog` `catalog.json`** — if it is hyphenated (`agentic-workflow`) the allow-list entry must be adjusted. If the token differs, this change is a safe no-op (nothing else is affected).

## Follow-ups
- Confirm the provider token against `Qovery/service-catalog` and, if needed, publish the actual agentic workflow blueprint entries there.
- Dedicated card presentation / deploy routing for agentic workflow blueprints (e.g. routing "Deploy" to the agentic-workflow creation flow) likely requires a service-type/kind field on `BlueprintItem` from the generated `qovery-typescript-axios` API — out of scope for this minimal change.

## Jira
https://qovery.atlassian.net/browse/QOV-2181


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows agentic workflow blueprints on all clusters by treating `AGENTIC_WORKFLOW` as cloud-agnostic. Previously these blueprints were hidden on cloud-bound clusters; now they appear regardless of provider, matching `EXTERNAL`/`HELM`.

- Adds `AGENTIC_WORKFLOW` to `CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS` in `blueprint-utils.ts`; other providers unchanged.
- Extends `isBlueprintCompatibleWithCluster` test to cover `AGENTIC_WORKFLOW`.
- Action: Confirm the service catalog provider token is `AGENTIC_WORKFLOW`; adjust the allow-list entry if the token differs.

<sup>Written for commit 0d147561ad08570894c299b70892beeed26cfd67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

