### PR TITLE
feat(services): improve delete flow when service has been been deployed

### DIFF
--- a/libs/domains/services/feature/src/lib/service-actions/service-actions.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-actions/service-actions.spec.tsx
@@ -283,6 +283,30 @@ describe('ServiceActions', () => {
     })
   })
 
+  it('should propagate deletion errors from the confirmation modal action', async () => {
+    const error = new Error('Deletion failed')
+    mockDeleteService.mockRejectedValueOnce(error)
+    mockDeploymentStatus = {
+      state: 'READY',
+      service_deployment_status: 'NEVER_DEPLOYED',
+    }
+
+    const { userEvent } = renderWithProviders(
+      <ServiceActions serviceId={mockService.id} environment={mockEnvironment} />,
+      {
+        container: document.body,
+      }
+    )
+
+    await userEvent.click(screen.getByLabelText(/other actions/i))
+    await userEvent.click(screen.getByRole('menuitem', { name: /remove service/i }))
+
+    const { action } = mockOpenModalConfirmation.mock.calls[0][0]
+
+    await expect(action()).rejects.toBe(error)
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
   it('should keep the remove modal when the service has already been deployed', async () => {
     const { userEvent } = renderWithProviders(
       <ServiceActions serviceId={mockService.id} environment={mockEnvironment} />,
@@ -296,5 +320,32 @@ describe('ServiceActions', () => {
 
     expect(mockOpenServiceRemoveModal).toHaveBeenCalledWith(expect.objectContaining({ title: 'Remove service' }))
     expect(mockOpenModalConfirmation).not.toHaveBeenCalled()
+  })
+
+  it('should handle deletion errors after the remove modal has closed', async () => {
+    const error = new Error('Deletion failed')
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    mockDeleteService.mockRejectedValueOnce(error)
+
+    const { userEvent } = renderWithProviders(
+      <ServiceActions serviceId={mockService.id} environment={mockEnvironment} />,
+      {
+        container: document.body,
+      }
+    )
+
+    await userEvent.click(screen.getByLabelText(/other actions/i))
+    await userEvent.click(screen.getByRole('menuitem', { name: /remove service/i }))
+
+    const { actions } = mockOpenServiceRemoveModal.mock.calls[0][0]
+    const deleteAction = actions.find(({ id }: { id: string }) => id === 'delete')
+
+    await expect(
+      deleteAction.callback({ action: 'delete', name: 'delete', skipDestroy: false })
+    ).resolves.toBeUndefined()
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error)
+    expect(mockNavigate).not.toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
   })
 })

--- a/libs/domains/services/feature/src/lib/service-actions/service-actions.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-actions/service-actions.spec.tsx
@@ -7,8 +7,10 @@ let mockService = helmFactoryMock(1)[0]
 const mockEnvironment = environmentFactoryMock(1)[0]
 const mockNavigate = jest.fn()
 const mockDeployService = jest.fn()
+const mockDeleteService = jest.fn()
 const mockOpenModal = jest.fn()
 const mockOpenModalConfirmation = jest.fn()
+const mockOpenServiceRemoveModal = jest.fn()
 const mockCopyToClipboard = jest.fn()
 
 let mockDeploymentStatus = {
@@ -71,6 +73,19 @@ jest.mock('../hooks/use-running-status/use-running-status', () => ({
 jest.mock('../hooks/use-deploy-service/use-deploy-service', () => ({
   useDeployService: () => ({
     mutate: mockDeployService,
+  }),
+}))
+
+jest.mock('../hooks/use-delete-service/use-delete-service', () => ({
+  useDeleteService: () => ({
+    mutateAsync: mockDeleteService,
+  }),
+}))
+
+jest.mock('../service-remove-modal/use-service-remove-modal/use-service-remove-modal', () => ({
+  __esModule: true,
+  default: () => ({
+    openServiceRemoveModal: mockOpenServiceRemoveModal,
   }),
 }))
 
@@ -224,5 +239,62 @@ describe('ServiceActions', () => {
         name: mockService.name,
       })
     )
+  })
+
+  it('should use a simple delete confirmation when the service has never been deployed', async () => {
+    mockDeploymentStatus = {
+      state: 'READY',
+      service_deployment_status: 'NEVER_DEPLOYED',
+    }
+
+    const { userEvent } = renderWithProviders(
+      <ServiceActions serviceId={mockService.id} environment={mockEnvironment} />,
+      {
+        container: document.body,
+      }
+    )
+
+    await userEvent.click(screen.getByLabelText(/other actions/i))
+    await userEvent.click(screen.getByRole('menuitem', { name: /remove service/i }))
+
+    expect(mockOpenModalConfirmation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Delete service',
+        name: mockService.name,
+        confirmationMethod: 'action',
+      })
+    )
+    expect(mockOpenServiceRemoveModal).not.toHaveBeenCalled()
+
+    const { action } = mockOpenModalConfirmation.mock.calls[0][0]
+    await action()
+
+    expect(mockDeleteService).toHaveBeenCalledWith({
+      serviceId: mockService.id,
+      serviceType: mockService.serviceType,
+    })
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/organization/$organizationId/project/$projectId/environment/$environmentId/overview',
+      params: {
+        organizationId: mockEnvironment.organization.id,
+        projectId: mockEnvironment.project.id,
+        environmentId: mockEnvironment.id,
+      },
+    })
+  })
+
+  it('should keep the remove modal when the service has already been deployed', async () => {
+    const { userEvent } = renderWithProviders(
+      <ServiceActions serviceId={mockService.id} environment={mockEnvironment} />,
+      {
+        container: document.body,
+      }
+    )
+
+    await userEvent.click(screen.getByLabelText(/other actions/i))
+    await userEvent.click(screen.getByRole('menuitem', { name: /remove service/i }))
+
+    expect(mockOpenServiceRemoveModal).toHaveBeenCalledWith(expect.objectContaining({ title: 'Remove service' }))
+    expect(mockOpenModalConfirmation).not.toHaveBeenCalled()
   })
 })

--- a/libs/domains/services/feature/src/lib/service-actions/service-actions.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-actions/service-actions.spec.tsx
@@ -103,6 +103,10 @@ describe('ServiceActions', () => {
     }
   })
 
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('should match manage deployment snapshot', async () => {
     const { userEvent, baseElement } = renderWithProviders(
       <ServiceActions serviceId={mockService.id} environment={mockEnvironment} />,
@@ -345,7 +349,5 @@ describe('ServiceActions', () => {
     ).resolves.toBeUndefined()
     expect(consoleErrorSpy).toHaveBeenCalledWith(error)
     expect(mockNavigate).not.toHaveBeenCalled()
-
-    consoleErrorSpy.mockRestore()
   })
 })

--- a/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
+++ b/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
@@ -673,11 +673,13 @@ function MenuManageDeployment({
 
 function MenuOtherActions({
   state,
+  serviceDeploymentStatus,
   environment,
   service,
   variant,
 }: {
   state: StateEnum
+  serviceDeploymentStatus: ServiceDeploymentStatusEnum
   environment: Environment
   service: AnyService
   variant?: ActionToolbarVariant
@@ -688,6 +690,7 @@ function MenuOtherActions({
     organization: { id: organizationId },
   } = environment
   const { openModal, closeModal } = useModal()
+  const { openModalConfirmation } = useModalConfirmation()
   const { openServiceRemoveModal } = useServiceRemoveModal()
   const navigate = useNavigate()
   const { mutateAsync: deleteService } = useDeleteService({ organizationId, environmentId })
@@ -716,7 +719,37 @@ function MenuOtherActions({
     )
     .otherwise(() => null)
 
-  const mutationRemove = async () => {
+  const mutationDelete = async (skipDestroy?: boolean) => {
+    if (!isEditableService(service)) {
+      return
+    }
+
+    try {
+      await deleteService({
+        serviceId: service.id,
+        serviceType: service.serviceType,
+        ...(skipDestroy !== undefined && { skipDestroy }),
+      })
+      navigate({
+        to: '/organization/$organizationId/project/$projectId/environment/$environmentId/overview',
+        params: { organizationId, projectId, environmentId },
+      })
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  const mutationRemove = () => {
+    if (serviceDeploymentStatus === ServiceDeploymentStatusEnum.NEVER_DEPLOYED) {
+      openModalConfirmation({
+        title: 'Delete service',
+        name: service.name,
+        confirmationMethod: 'action',
+        action: mutationDelete,
+      })
+      return
+    }
+
     openServiceRemoveModal({
       title: 'Remove service',
       name: service.name,
@@ -794,22 +827,7 @@ function MenuOtherActions({
           icon: 'trash-can',
           color: 'red',
           callback: async ({ skipDestroy }) => {
-            if (!isEditableService(service)) {
-              return
-            }
-            try {
-              await deleteService({
-                serviceId: service.id,
-                serviceType: service.serviceType,
-                skipDestroy,
-              })
-              navigate({
-                to: '/organization/$organizationId/project/$projectId/environment/$environmentId/overview',
-                params: { organizationId, projectId, environmentId },
-              })
-            } catch (error) {
-              console.error(error)
-            }
+            await mutationDelete(skipDestroy)
           },
         },
       ],
@@ -987,6 +1005,7 @@ export function ServiceActions({
       {variant !== 'deploy-dropdown-only' && (
         <MenuOtherActions
           state={deploymentStatus.state}
+          serviceDeploymentStatus={deploymentStatus.service_deployment_status}
           environment={environment}
           service={service}
           variant={variant}

--- a/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
+++ b/libs/domains/services/feature/src/lib/service-actions/service-actions.tsx
@@ -724,19 +724,15 @@ function MenuOtherActions({
       return
     }
 
-    try {
-      await deleteService({
-        serviceId: service.id,
-        serviceType: service.serviceType,
-        ...(skipDestroy !== undefined && { skipDestroy }),
-      })
-      navigate({
-        to: '/organization/$organizationId/project/$projectId/environment/$environmentId/overview',
-        params: { organizationId, projectId, environmentId },
-      })
-    } catch (error) {
-      console.error(error)
-    }
+    await deleteService({
+      serviceId: service.id,
+      serviceType: service.serviceType,
+      ...(skipDestroy !== undefined && { skipDestroy }),
+    })
+    navigate({
+      to: '/organization/$organizationId/project/$projectId/environment/$environmentId/overview',
+      params: { organizationId, projectId, environmentId },
+    })
   }
 
   const mutationRemove = () => {
@@ -827,7 +823,11 @@ function MenuOtherActions({
           icon: 'trash-can',
           color: 'red',
           callback: async ({ skipDestroy }) => {
-            await mutationDelete(skipDestroy)
+            try {
+              await mutationDelete(skipDestroy)
+            } catch (error) {
+              console.error(error)
+            }
           },
         },
       ],


### PR DESCRIPTION
## Summary

This PR improves the deletion flow of a service when it has never been deployed before. In this case, we should use a simple confirmation modal instead of the complex modal asking the user to choose between "uninstall" and "delete".

**Issue**: [QOV-1186](https://qovery.atlassian.net/browse/QOV-1186)

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings
<img width="1621" height="587" alt="SCR-20260825-ixlr" src="https://github.com/user-attachments/assets/fdf17af5-c35f-4365-84ff-f93b2fec60d2" />



## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code


[QOV-1186]: https://qovery.atlassian.net/browse/QOV-1186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Never-deployed services now use a simple delete confirmation instead of the uninstall/delete modal; deployed services still use the remove modal. This reduces friction and surfaces deletion errors correctly. Addresses QOV-1186.

- New Features
  - Navigates to the environment overview after successful deletion.
  - Uses confirmationMethod: 'action' for the never-deployed path.

- Bug Fixes
  - Propagates failures from the confirmation modal delete action.
  - Logs errors from the remove modal’s post-close delete action and prevents navigation on failure.

<sup>Written for commit 1ebb0932a057d4a073829b486db04ccc237e8b71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

