### PR TITLE
fix(onboarding): require a use case selection so onboarding.use_cases is never empty

### DIFF
--- a/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
@@ -35,12 +35,11 @@ interface UseCaseCardProps {
   value: string
   label: string
   iconName: IconName
-  colSpan: string
   selected: boolean
   onToggle: (value: string) => void
 }
 
-function UseCaseCard({ value, label, iconName, colSpan, selected, onToggle }: UseCaseCardProps) {
+function UseCaseCard({ value, label, iconName, selected, onToggle }: UseCaseCardProps) {
   return (
     <div
       role="checkbox"
@@ -54,8 +53,7 @@ function UseCaseCard({ value, label, iconName, colSpan, selected, onToggle }: Us
         }
       }}
       className={twMerge(
-        'focus-visible:outline-brand-11 flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
-        colSpan,
+        'focus-visible:outline-brand-11 flex w-[calc((100%-1.5rem)/3)] cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
         selected
           ? 'border-brand-component bg-surface-brand-subtle'
           : 'border-neutral bg-background hover:border-neutral-component hover:bg-surface-neutral-subtle'
@@ -83,14 +81,13 @@ export function StepUseCases({ onSubmit, onBack }: StepUseCasesProps) {
     <div className="mx-auto max-w-content-with-navigation-left pb-10">
       <h1 className="h3 mb-3 text-neutral">What are you looking to do?</h1>
       <p className="mb-10 text-sm text-neutral">Select all that apply.</p>
-      <div className="grid grid-cols-6 gap-3">
+      <div className="flex flex-wrap justify-center gap-3">
         {USE_CASES.map((useCase) => (
           <UseCaseCard
             key={useCase.value}
             value={useCase.value}
             label={useCase.label}
             iconName={useCase.iconName}
-            colSpan="col-span-2"
             selected={selected.includes(useCase.value)}
             onToggle={toggle}
           />

--- a/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
@@ -106,7 +106,7 @@ export function StepUseCases({ onSubmit, onBack }: StepUseCasesProps) {
           <Icon iconName="arrow-left" />
           Back
         </Button>
-        <Button type="button" size="lg" onClick={() => onSubmit(selected)}>
+        <Button type="button" size="lg" disabled={selected.length === 0} onClick={() => onSubmit(selected)}>
           Continue
         </Button>
       </div>

--- a/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
@@ -10,16 +10,6 @@ const USE_CASES: Array<{ value: string; label: string; iconName: IconName }> = [
     iconName: 'microchip-ai',
   },
   {
-    value: 'rde',
-    label: 'Enable my non-tech team to ship apps',
-    iconName: 'users',
-  },
-  {
-    value: 'spec-to-prod',
-    label: 'Go from spec to production with AI coding agents',
-    iconName: 'diagram-project',
-  },
-  {
     value: 'automate-deployments',
     label: 'Automate deployments without manual steps',
     iconName: 'rocket',
@@ -88,7 +78,7 @@ export function StepUseCases({ onSubmit, onBack }: StepUseCasesProps) {
     <div className="mx-auto max-w-content-with-navigation-left pb-10">
       <h1 className="h3 mb-3 text-neutral">What are you looking to do?</h1>
       <p className="mb-10 text-sm text-neutral">Select all that apply.</p>
-      <div className="grid grid-cols-6 gap-3">
+      <div className="grid grid-cols-4 gap-3">
         {USE_CASES.map((useCase) => (
           <UseCaseCard
             key={useCase.value}

--- a/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
@@ -53,7 +53,7 @@ function UseCaseCard({ value, label, iconName, selected, onToggle }: UseCaseCard
         }
       }}
       className={twMerge(
-'focus-visible:outline-brand-11 flex w-[calc((100%_-_1.5rem)/3)] cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+        'focus-visible:outline-brand-11 flex w-[calc((100%_-_1.5rem)/3)] cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
         selected
           ? 'border-brand-component bg-surface-brand-subtle'
           : 'border-neutral bg-background hover:border-neutral-component hover:bg-surface-neutral-subtle'

--- a/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
@@ -53,7 +53,7 @@ function UseCaseCard({ value, label, iconName, selected, onToggle }: UseCaseCard
         }
       }}
       className={twMerge(
-        'focus-visible:outline-brand-11 flex w-[calc((100%-1.5rem)/3)] cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+'focus-visible:outline-brand-11 flex w-[calc((100%_-_1.5rem)/3)] cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
         selected
           ? 'border-brand-component bg-surface-brand-subtle'
           : 'border-neutral bg-background hover:border-neutral-component hover:bg-surface-neutral-subtle'

--- a/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
@@ -15,6 +15,11 @@ const USE_CASES: Array<{ value: string; label: string; iconName: IconName }> = [
     iconName: 'rocket',
   },
   {
+    value: 'migrate-to-qovery',
+    label: 'Migrate to Qovery from Heroku, Render or another PaaS',
+    iconName: 'right-left',
+  },
+  {
     value: 'ephemeral-environments',
     label: 'Create environments on demand (testing/dev/QA)',
     iconName: 'flask',
@@ -78,7 +83,7 @@ export function StepUseCases({ onSubmit, onBack }: StepUseCasesProps) {
     <div className="mx-auto max-w-content-with-navigation-left pb-10">
       <h1 className="h3 mb-3 text-neutral">What are you looking to do?</h1>
       <p className="mb-10 text-sm text-neutral">Select all that apply.</p>
-      <div className="grid grid-cols-4 gap-3">
+      <div className="grid grid-cols-6 gap-3">
         {USE_CASES.map((useCase) => (
           <UseCaseCard
             key={useCase.value}

--- a/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
@@ -15,8 +15,8 @@ const USE_CASES: Array<{ value: string; label: string; iconName: IconName }> = [
     iconName: 'rocket',
   },
   {
-    value: 'migrate-to-qovery',
-    label: 'Migrate to Qovery from Heroku, Render or another PaaS',
+    value: 'migrate-cloud-provider',
+    label: 'Migrate to another cloud provider from Heroku, Render or another PaaS',
     iconName: 'right-left',
   },
   {


### PR DESCRIPTION
## Summary

**Issue**: QOV-2195

- Some orgs never populated onboarding.use_cases because the "Continue" button on the use-cases step could be clicked with nothing selected, permanently hiding the "Getting started" checklist on the org overview for every member.
- Made use case selection mandatory (disable "Continue" until at least one is picked).
- Replaced rde and spec-to-prod use cases with a new migrate-to-qovery one.
- Switched the cards layout to flex flex-wrap justify-center so an incomplete last row stays centered.

## Screenshots / Recordings

| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| <img width="743" height="433" alt="image" src="https://github.com/user-attachments/assets/5344e3c8-6b68-4208-a738-e11acdf10504" /> | <img width="752" height="430" alt="image" src="https://github.com/user-attachments/assets/6a442884-0c27-4283-8381-669b82c10801" />|

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires onboarding users to select at least one use case before continuing, fixing QOV-2195 so the getting-started checklist is no longer permanently hidden by an empty selection.

- Replaces the `rde` and `spec-to-prod` options with a "Migrate to another cloud provider from Heroku, Render or another PaaS" use case.
- Centers the use case cards when the last row is incomplete.
- The Continue button is disabled until at least one use case is selected.

<sup>Written for commit 62b3790d6487a6bc082ef7cb806fdaeff8bf3c0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



