### PR TITLE
chore(release): promote staging to production

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/configuration.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/configuration.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute(
 })
 
 function RouteComponent() {
-  useDocumentTitle('Agentic workflow configuration')
+  useDocumentTitle('Agent task configuration')
 
   return <AgenticWorkflowConfiguration />
 }

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/summary.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/summary.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute(
 })
 
 function RouteComponent() {
-  useDocumentTitle('Summary - Create agentic workflow')
+  useDocumentTitle('Summary - Create agent task')
 
   return <AgenticWorkflowSummary />
 }

--- a/libs/domains/audit-logs/feature/src/lib/audit-logs-view/audit-logs-view.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/audit-logs-view/audit-logs-view.tsx
@@ -7,9 +7,8 @@ import { eventsFactoryMock } from '@qovery/shared/factories'
 import { type AuditLogsParams, DEFAULT_PAGE_SIZE } from '@qovery/shared/router'
 import { ALL, type NavigationLevel, type SelectedItem, type TableFilterProps } from '@qovery/shared/ui'
 import { useDocumentTitle, useSupportChat } from '@qovery/shared/util-hooks'
-import { upperCaseFirstLetter } from '@qovery/shared/util-js'
 import { AuditLogs } from '../audit-logs/audit-logs'
-import { initializeSelectedItemsFromQueryParams } from '../utils/target-type-selection-utils'
+import { getTargetTypeLabel, initializeSelectedItemsFromQueryParams } from '../utils/target-type-selection-utils'
 
 const route = getRouteApi('/_authenticated/organization/$organizationId/audit-logs')
 
@@ -107,7 +106,7 @@ export function AuditLogsView() {
 
     const organizationEventTargetTypes = Object.keys(OrganizationEventTargetType).map((item) => ({
       value: item,
-      name: upperCaseFirstLetter(item).replace(/_/g, ' '),
+      name: getTargetTypeLabel(item),
     }))
 
     initializeSelectedItemsFromQueryParams(organizationId, organizationEventTargetTypes, 'target_type', urlParams)

--- a/libs/domains/audit-logs/feature/src/lib/audit-logs/audit-logs.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/audit-logs/audit-logs.tsx
@@ -23,13 +23,13 @@ import {
   type TableHeadProps,
 } from '@qovery/shared/ui'
 import { type SelectedTimestamps } from '@qovery/shared/ui'
-import { upperCaseFirstLetter } from '@qovery/shared/util-js'
 import FilterSection from '../filter-section/filter-section'
 import RowEventFeature from '../row-event-feature/row-event-feature'
 import {
   computeDisplayByLabel,
   computeMenusToDisplay,
   computeSelectedItemsFromFilter,
+  getTargetTypeLabel,
 } from '../utils/target-type-selection-utils'
 
 export interface AuditLogsProps {
@@ -141,7 +141,7 @@ function createTableDataHead(
         initialData: Object.keys(OrganizationEventTargetType).map((item) => {
           return {
             value: item,
-            name: upperCaseFirstLetter(item).replace(/_/g, ' '),
+            name: getTargetTypeLabel(item),
           }
         }),
         initialSelectedItems: targetTypeSelectedItems,

--- a/libs/domains/audit-logs/feature/src/lib/filter-section/filter-section.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/filter-section/filter-section.spec.tsx
@@ -1,3 +1,4 @@
+import { OrganizationEventTargetType } from 'qovery-typescript-axios'
 import { type DecodedValueMap } from 'use-query-params'
 import { type AuditLogsParams } from '@qovery/shared/router'
 import { type SelectedItem } from '@qovery/shared/ui'
@@ -72,6 +73,30 @@ describe('FilterSection', () => {
 
     screen.getByText(/Target Type:/)
     screen.getByText(/Application/)
+  })
+
+  it('should render Agent task in target type and target badges', () => {
+    const queryParamsWithTarget = {
+      targetId: 'target-123',
+      targetType: OrganizationEventTargetType.AGENTIC_WORKFLOW,
+    }
+    const selectedItems: SelectedItem[] = [
+      {
+        filterKey: 'target_id',
+        item: { value: 'target-123', name: 'Review pull requests' },
+      },
+    ]
+
+    renderWithProviders(
+      <FilterSection
+        {...props}
+        queryParams={queryParamsWithTarget as DecodedValueMap<AuditLogsParams>}
+        targetTypeSelectedItems={selectedItems}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /Target Type: Agent task/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Agent task: Review pull requests/ })).toBeInTheDocument()
   })
 
   it('should render user badge when triggeredBy is set', () => {

--- a/libs/domains/audit-logs/feature/src/lib/filter-section/filter-section.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/filter-section/filter-section.tsx
@@ -4,6 +4,7 @@ import { type AuditLogsParams } from '@qovery/shared/router'
 import { Button, Icon, type SelectedItem, type TableFilterProps, Truncate } from '@qovery/shared/ui'
 import { dateYearMonthDayHourMinuteSecond } from '@qovery/shared/util-dates'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
+import { getTargetTypeLabel } from '../utils/target-type-selection-utils'
 
 export interface CustomFilterProps {
   clearFilter: () => void
@@ -55,7 +56,7 @@ function buildBadges(queryParams: AuditLogsParams, selectedItemsTargetType: Sele
     badges.push({
       key: 'target_type',
       displayedName: 'Target Type',
-      value: upperCaseFirstLetter(queryParams.targetType).split('_').join(' '),
+      value: getTargetTypeLabel(queryParams.targetType),
       isDeletable: true,
     })
   }
@@ -105,9 +106,7 @@ function buildBadges(queryParams: AuditLogsParams, selectedItemsTargetType: Sele
     const selectedItem = selectedItemsTargetType.find((selectedItem) => selectedItem.filterKey === 'target_id')
     if (selectedItem) {
       const targetName = selectedItem?.item?.name ?? '...'
-      const targetType = upperCaseFirstLetter(queryParams.targetType ?? '...')
-        .split('_')
-        .join(' ')
+      const targetType = getTargetTypeLabel(queryParams.targetType ?? '...')
       badges.push({
         key: 'target_id',
         displayedName: targetType,

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.spec.tsx
@@ -114,6 +114,20 @@ describe('RowEvent', () => {
     expect(screen.getByText('unsupported-target')).not.toHaveAttribute('href')
   })
 
+  it('should render Agent task for the agentic workflow target type', () => {
+    renderWithProviders(
+      <RowEvent
+        {...props}
+        event={{
+          ...props.event,
+          target_type: OrganizationEventTargetType.AGENTIC_WORKFLOW,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Agent task')).toBeInTheDocument()
+  })
+
   it.each([
     [OrganizationEventTargetType.ORGANIZATION, '/organization/1/settings'],
     [OrganizationEventTargetType.MEMBERS_AND_ROLES, '/organization/1/settings/members'],

--- a/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/row-event/row-event.tsx
@@ -13,6 +13,7 @@ import { IconEnum } from '@qovery/shared/enums'
 import { CodeDiffEditor, CodeEditor, type DiffStats, Icon, Skeleton, Tooltip, Truncate } from '@qovery/shared/ui'
 import { dateFullFormat, dateUTCString } from '@qovery/shared/util-dates'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
+import { getTargetTypeLabel } from '../utils/target-type-selection-utils'
 
 export interface RowEventProps {
   event: OrganizationEventResponse
@@ -312,7 +313,7 @@ export function RowEvent(props: RowEventProps) {
         </div>
         <div className="min-w-0 px-4 text-neutral-subtle">
           <Skeleton height={10} width={80} show={isPlaceholder}>
-            <>{upperCaseFirstLetter(event.target_type ?? '')?.replace(/_/g, ' ')}</>
+            <>{getTargetTypeLabel(event.target_type ?? '')}</>
           </Skeleton>
         </div>
         <div className="min-w-0 px-4">

--- a/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.spec.ts
+++ b/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.spec.ts
@@ -1,6 +1,6 @@
 import { OrganizationEventApi, OrganizationEventTargetType } from 'qovery-typescript-axios'
 import { type SelectedItem } from '@qovery/shared/ui'
-import { computeMenusToDisplay } from './target-type-selection-utils'
+import { computeMenusToDisplay, getTargetTypeLabel } from './target-type-selection-utils'
 
 const mockGetOrganizationEventTargets = jest.spyOn(OrganizationEventApi.prototype, 'getOrganizationEventTargets')
 
@@ -8,7 +8,7 @@ const targetTypeItem: SelectedItem = {
   filterKey: 'target_type',
   item: {
     value: OrganizationEventTargetType.AGENTIC_WORKFLOW,
-    name: 'Agentic workflow',
+    name: 'Agent task',
   },
 }
 
@@ -83,5 +83,15 @@ describe('computeMenusToDisplay', () => {
       'environment-1',
       undefined
     )
+  })
+})
+
+describe('getTargetTypeLabel', () => {
+  it('uses the Agent task product name for the agentic workflow API type', () => {
+    expect(getTargetTypeLabel(OrganizationEventTargetType.AGENTIC_WORKFLOW)).toBe('Agent task')
+  })
+
+  it('formats other API target types', () => {
+    expect(getTargetTypeLabel(OrganizationEventTargetType.CONTAINER_REGISTRY)).toBe('Container registry')
   })
 })

--- a/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.tsx
+++ b/libs/domains/audit-logs/feature/src/lib/utils/target-type-selection-utils.tsx
@@ -6,6 +6,7 @@ import {
   type NavigationLevel,
   type SelectedItem,
 } from '@qovery/shared/ui'
+import { upperCaseFirstLetter } from '@qovery/shared/util-js'
 
 const SERVICE_TARGET_TYPES: ReadonlySet<OrganizationEventTargetType> = new Set([
   OrganizationEventTargetType.AGENTIC_WORKFLOW,
@@ -16,6 +17,12 @@ const SERVICE_TARGET_TYPES: ReadonlySet<OrganizationEventTargetType> = new Set([
   OrganizationEventTargetType.JOB,
   OrganizationEventTargetType.TERRAFORM,
 ])
+
+export function getTargetTypeLabel(targetType: string) {
+  return targetType === OrganizationEventTargetType.AGENTIC_WORKFLOW
+    ? 'Agent task'
+    : upperCaseFirstLetter(targetType).replace(/_/g, ' ')
+}
 
 function getTargetTypeSelected(selectedItems: SelectedItem[]): OrganizationEventTargetType | undefined {
   const selectedTargetType = selectedItems.find((selectedItem) => {

--- a/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.tsx
+++ b/libs/domains/environments/feature/src/lib/environments-table/environment-section/environment-section.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate, useParams } from '@tanstack/react-router'
 import { EnvironmentModeEnum, type EnvironmentOverviewResponse, StateEnum } from 'qovery-typescript-axios'
-import { type KeyboardEvent, type MouseEvent } from 'react'
+import { type KeyboardEvent, type MouseEvent, useMemo } from 'react'
 import { match } from 'ts-pattern'
 import { ClusterAvatar } from '@qovery/domains/clusters/feature'
 import { Button, Checkbox, DeploymentAction, Heading, Icon, Section, TablePrimitives, Tooltip } from '@qovery/shared/ui'
@@ -187,6 +187,11 @@ function EnvRow({
   )
 }
 
+function lastOperationTimestamp(overview: EnvironmentOverviewResponse) {
+  const lastDeploymentDate = overview.deployment_status?.last_deployment_date
+  return lastDeploymentDate ? new Date(lastDeploymentDate).getTime() : 0
+}
+
 export function EnvironmentSection({
   type,
   items,
@@ -208,6 +213,16 @@ export function EnvironmentSection({
     .with('DEVELOPMENT', () => 'Development')
     .with('PREVIEW', () => 'Ephemeral')
     .exhaustive()
+
+  const sortedItems = useMemo(() => {
+    if (type !== EnvironmentModeEnum.PREVIEW) {
+      return items
+    }
+
+    return [...items].sort(
+      (environmentA, environmentB) => lastOperationTimestamp(environmentB) - lastOperationTimestamp(environmentA)
+    )
+  }, [items, type])
 
   const EmptyState = () =>
     match(type)
@@ -295,7 +310,7 @@ export function EnvironmentSection({
           </Table.Header>
 
           <Table.Body className="divide-y divide-neutral">
-            {items.map((environmentOverview) => (
+            {sortedItems.map((environmentOverview) => (
               <EnvRow
                 key={environmentOverview.id}
                 overview={environmentOverview}

--- a/libs/domains/environments/feature/src/lib/environments-table/environments-table.spec.tsx
+++ b/libs/domains/environments/feature/src/lib/environments-table/environments-table.spec.tsx
@@ -39,7 +39,12 @@ jest.mock('./environments-table-action-bar', () => ({
   EnvironmentsTableActionBar: () => <div data-testid="environments-table-action-bar" />,
 }))
 
-function environmentOverview(id: string, mode: EnvironmentModeEnum, name: string): EnvironmentOverviewResponse {
+function environmentOverview(
+  id: string,
+  mode: EnvironmentModeEnum,
+  name: string,
+  lastDeploymentDate?: string
+): EnvironmentOverviewResponse {
   return {
     id,
     mode,
@@ -48,6 +53,7 @@ function environmentOverview(id: string, mode: EnvironmentModeEnum, name: string
       service_count: 0,
       managed_by: 'QOVERY',
     },
+    ...(lastDeploymentDate ? { deployment_status: { last_deployment_date: lastDeploymentDate } } : {}),
   } as EnvironmentOverviewResponse
 }
 
@@ -91,6 +97,25 @@ describe('EnvironmentsTable', () => {
       'Alpha',
       'Zulu',
       'Beta',
+    ])
+  })
+
+  it('should sort ephemeral environments by last operation with newer environments first', () => {
+    mockUseProject.mockReturnValue({ data: { name: 'Project Alpha' } })
+    mockUseEnvironmentsOverview.mockReturnValue({
+      data: [
+        environmentOverview('env-1', EnvironmentModeEnum.PREVIEW, 'Bravo', '2024-03-01T00:00:00Z'),
+        environmentOverview('env-2', EnvironmentModeEnum.PREVIEW, 'Alpha', '2024-01-01T00:00:00Z'),
+        environmentOverview('env-3', EnvironmentModeEnum.PREVIEW, 'Charlie', '2024-02-01T00:00:00Z'),
+      ],
+    })
+
+    renderWithProviders(<EnvironmentsTable />)
+
+    expect(screen.getAllByRole('link', { name: /^(Alpha|Bravo|Charlie)$/ }).map((link) => link.textContent)).toEqual([
+      'Bravo',
+      'Charlie',
+      'Alpha',
     ])
   })
 

--- a/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
+++ b/libs/domains/onboarding/feature/src/lib/step-use-cases/step-use-cases.tsx
@@ -10,19 +10,14 @@ const USE_CASES: Array<{ value: string; label: string; iconName: IconName }> = [
     iconName: 'microchip-ai',
   },
   {
-    value: 'rde',
-    label: 'Enable my non-tech team to ship apps',
-    iconName: 'users',
-  },
-  {
-    value: 'spec-to-prod',
-    label: 'Go from spec to production with AI coding agents',
-    iconName: 'diagram-project',
-  },
-  {
     value: 'automate-deployments',
     label: 'Automate deployments without manual steps',
     iconName: 'rocket',
+  },
+  {
+    value: 'migrate-cloud-provider',
+    label: 'Migrate to another cloud provider from Heroku, Render or another PaaS',
+    iconName: 'right-left',
   },
   {
     value: 'ephemeral-environments',
@@ -40,12 +35,11 @@ interface UseCaseCardProps {
   value: string
   label: string
   iconName: IconName
-  colSpan: string
   selected: boolean
   onToggle: (value: string) => void
 }
 
-function UseCaseCard({ value, label, iconName, colSpan, selected, onToggle }: UseCaseCardProps) {
+function UseCaseCard({ value, label, iconName, selected, onToggle }: UseCaseCardProps) {
   return (
     <div
       role="checkbox"
@@ -59,8 +53,7 @@ function UseCaseCard({ value, label, iconName, colSpan, selected, onToggle }: Us
         }
       }}
       className={twMerge(
-        'focus-visible:outline-brand-11 flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
-        colSpan,
+        'focus-visible:outline-brand-11 flex w-[calc((100%_-_1.5rem)/3)] cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
         selected
           ? 'border-brand-component bg-surface-brand-subtle'
           : 'border-neutral bg-background hover:border-neutral-component hover:bg-surface-neutral-subtle'
@@ -88,14 +81,13 @@ export function StepUseCases({ onSubmit, onBack }: StepUseCasesProps) {
     <div className="mx-auto max-w-content-with-navigation-left pb-10">
       <h1 className="h3 mb-3 text-neutral">What are you looking to do?</h1>
       <p className="mb-10 text-sm text-neutral">Select all that apply.</p>
-      <div className="grid grid-cols-6 gap-3">
+      <div className="flex flex-wrap justify-center gap-3">
         {USE_CASES.map((useCase) => (
           <UseCaseCard
             key={useCase.value}
             value={useCase.value}
             label={useCase.label}
             iconName={useCase.iconName}
-            colSpan="col-span-2"
             selected={selected.includes(useCase.value)}
             onToggle={toggle}
           />
@@ -106,7 +98,7 @@ export function StepUseCases({ onSubmit, onBack }: StepUseCasesProps) {
           <Icon iconName="arrow-left" />
           Back
         </Button>
-        <Button type="button" size="lg" onClick={() => onSubmit(selected)}>
+        <Button type="button" size="lg" disabled={selected.length === 0} onClick={() => onSubmit(selected)}>
           Continue
         </Button>
       </div>

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
@@ -42,19 +42,19 @@ interface FormValues {
 }
 
 const PAGE_CONTENT: Record<SettingsPage, { title: string; description: string }> = {
-  general: { title: 'General settings', description: 'Configure the workflow name, description, and availability.' },
+  general: { title: 'General settings', description: 'Configure the agent task name, description, and availability.' },
   'ai-configuration': {
     title: 'AI configuration',
-    description: 'Configure the model and instructions used by this workflow.',
+    description: 'Configure the model and instructions used by this agent task.',
   },
   connections: {
     title: 'Connections',
-    description: 'Configure the Git repositories, MCP servers, and Dockerfile fragment available to the workflow.',
+    description: 'Configure the Git repositories, MCP servers, and Dockerfile fragment available to the agent task.',
   },
-  outputs: { title: 'Outputs', description: 'Configure the webhooks called when the workflow produces an output.' },
+  outputs: { title: 'Outputs', description: 'Configure the webhooks called when the agent task produces an output.' },
   governance: {
     title: 'Governance',
-    description: 'Control the hosts and webhook source addresses allowed for this workflow.',
+    description: 'Control the hosts and webhook source addresses allowed for this agent task.',
   },
 }
 
@@ -241,7 +241,7 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
               name="name"
               label="Name"
               value={values.name}
-              error={!values.name.trim() ? 'Please enter a workflow name.' : undefined}
+              error={!values.name.trim() ? 'Please enter an agent task name.' : undefined}
               onChange={(event) => form.setValue('name', event.currentTarget.value, { shouldDirty: true })}
             />
             <InputTextArea
@@ -254,14 +254,14 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
               small
               align="top"
               value={values.enabled}
-              title="Enable workflow"
-              description="Allow this workflow to listen for and process incoming requests."
+              title="Enable agent task"
+              description="Allow this agent task to listen for and process incoming requests."
               onChange={(value) => form.setValue('enabled', value, { shouldDirty: true })}
             />
             <div className="pt-6">
               <h2 className="mb-1 text-base font-medium text-neutral">Resources</h2>
               <p className="mb-4 text-sm text-neutral-subtle">
-                Configure the compute resources allocated to the workflow.
+                Configure the compute resources allocated to the agent task.
               </p>
               <div className="grid gap-4 sm:grid-cols-2">
                 {(['cpu', 'ram', 'gpu', 'storage'] as const).map((name) => (
@@ -303,7 +303,7 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
               <div>
                 <h2 className="text-base font-medium text-neutral">Git repositories</h2>
                 <p className="mt-1 text-sm text-neutral-subtle">
-                  Select the repositories and branches the workflow can access.
+                  Select the repositories and branches the agent task can access.
                 </p>
               </div>
               <Button type="button" variant="outline" color="neutral" size="sm" onClick={addRepository}>

--- a/libs/domains/services/feature/src/lib/agentic-workflow-service-actions/agentic-workflow-service-actions.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-service-actions/agentic-workflow-service-actions.tsx
@@ -44,8 +44,7 @@ export function AgenticWorkflowServiceActions({
   const deleteAgenticWorkflow = () => {
     openModalConfirmation({
       title: `Delete ${service.name}?`,
-      description:
-        'This will permanently delete the agentic workflow and its associated data. This action cannot be undone.',
+      description: 'This will permanently delete the agent task and its associated data. This action cannot be undone.',
       name: service.name,
       action: async () => {
         await deleteService({ serviceId: service.id, serviceType: service.serviceType })

--- a/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.spec.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.spec.tsx
@@ -70,7 +70,7 @@ describe('AgenticWorkflowServiceList', () => {
     })
     renderWithProviders(<AgenticWorkflowServiceList environment={environment} />)
 
-    expect(screen.getByRole('heading', { name: 'Agentic workflows' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Agent tasks' })).toBeInTheDocument()
     expect(screen.getByText('Review pull requests')).toBeInTheDocument()
     expect(screen.getByText('Triage incidents')).toBeInTheDocument()
     expect(screen.getByText('Enabled')).toBeInTheDocument()

--- a/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.tsx
@@ -84,9 +84,9 @@ export function AgenticWorkflowServiceList({ environment }: AgenticWorkflowServi
     <Section className="flex flex-col gap-3.5">
       <div className="flex flex-col gap-1">
         <Heading level={3} className="font-medium text-neutral-subtle">
-          Agentic workflows
+          Agent tasks
         </Heading>
-        <p className="text-sm text-neutral-subtle">AI workflows triggered through webhooks and connected services.</p>
+        <p className="text-sm text-neutral-subtle">One-time tasks delegated to AI agents.</p>
       </div>
 
       <div className="flex flex-col overflow-hidden rounded-lg border border-neutral">

--- a/libs/domains/services/feature/src/lib/hooks/use-edit-service/use-edit-service.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-edit-service/use-edit-service.ts
@@ -35,7 +35,7 @@ export function useEditService({
               if (payload.serviceType === 'AGENTIC_WORKFLOW') {
                 return {
                   title: 'Service updated',
-                  description: 'Your agentic workflow settings were saved',
+                  description: 'Your agent task settings were saved',
                 }
               }
               return {

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
@@ -321,9 +321,9 @@ export function AgenticWorkflowConfiguration() {
     <FunnelFlowBody customContentWidth="max-w-[620px]">
       <Section>
         <header className="mb-5">
-          <Heading level={1}>Create agentic workflow</Heading>
+          <Heading level={1}>Create agent task</Heading>
           <p className="mt-1 text-sm leading-5 text-neutral-subtle">
-            Configure the inputs, tools, model, governance, and outputs used by your workflow.
+            Configure the inputs, tools, model, governance, and outputs used by your agent task.
           </p>
         </header>
 
@@ -338,7 +338,7 @@ export function AgenticWorkflowConfiguration() {
               label="Name"
               value={values.name}
               autoFocus
-              error={showNameError ? 'Please enter a workflow name.' : undefined}
+              error={showNameError ? 'Please enter an agent task name.' : undefined}
               onChange={(event) => form.setValue('name', event.currentTarget.value, { shouldDirty: true })}
             />
             <InputTextArea
@@ -374,8 +374,8 @@ export function AgenticWorkflowConfiguration() {
               small
               align="top"
               value={values.workflowEnabled}
-              title="Enable workflow"
-              description="Start listening and executing this workflow as soon as it is created."
+              title="Enable agent task"
+              description="Start listening and executing this agent task as soon as it is created."
               onChange={(value) => form.setValue('workflowEnabled', value, { shouldDirty: true })}
             />
             <ContinueButton disabled={!values.name.trim()} onClick={goToNextSection} />
@@ -708,7 +708,7 @@ export function AgenticWorkflowConfiguration() {
               value={values.agentPrompt}
               textareaClassName="min-h-40"
               variableKeys={variableValues.map((variable) => variable.variable ?? '').filter(Boolean)}
-              hint="Describe the workflow behavior. Example: review incoming webhook payloads, open a pull request when needed, then notify the team."
+              hint="Describe the agent task behavior. Example: review incoming webhook payloads, open a pull request when needed, then notify the team."
               onChange={(value) => form.setValue('agentPrompt', value, { shouldDirty: true })}
             />
             <ContinueButton disabled={!values.agentPrompt.trim()} onClick={goToNextSection} />

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/ai-model-cards.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/ai-model-cards.tsx
@@ -22,7 +22,7 @@ export function AIModelCards() {
           <img src="/assets/ai-tools/claude.svg" alt="" aria-hidden="true" className="h-5 w-5" />
           Anthropic
         </span>
-        <span className="text-xs text-neutral-subtle">Claude models used by the workflow agent.</span>
+        <span className="text-xs text-neutral-subtle">Claude models used by the agent task.</span>
       </button>
       <button
         type="button"

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-summary.tsx
@@ -154,9 +154,9 @@ export function AgenticWorkflowSummary() {
     <FunnelFlowBody customContentWidth="max-w-[1024px]">
       <Section className="space-y-10">
         <div className="flex flex-col gap-2">
-          <Heading className="mb-2">Ready to create your agentic workflow</Heading>
+          <Heading className="mb-2">Ready to create your agent task</Heading>
           <p className="text-sm text-neutral-subtle">
-            Review the workflow configuration before creating it. Webhook details will be generated after creation.
+            Review the agent task configuration before creating it. Webhook details will be generated after creation.
           </p>
         </div>
 

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -131,7 +131,7 @@ describe('ServiceNew', () => {
     expect(screen.getByText('Cron Job')).toBeInTheDocument()
     expect(screen.getByText('Helm')).toBeInTheDocument()
     expect(screen.getAllByText('Terraform').length).toBeGreaterThanOrEqual(1)
-    expect(screen.queryByText('Agentic workflow')).not.toBeInTheDocument()
+    expect(screen.queryByText('Agent task')).not.toBeInTheDocument()
   })
 
   it('should render agentic workflow entry when feature flag is enabled', () => {
@@ -141,8 +141,8 @@ describe('ServiceNew', () => {
       <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
     )
 
-    expect(screen.getByText('Agentic workflow')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Agentic workflow/i })).toHaveAttribute(
+    expect(screen.getByText('Agent task')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Agent task/i })).toHaveAttribute(
       'href',
       '/organization/org-1/project/project-1/environment/env-1/service/create/agentic-workflow'
     )

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -165,8 +165,8 @@ export function ServiceNew({
       ...(isAgenticWorkflowEnabled
         ? [
             {
-              title: 'Agentic workflow',
-              description: 'Run an AI workflow with webhooks, MCPs, governance, and configured outputs.',
+              title: 'Agent task',
+              description: 'Delegate a one-time task to an AI agent with access to repositories, MCPs, and webhooks.',
               icon: <Icon name="AGENTIC_WORKFLOW" width={32} height={32} />,
               link: getServicesPath(organizationId, projectId, environmentId, '/service/create/agentic-workflow'),
               cloud_provider: cloudProvider,


### PR DESCRIPTION
Opens the production promotion path from staging to main. Merging this PR triggers semantic-release, then the existing production deployment workflow.

Do not squash this PR. Use a merge commit to preserve the original conventional commits for semantic-release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes staging to main so the accumulated changes ship to production. Merging triggers semantic-release and the existing production deployment workflow.

Do not squash this PR. Use a merge commit to preserve the original conventional commits for semantic-release.

**Changes included**
- Renames the "agentic workflow" product surface to "agent task" across the console, service creation, settings, and audit log labels.
- Sorts ephemeral environments by last operation, newest first.
- Requires at least one onboarding use case before continuing and updates the available use case options.

<sup>Written for commit 4064d1c22d1eb88dc7adf608ff234f10e8979aab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

