### PR TITLE
fix(cluster-logs): remove gap between scroll controls

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.spec.tsx
@@ -53,6 +53,13 @@ describe('ClusterHeaderLogs', () => {
     expect(refScrollSection?.current?.scroll).toHaveBeenCalledWith(0, refScrollSection?.current?.scrollHeight)
   })
 
+  it('should render scroll controls without a gap', () => {
+    renderWithProviders(<ClusterHeaderLogs {...props} />)
+
+    expect(screen.getByTestId('scroll-up-button').parentElement).toHaveClass('gap-0')
+    expect(screen.getByTestId('scroll-down-button')).not.toHaveClass('mr-2')
+  })
+
   it('should trigger download on click', async () => {
     const { userEvent } = renderWithProviders(<ClusterHeaderLogs {...props} />)
     const buttons = screen.getAllByRole('button')

--- a/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.tsx
@@ -95,30 +95,32 @@ export function ClusterHeaderLogs({ cluster, clusterStatus, refScrollSection, da
             Launch diagnostic for this error
           </Button>
         )}
-        <Button
-          data-testid="scroll-up-button"
-          className="rounded-br-none rounded-tr-none border-r-0"
-          type="button"
-          variant="outline"
-          color="neutral"
-          size="sm"
-          iconOnly
-          onClick={() => forcedScroll()}
-        >
-          <Icon iconName="arrow-up-to-line" />
-        </Button>
-        <Button
-          data-testid="scroll-down-button"
-          className="mr-2 rounded-bl-none rounded-tl-none"
-          variant="outline"
-          type="button"
-          color="neutral"
-          size="sm"
-          iconOnly
-          onClick={() => forcedScroll(true)}
-        >
-          <Icon iconName="arrow-down-to-line" />
-        </Button>
+        <div className="flex items-center gap-0">
+          <Button
+            data-testid="scroll-up-button"
+            className="rounded-br-none rounded-tr-none border-r-0"
+            type="button"
+            variant="outline"
+            color="neutral"
+            size="sm"
+            iconOnly
+            onClick={() => forcedScroll()}
+          >
+            <Icon iconName="arrow-up-to-line" />
+          </Button>
+          <Button
+            data-testid="scroll-down-button"
+            className="rounded-bl-none rounded-tl-none"
+            variant="outline"
+            type="button"
+            color="neutral"
+            size="sm"
+            iconOnly
+            onClick={() => forcedScroll(true)}
+          >
+            <Icon iconName="arrow-down-to-line" />
+          </Button>
+        </div>
         <Button
           type="button"
           variant="outline"


### PR DESCRIPTION
## Summary
- group the cluster deployment-log scroll controls with zero gap
- remove the extra margin that separated the joined buttons
- add a regression test for the control layout

## Validation
- Prettier: passed
- ESLint: passed
- Jest: blocked before execution because the local install is missing declared dependency `@radix-ui/react-switch`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the gap between the cluster log scroll up and down buttons so they render as a single joined control instead of two separated buttons.

- Groups both buttons in a flex container with zero gap.
- Removes the extra margin that separated the scroll down button.
- Adds a regression test asserting the scroll controls have no gap.

<sup>Written for commit 1e20cda84ff85c2a59934ae39bf5f77b2b7db3a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

