### PR TITLE
fix(services): deployment timer

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
@@ -208,4 +208,67 @@ describe('HeaderLogs', () => {
 
     expect(screen.getByText('0m : 31s')).toBeInTheDocument()
   })
+
+  it('does not decrease when step timing becomes available', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    const { rerender } = renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: { total_computing_duration_sec: 0, total_duration_sec: null, details: [] },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 30s')).toBeInTheDocument()
+
+    rerender(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 0,
+            total_duration_sec: null,
+            details: [
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:30:00Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 30s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 31s')).toBeInTheDocument()
+  })
+
+  it('falls back to the recorded computing duration without timing data', () => {
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: { total_computing_duration_sec: 17, total_duration_sec: null, details: [] },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+  })
 })

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
@@ -105,19 +105,27 @@ describe('HeaderLogs', () => {
     expect(screen.getByTestId('child-content')).toBeInTheDocument()
   })
 
-  it('displays the total duration for a completed deployment', () => {
+  it('excludes non-computing overhead from a completed deployment duration', () => {
     renderWithProviders(
       <HeaderLogs
         {...mockProps}
         serviceStatus={{
           ...mockProps.serviceStatus,
           status_details: { action: 'DEPLOY', status: 'SUCCESS', sub_action: 'NONE' },
-          steps: { total_computing_duration_sec: 125, total_duration_sec: 130, details: [] },
+          steps: {
+            total_computing_duration_sec: 47,
+            total_duration_sec: 53,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 4 },
+              { step_name: 'DEPLOYMENT', status: 'SUCCESS', duration_sec: 43 },
+            ],
+          },
         }}
       />
     )
 
-    expect(screen.getByText('2m : 10s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+    expect(screen.queryByText('0m : 53s')).not.toBeInTheDocument()
   })
 
   it('adds the elapsed ongoing step duration to the completed step durations', () => {
@@ -155,7 +163,7 @@ describe('HeaderLogs', () => {
     expect(screen.getByText('0m : 48s')).toBeInTheDocument()
   })
 
-  it('falls back to the deployment elapsed time when step details are empty', () => {
+  it('does not use the last deployment date as computing time when step details are empty', () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
 
@@ -171,14 +179,14 @@ describe('HeaderLogs', () => {
       />
     )
 
-    expect(screen.getByText('0m : 30s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
 
     act(() => jest.advanceTimersByTime(1_000))
 
-    expect(screen.getByText('0m : 31s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
   })
 
-  it('falls back to the deployment elapsed time when no step has a live start time', () => {
+  it('uses recorded computing time when no step has a live start time', () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
 
@@ -202,11 +210,11 @@ describe('HeaderLogs', () => {
       />
     )
 
-    expect(screen.getByText('0m : 30s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
 
     act(() => jest.advanceTimersByTime(1_000))
 
-    expect(screen.getByText('0m : 31s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
   })
 
   it('does not decrease when step timing becomes available', () => {
@@ -225,7 +233,7 @@ describe('HeaderLogs', () => {
       />
     )
 
-    expect(screen.getByText('0m : 30s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
 
     rerender(
       <HeaderLogs
@@ -250,11 +258,11 @@ describe('HeaderLogs', () => {
       />
     )
 
-    expect(screen.getByText('0m : 30s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
 
     act(() => jest.advanceTimersByTime(1_000))
 
-    expect(screen.getByText('0m : 31s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 1s')).toBeInTheDocument()
   })
 
   it('falls back to the recorded computing duration without timing data', () => {

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
@@ -154,4 +154,58 @@ describe('HeaderLogs', () => {
 
     expect(screen.getByText('0m : 48s')).toBeInTheDocument()
   })
+
+  it('falls back to the deployment elapsed time when step details are empty', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: { total_computing_duration_sec: 0, total_duration_sec: null, details: [] },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 30s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 31s')).toBeInTheDocument()
+  })
+
+  it('falls back to the deployment elapsed time when no step has a live start time', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 2 },
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 15 },
+              { step_name: 'DEPLOYMENT', status: 'ONGOING', duration_sec: 0 },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 30s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 31s')).toBeInTheDocument()
+  })
 })

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
 import { useLinks, useService } from '@qovery/domains/services/feature'
-import { renderWithProviders, screen, within } from '@qovery/shared/util-tests'
+import { act, renderWithProviders, screen, within } from '@qovery/shared/util-tests'
 import { HeaderLogs, type HeaderLogsProps } from './header-logs'
 
 jest.mock('@tanstack/react-router', () => ({
@@ -25,6 +25,7 @@ jest.mock('@qovery/domains/services/feature', () => ({
   useLinks: jest.fn(),
   ServiceAvatar: () => <div data-testid="service-avatar" />,
   ServiceLinksPopover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ServiceActions: () => <div />,
 }))
 
 const mockProps: HeaderLogsProps = {
@@ -47,6 +48,10 @@ const mockProps: HeaderLogsProps = {
 }
 
 describe('HeaderLogs', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   beforeEach(() => {
     useService.mockReturnValue({
       data: {
@@ -98,5 +103,55 @@ describe('HeaderLogs', () => {
       </HeaderLogs>
     )
     expect(screen.getByTestId('child-content')).toBeInTheDocument()
+  })
+
+  it('displays the total duration for a completed deployment', () => {
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'SUCCESS', sub_action: 'NONE' },
+          steps: { total_computing_duration_sec: 125, total_duration_sec: 130, details: [] },
+        }}
+      />
+    )
+
+    expect(screen.getByText('2m : 10s')).toBeInTheDocument()
+  })
+
+  it('adds the elapsed ongoing step duration to the completed step durations', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 2 },
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 15 },
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 48s')).toBeInTheDocument()
   })
 })

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
@@ -163,6 +163,42 @@ describe('HeaderLogs', () => {
     expect(screen.getByText('0m : 48s')).toBeInTheDocument()
   })
 
+  it('excludes queueing steps from an ongoing deployment computing duration', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 12 },
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 48s')).toBeInTheDocument()
+    expect(screen.queryByText('1m : 0s')).not.toBeInTheDocument()
+  })
+
   it('does not use the last deployment date as computing time when step details are empty', () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
@@ -217,7 +253,7 @@ describe('HeaderLogs', () => {
     expect(screen.getByText('0m : 17s')).toBeInTheDocument()
   })
 
-  it('does not decrease when step timing becomes available', () => {
+  it('starts ticking when a computing step follows queueing', () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
 
@@ -228,12 +264,28 @@ describe('HeaderLogs', () => {
           ...mockProps.serviceStatus,
           last_deployment_date: '2026-08-28T13:29:30Z',
           status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
-          steps: { total_computing_duration_sec: 0, total_duration_sec: null, details: [] },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              {
+                step_name: 'DEPLOYMENT_QUEUEING',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
         }}
       />
     )
 
-    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
 
     rerender(
       <HeaderLogs
@@ -243,14 +295,16 @@ describe('HeaderLogs', () => {
           last_deployment_date: '2026-08-28T13:29:30Z',
           status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
           steps: {
-            total_computing_duration_sec: 0,
+            total_computing_duration_sec: 17,
             total_duration_sec: null,
             details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 31 },
               {
                 step_name: 'DEPLOYMENT',
                 status: 'ONGOING',
                 duration_sec: 0,
-                started_at: '2026-08-28T13:30:00Z',
+                started_at: '2026-08-28T13:30:01Z',
               },
             ],
           },
@@ -258,11 +312,11 @@ describe('HeaderLogs', () => {
       />
     )
 
-    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
 
     act(() => jest.advanceTimersByTime(1_000))
 
-    expect(screen.getByText('0m : 1s')).toBeInTheDocument()
+    expect(screen.getByText('0m : 18s')).toBeInTheDocument()
   })
 
   it('falls back to the recorded computing duration without timing data', () => {

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -14,7 +14,7 @@ import { dateUTCString } from '@qovery/shared/util-dates'
 import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { pluralize, trimId } from '@qovery/shared/util-js'
 import { PodHealthChips } from '../pod-health-chips/pod-health-chips'
-import { getServiceStepsDurationSec } from '../service-step-metrics'
+import { getServiceStepsComputingDurationSec, hasLiveServiceStepComputingDuration } from '../service-step-metrics'
 
 export interface HeaderLogsProps extends PropsWithChildren {
   type: 'DEPLOYMENT' | 'SERVICE'
@@ -24,12 +24,12 @@ export interface HeaderLogsProps extends PropsWithChildren {
   environmentStatus?: EnvironmentStatus
 }
 
-function getOngoingDeploymentDurationSec(serviceStatus: Status, nowMs: number) {
+function getOngoingDeploymentComputingDurationSec(serviceStatus: Status, nowMs: number) {
   const steps = serviceStatus.steps?.details ?? []
-  const stepsDurationSec = getServiceStepsDurationSec(steps, nowMs)
+  const stepsComputingDurationSec = getServiceStepsComputingDurationSec(steps, nowMs)
   const recordedComputingDurationSec = serviceStatus.steps?.total_computing_duration_sec ?? 0
 
-  return Math.max(stepsDurationSec, recordedComputingDurationSec)
+  return Math.max(stepsComputingDurationSec, recordedComputingDurationSec)
 }
 
 export function HeaderLogs({
@@ -60,11 +60,12 @@ export function HeaderLogs({
   const isOngoing = match(serviceStatus?.status_details?.status)
     .with('ONGOING', 'CANCELING', () => true)
     .otherwise(() => false)
+  const hasLiveComputingDuration = hasLiveServiceStepComputingDuration(serviceStatus.steps?.details ?? [])
 
-  useIntervalTick(isOngoing)
+  useIntervalTick(isOngoing && hasLiveComputingDuration)
 
-  const totalDurationSec = isOngoing
-    ? getOngoingDeploymentDurationSec(serviceStatus, Date.now())
+  const computingDurationSec = isOngoing
+    ? getOngoingDeploymentComputingDurationSec(serviceStatus, Date.now())
     : serviceStatus.steps?.total_computing_duration_sec ?? 0
 
   if (!service) return null
@@ -128,7 +129,7 @@ export function HeaderLogs({
                     title={dateUTCString(serviceStatus.last_deployment_date ?? '')}
                   >
                     <Icon iconName="stopwatch" iconStyle="regular" className="text-base text-neutral-subtle" />
-                    {Math.floor(totalDurationSec / 60)}m : {totalDurationSec % 60}s
+                    {Math.floor(computingDurationSec / 60)}m : {computingDurationSec % 60}s
                   </span>
                   <svg xmlns="http://www.w3.org/2000/svg" width="5" height="6" fill="none" viewBox="0 0 5 6">
                     <circle cx="2.5" cy="2.955" r="2.5" fill="var(--neutral-6)"></circle>

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -24,6 +24,25 @@ export interface HeaderLogsProps extends PropsWithChildren {
   environmentStatus?: EnvironmentStatus
 }
 
+function getOngoingDeploymentDurationSec(serviceStatus: Status, nowMs: number) {
+  const steps = serviceStatus.steps?.details ?? []
+  const stepsDurationSec = getServiceStepsDurationSec(steps, nowMs)
+  const hasLiveStepDuration = steps.some((step) => {
+    if (step.status !== 'ONGOING' || !step.started_at) return false
+
+    return Number.isFinite(Date.parse(step.started_at))
+  })
+
+  if (hasLiveStepDuration) return stepsDurationSec
+
+  const deploymentStartedAtMs = Date.parse(serviceStatus.last_deployment_date ?? '')
+  const deploymentDurationSec = Number.isFinite(deploymentStartedAtMs)
+    ? Math.max(0, Math.floor((nowMs - deploymentStartedAtMs) / 1_000))
+    : 0
+
+  return Math.max(stepsDurationSec, deploymentDurationSec)
+}
+
 export function HeaderLogs({
   type,
   environment,
@@ -56,7 +75,7 @@ export function HeaderLogs({
   useIntervalTick(isOngoing)
 
   const totalDurationSec = isOngoing
-    ? getServiceStepsDurationSec(serviceStatus.steps?.details ?? [], Date.now())
+    ? getOngoingDeploymentDurationSec(serviceStatus, Date.now())
     : serviceStatus.steps?.total_duration_sec ?? serviceStatus.steps?.total_computing_duration_sec ?? 0
 
   if (!service) return null

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -14,6 +14,7 @@ import { dateUTCString } from '@qovery/shared/util-dates'
 import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { pluralize, trimId } from '@qovery/shared/util-js'
 import { PodHealthChips } from '../pod-health-chips/pod-health-chips'
+import { getServiceStepsDurationSec } from '../service-step-metrics'
 
 export interface HeaderLogsProps extends PropsWithChildren {
   type: 'DEPLOYMENT' | 'SERVICE'
@@ -54,10 +55,9 @@ export function HeaderLogs({
 
   useIntervalTick(isOngoing)
 
-  const totalDurationSec =
-    isOngoing && serviceStatus?.last_deployment_date
-      ? Math.floor((Date.now() - new Date(serviceStatus.last_deployment_date).getTime()) / 1000)
-      : serviceStatus?.steps?.total_computing_duration_sec ?? 0
+  const totalDurationSec = isOngoing
+    ? getServiceStepsDurationSec(serviceStatus.steps?.details ?? [], Date.now())
+    : serviceStatus.steps?.total_duration_sec ?? serviceStatus.steps?.total_computing_duration_sec ?? 0
 
   if (!service) return null
 

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -27,14 +27,9 @@ export interface HeaderLogsProps extends PropsWithChildren {
 function getOngoingDeploymentDurationSec(serviceStatus: Status, nowMs: number) {
   const steps = serviceStatus.steps?.details ?? []
   const stepsDurationSec = getServiceStepsDurationSec(steps, nowMs)
-
-  const deploymentStartedAtMs = Date.parse(serviceStatus.last_deployment_date ?? '')
-  const deploymentDurationSec = Number.isFinite(deploymentStartedAtMs)
-    ? Math.max(0, Math.floor((nowMs - deploymentStartedAtMs) / 1_000))
-    : 0
   const recordedComputingDurationSec = serviceStatus.steps?.total_computing_duration_sec ?? 0
 
-  return Math.max(stepsDurationSec, deploymentDurationSec, recordedComputingDurationSec)
+  return Math.max(stepsDurationSec, recordedComputingDurationSec)
 }
 
 export function HeaderLogs({
@@ -70,7 +65,7 @@ export function HeaderLogs({
 
   const totalDurationSec = isOngoing
     ? getOngoingDeploymentDurationSec(serviceStatus, Date.now())
-    : serviceStatus.steps?.total_duration_sec ?? serviceStatus.steps?.total_computing_duration_sec ?? 0
+    : serviceStatus.steps?.total_computing_duration_sec ?? 0
 
   if (!service) return null
 

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -27,20 +27,14 @@ export interface HeaderLogsProps extends PropsWithChildren {
 function getOngoingDeploymentDurationSec(serviceStatus: Status, nowMs: number) {
   const steps = serviceStatus.steps?.details ?? []
   const stepsDurationSec = getServiceStepsDurationSec(steps, nowMs)
-  const hasLiveStepDuration = steps.some((step) => {
-    if (step.status !== 'ONGOING' || !step.started_at) return false
-
-    return Number.isFinite(Date.parse(step.started_at))
-  })
-
-  if (hasLiveStepDuration) return stepsDurationSec
 
   const deploymentStartedAtMs = Date.parse(serviceStatus.last_deployment_date ?? '')
   const deploymentDurationSec = Number.isFinite(deploymentStartedAtMs)
     ? Math.max(0, Math.floor((nowMs - deploymentStartedAtMs) / 1_000))
     : 0
+  const recordedComputingDurationSec = serviceStatus.steps?.total_computing_duration_sec ?? 0
 
-  return Math.max(stepsDurationSec, deploymentDurationSec)
+  return Math.max(stepsDurationSec, deploymentDurationSec, recordedComputingDurationSec)
 }
 
 export function HeaderLogs({

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.spec.tsx
@@ -1,6 +1,6 @@
 import { StateEnum, type Status } from 'qovery-typescript-axios'
 import { type Terraform } from '@qovery/domains/services/data-access'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { act, renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { FiltersStageStep, type FiltersStageStepProps } from './filters-stage-step'
 
 const mockToggleColumnFilter = jest.fn()
@@ -27,6 +27,11 @@ jest.mock('@tanstack/react-router', () => ({
 describe('FiltersStageStep', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it('renders BUILD and DEPLOY buttons', () => {
@@ -64,5 +69,59 @@ describe('FiltersStageStep', () => {
     renderWithProviders(<FiltersStageStep {...defaultProps} />)
     expect(screen.getByText('1m : 0s')).toBeInTheDocument() // BUILD duration
     expect(screen.getByText('2m : 0s')).toBeInTheDocument() // DEPLOY duration
+  })
+
+  it('ticks the current step duration locally from its backend start time', () => {
+    jest.setSystemTime(new Date('2026-08-25T10:05:00Z'))
+    const props = {
+      ...defaultProps,
+      serviceStatus: {
+        ...defaultProps.serviceStatus,
+        steps: {
+          details: [
+            { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 60 },
+            {
+              step_name: 'BUILD',
+              status: 'ONGOING',
+              duration_sec: 0,
+              started_at: '2026-08-25T10:00:00Z',
+            },
+            { step_name: 'DEPLOYMENT', status: 'SUCCESS', duration_sec: 120 },
+          ],
+        },
+      },
+    }
+
+    renderWithProviders(<FiltersStageStep {...props} />)
+
+    expect(screen.getByText('6m : 0s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('6m : 1s')).toBeInTheDocument()
+  })
+
+  it('uses the recorded duration once a step is completed', () => {
+    jest.setSystemTime(new Date('2026-08-25T11:00:00Z'))
+    const props = {
+      ...defaultProps,
+      serviceStatus: {
+        ...defaultProps.serviceStatus,
+        steps: {
+          details: [
+            {
+              step_name: 'BUILD',
+              status: 'SUCCESS',
+              duration_sec: 300,
+              started_at: '2026-08-25T10:00:00Z',
+            },
+          ],
+        },
+      },
+    }
+
+    renderWithProviders(<FiltersStageStep {...props} />)
+
+    expect(screen.getByText('5m : 0s')).toBeInTheDocument()
   })
 })

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
@@ -9,17 +9,13 @@ import { Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
 import { type FilterType } from '../list-deployment-logs'
 
-type ServiceStepMetricWithLifecycle = Omit<ServiceStepMetric, 'status'> & {
-  status?: ServiceStepMetric['status'] | 'ONGOING'
-  started_at?: string | null
-}
 type StepMetricType = {
-  build: ServiceStepMetricWithLifecycle[]
-  deploy: ServiceStepMetricWithLifecycle[]
-  executing: ServiceStepMetricWithLifecycle[]
+  build: ServiceStepMetric[]
+  deploy: ServiceStepMetric[]
+  executing: ServiceStepMetric[]
 }
 
-const getStepDurationSec = (step: ServiceStepMetricWithLifecycle, nowMs: number) => {
+const getStepDurationSec = (step: ServiceStepMetric, nowMs: number) => {
   if (step.status !== 'ONGOING' || !step.started_at) return step.duration_sec || 0
 
   const startedAtMs = Date.parse(step.started_at)
@@ -29,7 +25,7 @@ const getStepDurationSec = (step: ServiceStepMetricWithLifecycle, nowMs: number)
 interface StageStepProps {
   type: Extract<FilterType, 'BUILD' | 'DEPLOY' | 'EXECUTING'>
   state: StateEnum
-  steps: ServiceStepMetricWithLifecycle[]
+  steps: ServiceStepMetric[]
   toggleColumnFilter: (type: FilterType) => void
   isFilterActive: (type: FilterType) => boolean
 }
@@ -169,7 +165,7 @@ export function FiltersStageStep({
 }: FiltersStageStepProps) {
   if (!steps?.details) return <div />
 
-  const categorizedSteps = (steps.details as ServiceStepMetricWithLifecycle[]).reduce(
+  const categorizedSteps = steps.details.reduce<StepMetricType>(
     (acc, step) => {
       if (!step.step_name) return acc
 
@@ -181,7 +177,7 @@ export function FiltersStageStep({
 
       return acc
     },
-    { build: [], deploy: [], executing: [] } as StepMetricType
+    { build: [], deploy: [], executing: [] }
   )
 
   return (

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
@@ -8,7 +8,11 @@ import { isHelmRepositorySource, isJobContainerSource } from '@qovery/shared/enu
 import { Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
-import { getServiceStepDurationSec, getServiceStepsDurationSec } from '../../service-step-metrics'
+import {
+  getServiceStepDurationSec,
+  getServiceStepsDurationSec,
+  isServiceStepDurationLive,
+} from '../../service-step-metrics'
 import { type FilterType } from '../list-deployment-logs'
 
 type StepMetricType = {
@@ -29,10 +33,7 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
   const { hash } = useLocation()
   const nowMs = Date.now()
   const totalDurationSec = getServiceStepsDurationSec(steps, nowMs)
-  const hasLiveDuration = steps.some(
-    (step) =>
-      step.status === 'ONGOING' && Boolean(step.started_at) && Number.isFinite(Date.parse(step.started_at ?? ''))
-  )
+  const hasLiveDuration = steps.some(isServiceStepDurationLive)
 
   const buildStep = steps.find((s) => s.step_name === 'BUILD')
   const deployStep = steps.find((s) => s.step_name === 'DEPLOYMENT')

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
@@ -6,6 +6,7 @@ import { P, match } from 'ts-pattern'
 import { type AnyService } from '@qovery/domains/services/data-access'
 import { isHelmRepositorySource, isJobContainerSource } from '@qovery/shared/enums'
 import { Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
+import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
 import { getServiceStepDurationSec, getServiceStepsDurationSec } from '../../service-step-metrics'
 import { type FilterType } from '../list-deployment-logs'
@@ -74,14 +75,7 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
     (type === 'BUILD' && status === 'BUILDING') ||
     (type === 'DEPLOY' && status === 'DEPLOYING') ||
     (type === 'EXECUTING' && status === 'EXECUTING')
-  const [, setTick] = useState(0)
-
-  useEffect(() => {
-    if (!hasLiveDuration) return
-
-    const intervalId = window.setInterval(() => setTick((tick) => tick + 1), 1_000)
-    return () => window.clearInterval(intervalId)
-  }, [hasLiveDuration])
+  useIntervalTick(hasLiveDuration)
 
   const shouldDisplayDuration = hasLiveDuration || totalDurationSec > 0
 

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
@@ -7,19 +7,13 @@ import { type AnyService } from '@qovery/domains/services/data-access'
 import { isHelmRepositorySource, isJobContainerSource } from '@qovery/shared/enums'
 import { Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
+import { getServiceStepDurationSec, getServiceStepsDurationSec } from '../../service-step-metrics'
 import { type FilterType } from '../list-deployment-logs'
 
 type StepMetricType = {
   build: ServiceStepMetric[]
   deploy: ServiceStepMetric[]
   executing: ServiceStepMetric[]
-}
-
-const getStepDurationSec = (step: ServiceStepMetric, nowMs: number) => {
-  if (step.status !== 'ONGOING' || !step.started_at) return step.duration_sec || 0
-
-  const startedAtMs = Date.parse(step.started_at)
-  return Number.isFinite(startedAtMs) ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000)) : 0
 }
 
 interface StageStepProps {
@@ -33,7 +27,7 @@ interface StageStepProps {
 function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: StageStepProps) {
   const { hash } = useLocation()
   const nowMs = Date.now()
-  const totalDurationSec = steps.reduce((acc, step) => acc + getStepDurationSec(step, nowMs), 0)
+  const totalDurationSec = getServiceStepsDurationSec(steps, nowMs)
   const hasLiveDuration = steps.some(
     (step) =>
       step.status === 'ONGOING' && Boolean(step.started_at) && Number.isFinite(Date.parse(step.started_at ?? ''))
@@ -120,7 +114,7 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
           <span className="flex flex-col gap-0.5">
             {steps.length > 0 ? (
               steps.map((step, index) => {
-                const durationSec = getStepDurationSec(step, nowMs)
+                const durationSec = getServiceStepDurationSec(step, nowMs)
 
                 return (
                   <span key={`${step.step_name}-${index}`} className="font-medium">

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
@@ -9,19 +9,39 @@ import { Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
 import { type FilterType } from '../list-deployment-logs'
 
-type StepMetricType = { build: ServiceStepMetric[]; deploy: ServiceStepMetric[]; executing: ServiceStepMetric[] }
+type ServiceStepMetricWithLifecycle = Omit<ServiceStepMetric, 'status'> & {
+  status?: ServiceStepMetric['status'] | 'ONGOING'
+  started_at?: string | null
+}
+type StepMetricType = {
+  build: ServiceStepMetricWithLifecycle[]
+  deploy: ServiceStepMetricWithLifecycle[]
+  executing: ServiceStepMetricWithLifecycle[]
+}
+
+const getStepDurationSec = (step: ServiceStepMetricWithLifecycle, nowMs: number) => {
+  if (step.status !== 'ONGOING' || !step.started_at) return step.duration_sec || 0
+
+  const startedAtMs = Date.parse(step.started_at)
+  return Number.isFinite(startedAtMs) ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000)) : 0
+}
 
 interface StageStepProps {
   type: Extract<FilterType, 'BUILD' | 'DEPLOY' | 'EXECUTING'>
   state: StateEnum
-  steps: ServiceStepMetric[]
+  steps: ServiceStepMetricWithLifecycle[]
   toggleColumnFilter: (type: FilterType) => void
   isFilterActive: (type: FilterType) => boolean
 }
 
 function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: StageStepProps) {
   const { hash } = useLocation()
-  const totalDurationSec = steps.reduce((acc, step) => acc + (step.duration_sec || 0), 0)
+  const nowMs = Date.now()
+  const totalDurationSec = steps.reduce((acc, step) => acc + getStepDurationSec(step, nowMs), 0)
+  const hasLiveDuration = steps.some(
+    (step) =>
+      step.status === 'ONGOING' && Boolean(step.started_at) && Number.isFinite(Date.parse(step.started_at ?? ''))
+  )
 
   const buildStep = steps.find((s) => s.step_name === 'BUILD')
   const deployStep = steps.find((s) => s.step_name === 'DEPLOYMENT')
@@ -29,16 +49,16 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
 
   const status = match({ type, state, buildStep, deployStep })
     .with({ type: 'BUILD' }, () => {
-      if (state === 'BUILDING') return 'BUILDING'
+      if (state === 'BUILDING' || hasLiveDuration) return 'BUILDING'
       return buildStep?.status
     })
     .with({ type: 'DEPLOY' }, () => {
       if (state === 'BUILDING') return 'READY'
-      if (state === 'DEPLOYING') return 'DEPLOYING'
+      if (state === 'DEPLOYING' || hasLiveDuration) return 'DEPLOYING'
       return deployStep?.status
     })
     .with({ type: 'EXECUTING' }, () => {
-      if (state === 'EXECUTING') return 'EXECUTING'
+      if (state === 'EXECUTING' || hasLiveDuration) return 'EXECUTING'
       return executingStep?.status
     })
     .exhaustive()
@@ -58,16 +78,28 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
     }
     // On the first load, if status is 'ERROR', the column filter is toggled
     // For all subsequent renders, the column filter is toggled only if the status is 'ERROR'
-  }, [status, toggleColumnFilter, isFirstLoad, hash])
+  }, [status, toggleColumnFilter, isFirstLoad, hash, type])
 
-  const isBuildingOrDeploying =
-    (type === 'BUILD' && status === 'BUILDING') || (type === 'DEPLOY' && status === 'DEPLOYING')
+  const isStepRunning =
+    (type === 'BUILD' && status === 'BUILDING') ||
+    (type === 'DEPLOY' && status === 'DEPLOYING') ||
+    (type === 'EXECUTING' && status === 'EXECUTING')
+  const [, setTick] = useState(0)
+
+  useEffect(() => {
+    if (!hasLiveDuration) return
+
+    const intervalId = window.setInterval(() => setTick((tick) => tick + 1), 1_000)
+    return () => window.clearInterval(intervalId)
+  }, [hasLiveDuration])
+
+  const shouldDisplayDuration = hasLiveDuration || totalDurationSec > 0
 
   const buttonClasses = clsx(
     'flex h-8 items-center gap-1.5 rounded-lg border border-neutral bg-surface-neutral px-2.5 text-sm font-medium text-neutral-subtle transition hover:border-neutral-subtle hover:bg-surface-neutral-component',
     {
       'border-neutral-strong bg-surface-neutral-subtle text-neutral': isFilterActive(type),
-      'border-brand-component bg-surface-brand-subtle': isBuildingOrDeploying && isFilterActive(type),
+      'border-brand-component bg-surface-brand-subtle': isStepRunning && isFilterActive(type),
       'border-positive-strong bg-surface-positive-subtle': status === 'SUCCESS' && isFilterActive(type),
       'border-negative-strong bg-surface-negative-subtle': status === 'ERROR' && isFilterActive(type),
     }
@@ -77,7 +109,7 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
     <button className={twMerge(buttonClasses)} onClick={() => toggleColumnFilter(type)}>
       <StatusChip status={status} />
       {upperCaseFirstLetter(type.toLowerCase())}
-      {totalDurationSec > 0 ? (
+      {shouldDisplayDuration ? (
         <>
           <svg xmlns="http://www.w3.org/2000/svg" width="5" height="6" fill="none" viewBox="0 0 5 6">
             <circle cx="2.5" cy="3" r="2.5" fill="#383E50" />
@@ -91,18 +123,22 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
         content={
           <span className="flex flex-col gap-0.5">
             {steps.length > 0 ? (
-              steps.map((step) => (
-                <span key={step.step_name} className="font-medium">
-                  {upperCaseFirstLetter(step.step_name)?.replace(/_/g, ' ')}:{' '}
-                  {step.duration_sec ? (
-                    <>
-                      {Math.floor(step.duration_sec / 60)}m {step.duration_sec % 60}s
-                    </>
-                  ) : (
-                    '0s'
-                  )}
-                </span>
-              ))
+              steps.map((step, index) => {
+                const durationSec = getStepDurationSec(step, nowMs)
+
+                return (
+                  <span key={`${step.step_name}-${index}`} className="font-medium">
+                    {upperCaseFirstLetter(step.step_name)?.replace(/_/g, ' ')}:{' '}
+                    {durationSec ? (
+                      <>
+                        {Math.floor(durationSec / 60)}m {durationSec % 60}s
+                      </>
+                    ) : (
+                      '0s'
+                    )}
+                  </span>
+                )
+              })
             ) : (
               <span>No detail available</span>
             )}
@@ -133,7 +169,7 @@ export function FiltersStageStep({
 }: FiltersStageStepProps) {
   if (!steps?.details) return <div />
 
-  const categorizedSteps = steps.details.reduce(
+  const categorizedSteps = (steps.details as ServiceStepMetricWithLifecycle[]).reduce(
     (acc, step) => {
       if (!step.step_name) return acc
 

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
@@ -1,7 +1,10 @@
 import {
   getServiceStepDurationSec,
+  getServiceStepsComputingDurationSec,
   getServiceStepsDurationSec,
+  hasLiveServiceStepComputingDuration,
   isServiceStepDurationLive,
+  isServiceStepIncludedInComputingDuration,
 } from './service-step-metrics'
 
 const nowMs = Date.parse('2026-08-28T13:30:00Z')
@@ -17,6 +20,28 @@ describe('isServiceStepDurationLive', () => {
     { status: 'SUCCESS', started_at: '2026-08-28T13:29:30Z' },
   ])('returns false without both ongoing status and a valid start time', (step) => {
     expect(isServiceStepDurationLive(step)).toBe(false)
+  })
+})
+
+describe('isServiceStepIncludedInComputingDuration', () => {
+  it.each(['BUILD_QUEUEING', 'DEPLOYMENT_QUEUEING'] as const)('excludes the %s step', (stepName) => {
+    expect(isServiceStepIncludedInComputingDuration({ step_name: stepName })).toBe(false)
+  })
+
+  it.each([
+    'REGISTRY_CREATE_REPOSITORY',
+    'GIT_CLONE',
+    'BUILD',
+    'MIRROR_IMAGE',
+    'DEPLOYMENT',
+    'ROUTER_DEPLOYMENT',
+    'EXECUTING',
+  ] as const)('includes the %s step', (stepName) => {
+    expect(isServiceStepIncludedInComputingDuration({ step_name: stepName })).toBe(true)
+  })
+
+  it('excludes a metric without a step name', () => {
+    expect(isServiceStepIncludedInComputingDuration({})).toBe(false)
   })
 })
 
@@ -81,5 +106,52 @@ describe('getServiceStepsDurationSec', () => {
 
   it('returns zero for an empty step list', () => {
     expect(getServiceStepsDurationSec([], nowMs)).toBe(0)
+  })
+})
+
+describe('getServiceStepsComputingDurationSec', () => {
+  it('excludes completed queueing steps from the live computing duration', () => {
+    const durationSec = getServiceStepsComputingDurationSec(
+      [
+        { step_name: 'BUILD_QUEUEING', status: 'SUCCESS', duration_sec: 12 },
+        { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 4 },
+        { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 8 },
+        {
+          step_name: 'DEPLOYMENT',
+          status: 'ONGOING',
+          duration_sec: 0,
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ],
+      nowMs
+    )
+
+    expect(durationSec).toBe(34)
+  })
+})
+
+describe('hasLiveServiceStepComputingDuration', () => {
+  it('returns false when only a queueing step is live', () => {
+    expect(
+      hasLiveServiceStepComputingDuration([
+        {
+          step_name: 'DEPLOYMENT_QUEUEING',
+          status: 'ONGOING',
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ])
+    ).toBe(false)
+  })
+
+  it('returns true when a computing step is live', () => {
+    expect(
+      hasLiveServiceStepComputingDuration([
+        {
+          step_name: 'DEPLOYMENT',
+          status: 'ONGOING',
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ])
+    ).toBe(true)
   })
 })

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
@@ -1,6 +1,24 @@
-import { getServiceStepDurationSec, getServiceStepsDurationSec } from './service-step-metrics'
+import {
+  getServiceStepDurationSec,
+  getServiceStepsDurationSec,
+  isServiceStepDurationLive,
+} from './service-step-metrics'
 
 const nowMs = Date.parse('2026-08-28T13:30:00Z')
+
+describe('isServiceStepDurationLive', () => {
+  it('returns true for an ongoing step with a valid start time', () => {
+    expect(isServiceStepDurationLive({ status: 'ONGOING', started_at: '2026-08-28T13:29:30Z' })).toBe(true)
+  })
+
+  it.each([
+    { status: 'ONGOING', started_at: 'invalid' },
+    { status: 'ONGOING' },
+    { status: 'SUCCESS', started_at: '2026-08-28T13:29:30Z' },
+  ])('returns false without both ongoing status and a valid start time', (step) => {
+    expect(isServiceStepDurationLive(step)).toBe(false)
+  })
+})
 
 describe('getServiceStepDurationSec', () => {
   it('returns the recorded duration for a completed step', () => {

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
@@ -34,6 +34,12 @@ describe('getServiceStepDurationSec', () => {
     expect(durationSec).toBe(0)
   })
 
+  it('returns the recorded duration when the start time is invalid', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', duration_sec: 12, started_at: 'invalid' }, nowMs)
+
+    expect(durationSec).toBe(12)
+  })
+
   it('does not return a negative duration for a future start time', () => {
     const durationSec = getServiceStepDurationSec({ status: 'ONGOING', started_at: '2026-08-28T13:31:00Z' }, nowMs)
 

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
@@ -1,0 +1,61 @@
+import { getServiceStepDurationSec, getServiceStepsDurationSec } from './service-step-metrics'
+
+const nowMs = Date.parse('2026-08-28T13:30:00Z')
+
+describe('getServiceStepDurationSec', () => {
+  it('returns the recorded duration for a completed step', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'SUCCESS', duration_sec: 15 }, nowMs)
+
+    expect(durationSec).toBe(15)
+  })
+
+  it('returns the elapsed duration for an ongoing step', () => {
+    const durationSec = getServiceStepDurationSec(
+      {
+        status: 'ONGOING',
+        duration_sec: 0,
+        started_at: '2026-08-28T13:29:29.500Z',
+      },
+      nowMs
+    )
+
+    expect(durationSec).toBe(30)
+  })
+
+  it('returns the recorded duration when an ongoing step has no start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', duration_sec: 12 }, nowMs)
+
+    expect(durationSec).toBe(12)
+  })
+
+  it('returns zero for an invalid start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', started_at: 'invalid' }, nowMs)
+
+    expect(durationSec).toBe(0)
+  })
+
+  it('does not return a negative duration for a future start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', started_at: '2026-08-28T13:31:00Z' }, nowMs)
+
+    expect(durationSec).toBe(0)
+  })
+})
+
+describe('getServiceStepsDurationSec', () => {
+  it('adds completed step durations to the elapsed ongoing step duration', () => {
+    const durationSec = getServiceStepsDurationSec(
+      [
+        { status: 'SUCCESS', duration_sec: 2 },
+        { status: 'SUCCESS', duration_sec: 15 },
+        { status: 'ONGOING', duration_sec: 0, started_at: '2026-08-28T13:29:30Z' },
+      ],
+      nowMs
+    )
+
+    expect(durationSec).toBe(47)
+  })
+
+  it('returns zero for an empty step list', () => {
+    expect(getServiceStepsDurationSec([], nowMs)).toBe(0)
+  })
+})

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
@@ -1,0 +1,12 @@
+import { type ServiceStepMetric } from 'qovery-typescript-axios'
+
+export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number) {
+  if (step.status !== 'ONGOING' || !step.started_at) return step.duration_sec || 0
+
+  const startedAtMs = Date.parse(step.started_at)
+  return Number.isFinite(startedAtMs) ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000)) : 0
+}
+
+export function getServiceStepsDurationSec(steps: ServiceStepMetric[], nowMs: number) {
+  return steps.reduce((totalDurationSec, step) => totalDurationSec + getServiceStepDurationSec(step, nowMs), 0)
+}

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
@@ -4,7 +4,7 @@ export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number
   if (step.status !== 'ONGOING' || !step.started_at) return step.duration_sec || 0
 
   const startedAtMs = Date.parse(step.started_at)
-  return Number.isFinite(startedAtMs) ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000)) : 0
+  return Number.isFinite(startedAtMs) ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000)) : step.duration_sec || 0
 }
 
 export function getServiceStepsDurationSec(steps: ServiceStepMetric[], nowMs: number) {

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
@@ -2,16 +2,28 @@ import { type ServiceStepMetric } from 'qovery-typescript-axios'
 
 const NON_COMPUTING_STEP_NAMES = new Set<ServiceStepMetric['step_name']>(['BUILD_QUEUEING', 'DEPLOYMENT_QUEUEING'])
 
+/**
+ * Returns whether a step contributes to the header's computing timer and q-core's `total_computing_duration_sec`.
+ * Unlike stage and wall-clock durations, computing time excludes build and deployment queueing.
+ */
 export function isServiceStepIncludedInComputingDuration(step: ServiceStepMetric) {
   return step.step_name !== undefined && !NON_COMPUTING_STEP_NAMES.has(step.step_name)
 }
 
+/**
+ * Returns whether an individual step should advance from its backend `started_at` timestamp.
+ * Completed steps may retain this timestamp, so the `ONGOING` status is essential to keep their final duration frozen.
+ */
 export function isServiceStepDurationLive(step: ServiceStepMetric) {
   if (step.status !== 'ONGOING' || !step.started_at) return false
 
   return Number.isFinite(Date.parse(step.started_at))
 }
 
+/**
+ * Returns an individual step's live elapsed time while ongoing, or its backend-recorded duration otherwise.
+ * This also provides a stable fallback when `started_at` is missing or malformed.
+ */
 export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number) {
   if (!isServiceStepDurationLive(step)) return step.duration_sec || 0
 
@@ -19,10 +31,18 @@ export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number
   return Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000))
 }
 
+/**
+ * Calculates a Build, Deploy, or Executing stage timer by adding every step assigned to that stage.
+ * Queueing is intentionally included because these timers represent the complete elapsed time of each stage.
+ */
 export function getServiceStepsDurationSec(steps: ServiceStepMetric[], nowMs: number) {
   return steps.reduce((totalDurationSec, step) => totalDurationSec + getServiceStepDurationSec(step, nowMs), 0)
 }
 
+/**
+ * Calculates the live header timer by adding completed and ongoing computing steps while excluding queueing.
+ * This keeps it comparable with q-core's completed computing total rather than the deployment history's wall-clock total.
+ */
 export function getServiceStepsComputingDurationSec(steps: ServiceStepMetric[], nowMs: number) {
   return steps.reduce(
     (totalDurationSec, step) =>
@@ -33,6 +53,10 @@ export function getServiceStepsComputingDurationSec(steps: ServiceStepMetric[], 
   )
 }
 
+/**
+ * Returns whether the header needs a one-second client-side update for an ongoing computing step.
+ * Queue-only and completed deployments remain stable because they do not change the displayed computing duration.
+ */
 export function hasLiveServiceStepComputingDuration(steps: ServiceStepMetric[]) {
   return steps.some((step) => isServiceStepIncludedInComputingDuration(step) && isServiceStepDurationLive(step))
 }

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
@@ -1,10 +1,16 @@
 import { type ServiceStepMetric } from 'qovery-typescript-axios'
 
-export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number) {
-  if (step.status !== 'ONGOING' || !step.started_at) return step.duration_sec || 0
+export function isServiceStepDurationLive(step: ServiceStepMetric) {
+  if (step.status !== 'ONGOING' || !step.started_at) return false
 
-  const startedAtMs = Date.parse(step.started_at)
-  return Number.isFinite(startedAtMs) ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000)) : step.duration_sec || 0
+  return Number.isFinite(Date.parse(step.started_at))
+}
+
+export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number) {
+  if (!isServiceStepDurationLive(step)) return step.duration_sec || 0
+
+  const startedAtMs = Date.parse(step.started_at ?? '')
+  return Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000))
 }
 
 export function getServiceStepsDurationSec(steps: ServiceStepMetric[], nowMs: number) {

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
@@ -1,5 +1,11 @@
 import { type ServiceStepMetric } from 'qovery-typescript-axios'
 
+const NON_COMPUTING_STEP_NAMES = new Set<ServiceStepMetric['step_name']>(['BUILD_QUEUEING', 'DEPLOYMENT_QUEUEING'])
+
+export function isServiceStepIncludedInComputingDuration(step: ServiceStepMetric) {
+  return step.step_name !== undefined && !NON_COMPUTING_STEP_NAMES.has(step.step_name)
+}
+
 export function isServiceStepDurationLive(step: ServiceStepMetric) {
   if (step.status !== 'ONGOING' || !step.started_at) return false
 
@@ -15,4 +21,18 @@ export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number
 
 export function getServiceStepsDurationSec(steps: ServiceStepMetric[], nowMs: number) {
   return steps.reduce((totalDurationSec, step) => totalDurationSec + getServiceStepDurationSec(step, nowMs), 0)
+}
+
+export function getServiceStepsComputingDurationSec(steps: ServiceStepMetric[], nowMs: number) {
+  return steps.reduce(
+    (totalDurationSec, step) =>
+      isServiceStepIncludedInComputingDuration(step)
+        ? totalDurationSec + getServiceStepDurationSec(step, nowMs)
+        : totalDurationSec,
+    0
+  )
+}
+
+export function hasLiveServiceStepComputingDuration(steps: ServiceStepMetric[]) {
+  return steps.some((step) => isServiceStepIncludedInComputingDuration(step) && isServiceStepDurationLive(step))
 }


### PR DESCRIPTION
## Goal

Keep deployment duration displays accurate and consistent with the Build, Deploy, and Executing stage timers while a deployment is progressing and after it completes.

Previously, ongoing step timers could remain frozen at the last backend duration. An intermediate implementation also treated full wall-clock duration, including queueing and orchestration gaps, as the header total even though the stage timers represent computing time.

## Changes

Individual step timers use the backend’s recorded duration once complete, or calculate live elapsed time from `started_at` while ongoing. Stage timers add every step in Build, Deploy, or Executing, including queueing time. The header adds completed and ongoing computing steps but excludes build and deployment queues, matching `total_computing_duration_sec`. Deployment history shows the engine’s complete wall-clock duration, so it can be higher because it includes queues, gaps, overhead, and rounding differences.
