### PR TITLE
feat(dev): support shared environment directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ First use
 
     yarn && yarn setup
 
+### Environment variables
+
+By default, the Console loads its environment variables from the repository's `.env` file. To share one environment configuration across Git worktrees, move the file to a stable directory and pass that directory when starting the Console:
+
+    QOVERY_CONSOLE_ENV_DIR="$HOME/.config/qovery-console" yarn start
+
+Vite loads `.env`, `.env.local`, and mode-specific environment files from that directory. When `QOVERY_CONSOLE_ENV_DIR` is not set, the repository root remains the default.
+
 Start the project on http://localhost:4200
 
     yarn start

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -2,15 +2,18 @@
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { defineConfig, loadEnv } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig(({ mode }) => {
-  const clientEnv = loadEnv(mode, process.cwd(), '')
+  const envDir = resolve(process.env.QOVERY_CONSOLE_ENV_DIR ?? process.cwd())
+  const clientEnv = loadEnv(mode, envDir, '')
+  delete clientEnv.QOVERY_CONSOLE_ENV_DIR
 
   return {
     root: __dirname,
+    envDir,
     cacheDir: '../../node_modules/.vite/apps/console',
     server: {
       port: 4200,


### PR DESCRIPTION
## Summary

**Issue**: N/A

Add support for loading Console environment variables from a stable directory shared across Git worktrees.

- Add `QOVERY_CONSOLE_ENV_DIR` configuration for local development
- Configure Vite to load environment files from the selected directory
- Preserve the repository root as the default environment directory
- Prevent `QOVERY_CONSOLE_ENV_DIR` from being exposed to the client
- Document the new setup in `README.md`

## Screenshots / Recordings

Not applicable.

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports loading Console environment variables from a shared directory so developers can reuse one env config across Git worktrees.

- Adds `QOVERY_CONSOLE_ENV_DIR` to point Vite at the directory containing the env files.
- Falls back to the repository root when the variable isn't set.
- Strips `QOVERY_CONSOLE_ENV_DIR` from the client-side env bundle to avoid leaking it.
- Documents the new setup in `README.md`.

<sup>Written for commit f014de9ba6dd38530304632c688818b06f06e724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

