### PR TITLE
feat(environments): sort ephemeral environments by latest operation

### DIFF
--- a/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.tsx
+++ b/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate, useParams } from '@tanstack/react-router'
 import { EnvironmentModeEnum, type EnvironmentOverviewResponse, StateEnum } from 'qovery-typescript-axios'
-import { type KeyboardEvent, type MouseEvent } from 'react'
+import { type KeyboardEvent, type MouseEvent, useMemo } from 'react'
 import { match } from 'ts-pattern'
 import { ClusterAvatar } from '@qovery/domains/clusters/feature'
 import { Button, Checkbox, DeploymentAction, Heading, Icon, Section, TablePrimitives, Tooltip } from '@qovery/shared/ui'
@@ -187,6 +187,11 @@ function EnvRow({
   )
 }
 
+function lastOperationTimestamp(overview: EnvironmentOverviewResponse) {
+  const lastDeploymentDate = overview.deployment_status?.last_deployment_date
+  return lastDeploymentDate ? new Date(lastDeploymentDate).getTime() : 0
+}
+
 export function EnvironmentSection({
   type,
   items,
@@ -208,6 +213,16 @@ export function EnvironmentSection({
     .with('DEVELOPMENT', () => 'Development')
     .with('PREVIEW', () => 'Ephemeral')
     .exhaustive()
+
+  const sortedItems = useMemo(() => {
+    if (type !== EnvironmentModeEnum.PREVIEW) {
+      return items
+    }
+
+    return [...items].sort(
+      (environmentA, environmentB) => lastOperationTimestamp(environmentB) - lastOperationTimestamp(environmentA)
+    )
+  }, [items, type])
 
   const EmptyState = () =>
     match(type)
@@ -295,7 +310,7 @@ export function EnvironmentSection({
           </Table.Header>
 
           <Table.Body className="divide-y divide-neutral">
-            {items.map((environmentOverview) => (
+            {sortedItems.map((environmentOverview) => (
               <EnvRow
                 key={environmentOverview.id}
                 overview={environmentOverview}

--- a/libs/domains/environments/feature/src/lib/environments-table/environments-table.spec.tsx
+++ b/libs/domains/environments/feature/src/lib/environments-table/environments-table.spec.tsx
@@ -39,7 +39,12 @@ jest.mock('./environments-table-action-bar', () => ({
   EnvironmentsTableActionBar: () => <div data-testid="environments-table-action-bar" />,
 }))
 
-function environmentOverview(id: string, mode: EnvironmentModeEnum, name: string): EnvironmentOverviewResponse {
+function environmentOverview(
+  id: string,
+  mode: EnvironmentModeEnum,
+  name: string,
+  lastDeploymentDate?: string
+): EnvironmentOverviewResponse {
   return {
     id,
     mode,
@@ -48,6 +53,7 @@ function environmentOverview(id: string, mode: EnvironmentModeEnum, name: string
       service_count: 0,
       managed_by: 'QOVERY',
     },
+    ...(lastDeploymentDate ? { deployment_status: { last_deployment_date: lastDeploymentDate } } : {}),
   } as EnvironmentOverviewResponse
 }
 
@@ -91,6 +97,25 @@ describe('EnvironmentsTable', () => {
       'Alpha',
       'Zulu',
       'Beta',
+    ])
+  })
+
+  it('should sort ephemeral environments by last operation with newer environments first', () => {
+    mockUseProject.mockReturnValue({ data: { name: 'Project Alpha' } })
+    mockUseEnvironmentsOverview.mockReturnValue({
+      data: [
+        environmentOverview('env-1', EnvironmentModeEnum.PREVIEW, 'Bravo', '2024-03-01T00:00:00Z'),
+        environmentOverview('env-2', EnvironmentModeEnum.PREVIEW, 'Alpha', '2024-01-01T00:00:00Z'),
+        environmentOverview('env-3', EnvironmentModeEnum.PREVIEW, 'Charlie', '2024-02-01T00:00:00Z'),
+      ],
+    })
+
+    renderWithProviders(<EnvironmentsTable />)
+
+    expect(screen.getAllByRole('link', { name: /^(Alpha|Bravo|Charlie)$/ }).map((link) => link.textContent)).toEqual([
+      'Bravo',
+      'Charlie',
+      'Alpha',
     ])
   })
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: <!-- N/A — requested via Slack -->

Sorts the **Ephemeral** environments section by last operation, newest first, so the most recently updated preview environments appear at the top by default.

- Sorting is automatic and does not add any interactive controls.
- Sorting only applies to the Ephemeral section; other environment sections keep their existing order.
- Environments without a last deployment date appear after environments with one.
- The ordering is computed locally in `EnvironmentSection`; no data-layer changes are required.

## Screenshots / Recordings

No visual control was added; only the default row order changes.

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [x] Focused Jest test covering newest-first ordering
- [x] Prettier check on the changed files
- [ ] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts ephemeral (preview) environments in the Environments table by last operation, newest first, so the most recently updated previews appear at the top.

- Sorting applies only to the Ephemeral section; other sections keep their name ordering.
- Adds a unit test covering the default last-operation ordering.

<sup>Written for commit 599f3d4c7e76e2c49b7e859fe203802b6f296c3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
