### PR TITLE
feat(agent-task): rename agentic workflow

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/configuration.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/configuration.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute(
 })
 
 function RouteComponent() {
-  useDocumentTitle('Agentic workflow configuration')
+  useDocumentTitle('Agent task configuration')
 
   return <AgenticWorkflowConfiguration />
 }

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/summary.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/summary.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute(
 })
 
 function RouteComponent() {
-  useDocumentTitle('Summary - Create agentic workflow')
+  useDocumentTitle('Summary - Create agent task')
 
   return <AgenticWorkflowSummary />
 }

--- a/libs/domains/audit-logs/feature/src/lib/audit-logs-view/audit-logs-view.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/audit-logs-view/audit-logs-view.tsx
@@ -7,9 +7,8 @@ import { eventsFactoryMock } from '@qovery/shared/factories'
 import { type AuditLogsParams, DEFAULT_PAGE_SIZE } from '@qovery/shared/router'
 import { ALL, type NavigationLevel, type SelectedItem, type TableFilterProps } from '@qovery/shared/ui'
 import { useDocumentTitle, useSupportChat } from '@qovery/shared/util-hooks'
-import { upperCaseFirstLetter } from '@qovery/shared/util-js'
 import { AuditLogs } from '../audit-logs/audit-logs'
-import { initializeSelectedItemsFromQueryParams } from '../utils/target-type-selection-utils'
+import { getTargetTypeLabel, initializeSelectedItemsFromQueryParams } from '../utils/target-type-selection-utils'
 
 const route = getRouteApi('/_authenticated/organization/$organizationId/audit-logs')
 
@@ -107,7 +106,7 @@ export function AuditLogsView() {
 
     const organizationEventTargetTypes = Object.keys(OrganizationEventTargetType).map((item) => ({
       value: item,
-      name: upperCaseFirstLetter(item).replace(/_/g, ' '),
+      name: getTargetTypeLabel(item),
     }))
 
     initializeSelectedItemsFromQueryParams(organizationId, organizationEventTargetTypes, 'target_type', urlParams)

--- a/libs/domains/audit-logs/feature/src/lib/audit-logs/audit-logs.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/audit-logs/audit-logs.tsx
@@ -23,13 +23,13 @@ import {
   type TableHeadProps,
 } from '@qovery/shared/ui'
 import { type SelectedTimestamps } from '@qovery/shared/ui'
-import { upperCaseFirstLetter } from '@qovery/shared/util-js'
 import FilterSection from '../filter-section/filter-section'
 import RowEventFeature from '../row-event-feature/row-event-feature'
 import {
   computeDisplayByLabel,
   computeMenusToDisplay,
   computeSelectedItemsFromFilter,
+  getTargetTypeLabel,
 } from '../utils/target-type-selection-utils'
 
 export interface AuditLogsProps {
@@ -141,7 +141,7 @@ function createTableDataHead(
         initialData: Object.keys(OrganizationEventTargetType).map((item) => {
           return {
             value: item,
-            name: upperCaseFirstLetter(item).replace(/_/g, ' '),
+            name: getTargetTypeLabel(item),
           }
         }),
         initialSelectedItems: targetTypeSelectedItems,

--- a/libs/domains/audit-logs/feature/src/lib/filter-section/filter-section.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/filter-section/filter-section.spec.tsx
@@ -1,3 +1,4 @@
+import { OrganizationEventTargetType } from 'qovery-typescript-axios'
 import { type DecodedValueMap } from 'use-query-params'
 import { type AuditLogsParams } from '@qovery/shared/router'
 import { type SelectedItem } from '@qovery/shared/ui'
@@ -72,6 +73,30 @@ describe('FilterSection', () => {
 
     screen.getByText(/Target Type:/)
     screen.getByText(/Application/)
+  })
+
+  it('should render Agent task in target type and target badges', () => {
+    const queryParamsWithTarget = {
+      targetId: 'target-123',
+      targetType: OrganizationEventTargetType.AGENTIC_WORKFLOW,
+    }
+    const selectedItems: SelectedItem[] = [
+      {
+        filterKey: 'target_id',
+        item: { value: 'target-123', name: 'Review pull requests' },
+      },
+    ]
+
+    renderWithProviders(
+      <FilterSection
+        {...props}
+        queryParams={queryParamsWithTarget as DecodedValueMap<AuditLogsParams>}
+        targetTypeSelectedItems={selectedItems}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /Target Type: Agent task/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Agent task: Review pull requests/ })).toBeInTheDocument()
   })
 
   it('should render user badge when triggeredBy is set', () => {

--- a/libs/domains/audit-logs/feature/src/lib/filter-section/filter-section.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/filter-section/filter-section.tsx
@@ -4,6 +4,7 @@ import { type AuditLogsParams } from '@qovery/shared/router'
 import { Button, Icon, type SelectedItem, type TableFilterProps, Truncate } from '@qovery/shared/ui'
 import { dateYearMonthDayHourMinuteSecond } from '@qovery/shared/util-dates'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
+import { getTargetTypeLabel } from '../utils/target-type-selection-utils'
 
 export interface CustomFilterProps {
   clearFilter: () => void
@@ -55,7 +56,7 @@ function buildBadges(queryParams: AuditLogsParams, selectedItemsTargetType: Sele
     badges.push({
       key: 'target_type',
       displayedName: 'Target Type',
-      value: upperCaseFirstLetter(queryParams.targetType).split('_').join(' '),
+      value: getTargetTypeLabel(queryParams.targetType),
       isDeletable: true,
     })
   }
@@ -105,9 +106,7 @@ function buildBadges(queryParams: AuditLogsParams, selectedItemsTargetType: Sele
     const selectedItem = selectedItemsTargetType.find((selectedItem) => selectedItem.filterKey === 'target_id')
     if (selectedItem) {
       const targetName = selectedItem?.item?.name ?? '...'
-      const targetType = upperCaseFirstLetter(queryParams.targetType ?? '...')
-        .split('_')
-        .join(' ')
+      const targetType = getTargetTypeLabel(queryParams.targetType ?? '...')
       badges.push({
         key: 'target_id',
         displayedName: targetType,

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
@@ -114,6 +114,20 @@ describe('RowEvent', () => {
     expect(screen.getByText('unsupported-target')).not.toHaveAttribute('href')
   })
 
+  it('should render Agent task for the agentic workflow target type', () => {
+    renderWithProviders(
+      <RowEvent
+        {...props}
+        event={{
+          ...props.event,
+          target_type: OrganizationEventTargetType.AGENTIC_WORKFLOW,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Agent task')).toBeInTheDocument()
+  })
+
   it.each([
     [OrganizationEventTargetType.ORGANIZATION, '/organization/1/settings'],
     [OrganizationEventTargetType.MEMBERS_AND_ROLES, '/organization/1/settings/members'],

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
@@ -13,6 +13,7 @@ import { IconEnum } from '@qovery/shared/enums'
 import { CodeDiffEditor, CodeEditor, type DiffStats, Icon, Skeleton, Tooltip, Truncate } from '@qovery/shared/ui'
 import { dateFullFormat, dateUTCString } from '@qovery/shared/util-dates'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
+import { getTargetTypeLabel } from '../utils/target-type-selection-utils'
 
 export interface RowEventProps {
   event: OrganizationEventResponse
@@ -312,7 +313,7 @@ export function RowEvent(props: RowEventProps) {
         </div>
         <div className="min-w-0 px-4 text-neutral-subtle">
           <Skeleton height={10} width={80} show={isPlaceholder}>
-            <>{upperCaseFirstLetter(event.target_type ?? '')?.replace(/_/g, ' ')}</>
+            <>{getTargetTypeLabel(event.target_type ?? '')}</>
           </Skeleton>
         </div>
         <div className="min-w-0 px-4">

--- a/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.spec.ts
+++ b/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.spec.ts
@@ -1,6 +1,6 @@
 import { OrganizationEventApi, OrganizationEventTargetType } from 'qovery-typescript-axios'
 import { type SelectedItem } from '@qovery/shared/ui'
-import { computeMenusToDisplay } from './target-type-selection-utils'
+import { computeMenusToDisplay, getTargetTypeLabel } from './target-type-selection-utils'
 
 const mockGetOrganizationEventTargets = jest.spyOn(OrganizationEventApi.prototype, 'getOrganizationEventTargets')
 
@@ -8,7 +8,7 @@ const targetTypeItem: SelectedItem = {
   filterKey: 'target_type',
   item: {
     value: OrganizationEventTargetType.AGENTIC_WORKFLOW,
-    name: 'Agentic workflow',
+    name: 'Agent task',
   },
 }
 
@@ -83,5 +83,15 @@ describe('computeMenusToDisplay', () => {
       'environment-1',
       undefined
     )
+  })
+})
+
+describe('getTargetTypeLabel', () => {
+  it('uses the Agent task product name for the agentic workflow API type', () => {
+    expect(getTargetTypeLabel(OrganizationEventTargetType.AGENTIC_WORKFLOW)).toBe('Agent task')
+  })
+
+  it('formats other API target types', () => {
+    expect(getTargetTypeLabel(OrganizationEventTargetType.CONTAINER_REGISTRY)).toBe('Container registry')
   })
 })

--- a/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.tsx
@@ -6,6 +6,7 @@ import {
   type NavigationLevel,
   type SelectedItem,
 } from '@qovery/shared/ui'
+import { upperCaseFirstLetter } from '@qovery/shared/util-js'
 
 const SERVICE_TARGET_TYPES: ReadonlySet<OrganizationEventTargetType> = new Set([
   OrganizationEventTargetType.AGENTIC_WORKFLOW,
@@ -16,6 +17,12 @@ const SERVICE_TARGET_TYPES: ReadonlySet<OrganizationEventTargetType> = new Set([
   OrganizationEventTargetType.JOB,
   OrganizationEventTargetType.TERRAFORM,
 ])
+
+export function getTargetTypeLabel(targetType: string) {
+  return targetType === OrganizationEventTargetType.AGENTIC_WORKFLOW
+    ? 'Agent task'
+    : upperCaseFirstLetter(targetType).replace(/_/g, ' ')
+}
 
 function getTargetTypeSelected(selectedItems: SelectedItem[]): OrganizationEventTargetType | undefined {
   const selectedTargetType = selectedItems.find((selectedItem) => {

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
@@ -42,19 +42,19 @@ interface FormValues {
 }
 
 const PAGE_CONTENT: Record<SettingsPage, { title: string; description: string }> = {
-  general: { title: 'General settings', description: 'Configure the workflow name, description, and availability.' },
+  general: { title: 'General settings', description: 'Configure the agent task name, description, and availability.' },
   'ai-configuration': {
     title: 'AI configuration',
-    description: 'Configure the model and instructions used by this workflow.',
+    description: 'Configure the model and instructions used by this agent task.',
   },
   connections: {
     title: 'Connections',
-    description: 'Configure the Git repositories, MCP servers, and Dockerfile fragment available to the workflow.',
+    description: 'Configure the Git repositories, MCP servers, and Dockerfile fragment available to the agent task.',
   },
-  outputs: { title: 'Outputs', description: 'Configure the webhooks called when the workflow produces an output.' },
+  outputs: { title: 'Outputs', description: 'Configure the webhooks called when the agent task produces an output.' },
   governance: {
     title: 'Governance',
-    description: 'Control the hosts and webhook source addresses allowed for this workflow.',
+    description: 'Control the hosts and webhook source addresses allowed for this agent task.',
   },
 }
 
@@ -241,7 +241,7 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
               name="name"
               label="Name"
               value={values.name}
-              error={!values.name.trim() ? 'Please enter a workflow name.' : undefined}
+              error={!values.name.trim() ? 'Please enter an agent task name.' : undefined}
               onChange={(event) => form.setValue('name', event.currentTarget.value, { shouldDirty: true })}
             />
             <InputTextArea
@@ -254,14 +254,14 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
               small
               align="top"
               value={values.enabled}
-              title="Enable workflow"
-              description="Allow this workflow to listen for and process incoming requests."
+              title="Enable agent task"
+              description="Allow this agent task to listen for and process incoming requests."
               onChange={(value) => form.setValue('enabled', value, { shouldDirty: true })}
             />
             <div className="pt-6">
               <h2 className="mb-1 text-base font-medium text-neutral">Resources</h2>
               <p className="mb-4 text-sm text-neutral-subtle">
-                Configure the compute resources allocated to the workflow.
+                Configure the compute resources allocated to the agent task.
               </p>
               <div className="grid gap-4 sm:grid-cols-2">
                 {(['cpu', 'ram', 'gpu', 'storage'] as const).map((name) => (
@@ -303,7 +303,7 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
               <div>
                 <h2 className="text-base font-medium text-neutral">Git repositories</h2>
                 <p className="mt-1 text-sm text-neutral-subtle">
-                  Select the repositories and branches the workflow can access.
+                  Select the repositories and branches the agent task can access.
                 </p>
               </div>
               <Button type="button" variant="outline" color="neutral" size="sm" onClick={addRepository}>

--- a/libs/domains/services/feature/src/lib/agentic-workflow-service-actions/agentic-workflow-service-actions.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-service-actions/agentic-workflow-service-actions.tsx
@@ -44,8 +44,7 @@ export function AgenticWorkflowServiceActions({
   const deleteAgenticWorkflow = () => {
     openModalConfirmation({
       title: `Delete ${service.name}?`,
-      description:
-        'This will permanently delete the agentic workflow and its associated data. This action cannot be undone.',
+      description: 'This will permanently delete the agent task and its associated data. This action cannot be undone.',
       name: service.name,
       action: async () => {
         await deleteService({ serviceId: service.id, serviceType: service.serviceType })

--- a/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.spec.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.spec.tsx
@@ -70,7 +70,7 @@ describe('AgenticWorkflowServiceList', () => {
     })
     renderWithProviders(<AgenticWorkflowServiceList environment={environment} />)
 
-    expect(screen.getByRole('heading', { name: 'Agentic workflows' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Agent tasks' })).toBeInTheDocument()
     expect(screen.getByText('Review pull requests')).toBeInTheDocument()
     expect(screen.getByText('Triage incidents')).toBeInTheDocument()
     expect(screen.getByText('Enabled')).toBeInTheDocument()

--- a/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.tsx
@@ -84,9 +84,9 @@ export function AgenticWorkflowServiceList({ environment }: AgenticWorkflowServi
     <Section className="flex flex-col gap-3.5">
       <div className="flex flex-col gap-1">
         <Heading level={3} className="font-medium text-neutral-subtle">
-          Agentic workflows
+          Agent tasks
         </Heading>
-        <p className="text-sm text-neutral-subtle">AI workflows triggered through webhooks and connected services.</p>
+        <p className="text-sm text-neutral-subtle">One-time tasks delegated to AI agents.</p>
       </div>
 
       <div className="flex flex-col overflow-hidden rounded-lg border border-neutral">

--- a/libs/domains/services/feature/src/lib/hooks/use-edit-service/use-edit-service.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-edit-service/use-edit-service.ts
@@ -35,7 +35,7 @@ export function useEditService({
               if (payload.serviceType === 'AGENTIC_WORKFLOW') {
                 return {
                   title: 'Service updated',
-                  description: 'Your agentic workflow settings were saved',
+                  description: 'Your agent task settings were saved',
                 }
               }
               return {

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
@@ -321,9 +321,9 @@ export function AgenticWorkflowConfiguration() {
     <FunnelFlowBody customContentWidth="max-w-[620px]">
       <Section>
         <header className="mb-5">
-          <Heading level={1}>Create agentic workflow</Heading>
+          <Heading level={1}>Create agent task</Heading>
           <p className="mt-1 text-sm leading-5 text-neutral-subtle">
-            Configure the inputs, tools, model, governance, and outputs used by your workflow.
+            Configure the inputs, tools, model, governance, and outputs used by your agent task.
           </p>
         </header>
 
@@ -338,7 +338,7 @@ export function AgenticWorkflowConfiguration() {
               label="Name"
               value={values.name}
               autoFocus
-              error={showNameError ? 'Please enter a workflow name.' : undefined}
+              error={showNameError ? 'Please enter an agent task name.' : undefined}
               onChange={(event) => form.setValue('name', event.currentTarget.value, { shouldDirty: true })}
             />
             <InputTextArea
@@ -374,8 +374,8 @@ export function AgenticWorkflowConfiguration() {
               small
               align="top"
               value={values.workflowEnabled}
-              title="Enable workflow"
-              description="Start listening and executing this workflow as soon as it is created."
+              title="Enable agent task"
+              description="Start listening and executing this agent task as soon as it is created."
               onChange={(value) => form.setValue('workflowEnabled', value, { shouldDirty: true })}
             />
             <ContinueButton disabled={!values.name.trim()} onClick={goToNextSection} />
@@ -708,7 +708,7 @@ export function AgenticWorkflowConfiguration() {
               value={values.agentPrompt}
               textareaClassName="min-h-40"
               variableKeys={variableValues.map((variable) => variable.variable ?? '').filter(Boolean)}
-              hint="Describe the workflow behavior. Example: review incoming webhook payloads, open a pull request when needed, then notify the team."
+              hint="Describe the agent task behavior. Example: review incoming webhook payloads, open a pull request when needed, then notify the team."
               onChange={(value) => form.setValue('agentPrompt', value, { shouldDirty: true })}
             />
             <ContinueButton disabled={!values.agentPrompt.trim()} onClick={goToNextSection} />

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/ai-model-cards.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/ai-model-cards.tsx
@@ -22,7 +22,7 @@ export function AIModelCards() {
           <img src="/assets/ai-tools/claude.svg" alt="" aria-hidden="true" className="h-5 w-5" />
           Anthropic
         </span>
-        <span className="text-xs text-neutral-subtle">Claude models used by the workflow agent.</span>
+        <span className="text-xs text-neutral-subtle">Claude models used by the agent task.</span>
       </button>
       <button
         type="button"

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
@@ -154,9 +154,9 @@ export function AgenticWorkflowSummary() {
     <FunnelFlowBody customContentWidth="max-w-[1024px]">
       <Section className="space-y-10">
         <div className="flex flex-col gap-2">
-          <Heading className="mb-2">Ready to create your agentic workflow</Heading>
+          <Heading className="mb-2">Ready to create your agent task</Heading>
           <p className="text-sm text-neutral-subtle">
-            Review the workflow configuration before creating it. Webhook details will be generated after creation.
+            Review the agent task configuration before creating it. Webhook details will be generated after creation.
           </p>
         </div>
 

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -131,7 +131,7 @@ describe('ServiceNew', () => {
     expect(screen.getByText('Cron Job')).toBeInTheDocument()
     expect(screen.getByText('Helm')).toBeInTheDocument()
     expect(screen.getAllByText('Terraform').length).toBeGreaterThanOrEqual(1)
-    expect(screen.queryByText('Agentic workflow')).not.toBeInTheDocument()
+    expect(screen.queryByText('Agent task')).not.toBeInTheDocument()
   })
 
   it('should render agentic workflow entry when feature flag is enabled', () => {
@@ -141,8 +141,8 @@ describe('ServiceNew', () => {
       <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
     )
 
-    expect(screen.getByText('Agentic workflow')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Agentic workflow/i })).toHaveAttribute(
+    expect(screen.getByText('Agent task')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Agent task/i })).toHaveAttribute(
       'href',
       '/organization/org-1/project/project-1/environment/env-1/service/create/agentic-workflow'
     )

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -165,8 +165,8 @@ export function ServiceNew({
       ...(isAgenticWorkflowEnabled
         ? [
             {
-              title: 'Agentic workflow',
-              description: 'Run an AI workflow with webhooks, MCPs, governance, and configured outputs.',
+              title: 'Agent task',
+              description: 'Delegate a one-time task to an AI agent with access to repositories, MCPs, and webhooks.',
               icon: <Icon name="AGENTIC_WORKFLOW" width={32} height={32} />,
               link: getServicesPath(organizationId, projectId, environmentId, '/service/create/agentic-workflow'),
               cloud_provider: cloudProvider,


### PR DESCRIPTION
## Summary

**Issue**: N/A

- Rename the user-facing Agentic workflow terminology to Agent task across service creation, environment overview, settings, notifications, confirmation copy, document titles, and audit-log filters.
- Present Agent tasks as one-time tasks delegated to AI agents.
- Keep the existing `AGENTIC_WORKFLOW` API contracts, internal identifiers, routes, and telemetry values unchanged.
- Centralize the audit-log target label and cover its API-to-product-name mapping with a unit test.

## Screenshots / Recordings

Not included: this PR only updates product copy and does not change layout or behavior.

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [x] Focused Jest suites for services, service settings, and audit logs
- [x] Formatting checked
- [x] ESLint checked on all changed TypeScript files (zero errors; one pre-existing hook dependency warning)

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-a-scope-when-possible) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the user-facing "Agentic workflow" terminology to "Agent task" across service creation, settings, environment overview, notifications, confirmation copy, document titles, and audit-log filters. Only product copy changes; existing `AGENTIC_WORKFLOW` API contracts, internal identifiers, routes, and telemetry values remain unchanged.

- Centralizes audit-log target type mapping in a `getTargetTypeLabel` helper so the `AGENTIC_WORKFLOW` API type displays as "Agent task" in filters, badges, and event rows, covered by unit tests.

<sup>Written for commit f4e5c49ec0d1a0400d23910e107a3463dd67f377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

