### PR TITLE
fix(clusters): show advanced settings save action on payload changes

### DIFF
--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
@@ -39,6 +39,21 @@ describe('buildClusterAdvancedSettingsPayload', () => {
     }
   )
 
+  it('should fall back to the default when a string setting is empty', () => {
+    expect(
+      buildClusterAdvancedSettingsPayload(
+        {
+          'load_balancer.size': '',
+        },
+        {
+          'load_balancer.size': 'lb-s',
+        }
+      )
+    ).toEqual({
+      'load_balancer.size': 'lb-s',
+    })
+  })
+
   it('should prefer nested form values over stale flattened values', () => {
     expect(
       buildClusterAdvancedSettingsPayload({

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
@@ -11,6 +11,24 @@ describe('buildClusterAdvancedSettingsPayload', () => {
     })
   })
 
+  it.each(['1.0', 'true', 'null', '1e3'])(
+    'should preserve the JSON-parseable value %s when the setting default is a string',
+    (value) => {
+      expect(
+        buildClusterAdvancedSettingsPayload(
+          {
+            'load_balancer.size': value,
+          },
+          {
+            'load_balancer.size': 'lb-s',
+          }
+        )
+      ).toEqual({
+        'load_balancer.size': value,
+      })
+    }
+  )
+
   it('should prefer nested form values over stale flattened values', () => {
     expect(
       buildClusterAdvancedSettingsPayload({

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
@@ -1,0 +1,26 @@
+import { buildClusterAdvancedSettingsPayload } from './build-cluster-advanced-settings-payload'
+
+describe('buildClusterAdvancedSettingsPayload', () => {
+  it('should preserve already flattened settings', () => {
+    expect(
+      buildClusterAdvancedSettingsPayload({
+        'cluster.setting': '1.0',
+      })
+    ).toEqual({
+      'cluster.setting': 1,
+    })
+  })
+
+  it('should prefer nested form values over stale flattened values', () => {
+    expect(
+      buildClusterAdvancedSettingsPayload({
+        'cluster.setting': '1',
+        cluster: {
+          setting: '2',
+        },
+      })
+    ).toEqual({
+      'cluster.setting': 2,
+    })
+  })
+})

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
@@ -11,6 +11,16 @@ describe('buildClusterAdvancedSettingsPayload', () => {
     })
   })
 
+  it('should normalize a trailing decimal point as a number', () => {
+    expect(
+      buildClusterAdvancedSettingsPayload({
+        'cluster.setting': '1.',
+      })
+    ).toEqual({
+      'cluster.setting': 1,
+    })
+  })
+
   it.each(['1.0', 'true', 'null', '1e3'])(
     'should preserve the JSON-parseable value %s when the setting default is a string',
     (value) => {

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
@@ -31,15 +31,12 @@ export function buildClusterAdvancedSettingsPayload(
   data: Record<string, unknown>,
   defaultAdvancedSettings?: ClusterAdvancedSettings
 ): ClusterAdvancedSettings {
-  const dataWithoutFlatKeys = { ...data }
-
-  Object.keys(dataWithoutFlatKeys).forEach((key) => {
-    if (key.includes('.')) {
-      delete dataWithoutFlatKeys[key]
-    }
-  })
-
-  const dataFormatted = objectFlattener(dataWithoutFlatKeys)
+  const flatData = Object.fromEntries(Object.entries(data).filter(([key]) => key.includes('.')))
+  const nestedData = Object.fromEntries(Object.entries(data).filter(([key]) => !key.includes('.')))
+  const dataFormatted = {
+    ...flatData,
+    ...objectFlattener(nestedData),
+  }
 
   return normalizeClusterAdvancedSettings(dataFormatted, defaultAdvancedSettings)
 }

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
@@ -3,6 +3,10 @@ import { objectFlattener } from '@qovery/shared/util-js'
 
 function normalizeClusterAdvancedSettingValue(value: unknown, defaultValue: unknown): unknown {
   if (typeof value === 'string') {
+    if (value === '') {
+      return typeof defaultValue === 'object' ? defaultValue : defaultValue ?? ''
+    }
+
     if (typeof defaultValue === 'string') {
       return value
     }
@@ -10,10 +14,6 @@ function normalizeClusterAdvancedSettingValue(value: unknown, defaultValue: unkn
     try {
       return JSON.parse(value)
     } catch {
-      if (value === '') {
-        return typeof defaultValue === 'object' ? defaultValue : defaultValue ?? ''
-      }
-
       const numericValue = Number(value)
       if (Number.isFinite(numericValue)) {
         return numericValue

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
@@ -13,6 +13,11 @@ function normalizeClusterAdvancedSettingValue(value: unknown, defaultValue: unkn
       if (value === '') {
         return typeof defaultValue === 'object' ? defaultValue : defaultValue ?? ''
       }
+
+      const numericValue = Number(value)
+      if (Number.isFinite(numericValue)) {
+        return numericValue
+      }
     }
   }
 

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
@@ -3,6 +3,10 @@ import { objectFlattener } from '@qovery/shared/util-js'
 
 function normalizeClusterAdvancedSettingValue(value: unknown, defaultValue: unknown): unknown {
   if (typeof value === 'string') {
+    if (typeof defaultValue === 'string') {
+      return value
+    }
+
     try {
       return JSON.parse(value)
     } catch {

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
@@ -1,0 +1,45 @@
+import { type ClusterAdvancedSettings } from 'qovery-typescript-axios'
+import { objectFlattener } from '@qovery/shared/util-js'
+
+function normalizeClusterAdvancedSettingValue(value: unknown, defaultValue: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch {
+      if (value === '') {
+        return typeof defaultValue === 'object' ? defaultValue : defaultValue ?? ''
+      }
+    }
+  }
+
+  return value
+}
+
+export function normalizeClusterAdvancedSettings(
+  advancedSettings: ClusterAdvancedSettings | Record<string, unknown>,
+  defaultAdvancedSettings?: ClusterAdvancedSettings
+): ClusterAdvancedSettings {
+  return Object.fromEntries(
+    Object.entries(advancedSettings).map(([key, value]) => [
+      key,
+      normalizeClusterAdvancedSettingValue(value, defaultAdvancedSettings?.[key as keyof ClusterAdvancedSettings]),
+    ])
+  ) as ClusterAdvancedSettings
+}
+
+export function buildClusterAdvancedSettingsPayload(
+  data: Record<string, unknown>,
+  defaultAdvancedSettings?: ClusterAdvancedSettings
+): ClusterAdvancedSettings {
+  const dataWithoutFlatKeys = { ...data }
+
+  Object.keys(dataWithoutFlatKeys).forEach((key) => {
+    if (key.includes('.')) {
+      delete dataWithoutFlatKeys[key]
+    }
+  })
+
+  const dataFormatted = objectFlattener(dataWithoutFlatKeys)
+
+  return normalizeClusterAdvancedSettings(dataFormatted, defaultAdvancedSettings)
+}

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
@@ -1,0 +1,65 @@
+import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { ClusterAdvancedSettingsFeature } from './cluster-advanced-settings-feature'
+
+const mockUseClusterAdvancedSettings = jest.fn()
+const mockUseDefaultAdvancedSettings = jest.fn()
+const mockUseEditClusterAdvancedSettings = jest.fn()
+const mockEditClusterAdvancedSettings = jest.fn()
+
+jest.mock('@tanstack/react-router', () => ({
+  useParams: () => ({ organizationId: 'organization-id', clusterId: 'cluster-id' }),
+}))
+
+jest.mock('../hooks/use-cluster-advanced-settings/use-cluster-advanced-settings', () => ({
+  useClusterAdvancedSettings: () => mockUseClusterAdvancedSettings(),
+}))
+
+jest.mock('../hooks/use-default-advanced-settings/use-default-advanced-settings', () => ({
+  useDefaultAdvancedSettings: () => mockUseDefaultAdvancedSettings(),
+}))
+
+jest.mock('../hooks/use-edit-cluster-advanced-settings/use-edit-cluster-advanced-settings', () => ({
+  useEditClusterAdvancedSettings: () => mockUseEditClusterAdvancedSettings(),
+}))
+
+describe('ClusterAdvancedSettingsFeature', () => {
+  beforeEach(() => {
+    mockEditClusterAdvancedSettings.mockReset()
+    mockUseClusterAdvancedSettings.mockReturnValue({
+      data: { 'cluster.setting': 1 },
+      isLoading: false,
+    })
+    mockUseDefaultAdvancedSettings.mockReturnValue({
+      data: { 'cluster.setting': 1 },
+    })
+    mockUseEditClusterAdvancedSettings.mockReturnValue({ mutateAsync: mockEditClusterAdvancedSettings })
+  })
+
+  it('should keep the save banner hidden until the payload changes after the form reset', async () => {
+    const { userEvent } = renderWithProviders(<ClusterAdvancedSettingsFeature />)
+
+    const textarea = await screen.findByRole('textbox')
+    await waitFor(() => expect(textarea).toHaveValue('1'))
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '2')
+
+    await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible())
+  })
+
+  it('should hide the save banner after the settings are saved', async () => {
+    mockEditClusterAdvancedSettings.mockImplementation((_variables: unknown, options?: { onSuccess?: () => void }) =>
+      options?.onSuccess?.()
+    )
+    const { userEvent } = renderWithProviders(<ClusterAdvancedSettingsFeature />)
+
+    const textarea = await screen.findByRole('textbox')
+    await waitFor(() => expect(textarea).toHaveValue('1'))
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '2')
+    await userEvent.click(await screen.findByTestId('submit-button'))
+
+    await waitFor(() => expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument())
+  })
+})

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
@@ -1,4 +1,4 @@
-import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { fireEvent, renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
 import { ClusterAdvancedSettingsFeature } from './cluster-advanced-settings-feature'
 
 const mockUseClusterAdvancedSettings = jest.fn()
@@ -82,6 +82,9 @@ describe('ClusterAdvancedSettingsFeature', () => {
     await userEvent.type(textarea, '2')
     await userEvent.click(await screen.findByTestId('submit-button'))
 
-    await waitFor(() => expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument())
+    const toaster = screen.getByTestId('sticky-action-form-toaster')
+    await waitFor(() => expect(toaster).toHaveClass('animate-action-bar-fade-out'))
+    fireEvent.animationEnd(toaster)
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import { ClusterAdvancedSettingsFeature } from './cluster-advanced-settings-feature'
 
 const mockUseClusterAdvancedSettings = jest.fn()
@@ -82,9 +82,6 @@ describe('ClusterAdvancedSettingsFeature', () => {
     await userEvent.type(textarea, '2')
     await userEvent.click(await screen.findByTestId('submit-button'))
 
-    const toaster = screen.getByTestId('sticky-action-form-toaster')
-    await waitFor(() => expect(toaster).toHaveClass('animate-action-bar-fade-out'))
-    fireEvent.animationEnd(toaster)
-    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+    await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
@@ -48,6 +48,21 @@ describe('ClusterAdvancedSettingsFeature', () => {
     await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible())
   })
 
+  it('should keep the save banner hidden for a payload-equivalent edit', async () => {
+    const { userEvent } = renderWithProviders(<ClusterAdvancedSettingsFeature />)
+
+    const textarea = await screen.findByRole('textbox')
+    await waitFor(() => expect(textarea).toHaveValue('1'))
+
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '1.0')
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('1.0')
+      expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+    })
+  })
+
   it('should hide the save banner after the settings are saved', async () => {
     mockEditClusterAdvancedSettings.mockImplementation((_variables: unknown, options?: { onSuccess?: () => void }) =>
       options?.onSuccess?.()

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
@@ -55,7 +55,14 @@ describe('ClusterAdvancedSettingsFeature', () => {
     await waitFor(() => expect(textarea).toHaveValue('1'))
 
     await userEvent.clear(textarea)
-    await userEvent.type(textarea, '1.0')
+    await userEvent.type(textarea, '1.')
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('1.')
+      expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+    })
+
+    await userEvent.type(textarea, '0')
 
     await waitFor(() => {
       expect(textarea).toHaveValue('1.0')

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.tsx
@@ -1,11 +1,11 @@
 import { useParams } from '@tanstack/react-router'
 import { type ClusterAdvancedSettings as ClusterAdvancedSettingsType } from 'qovery-typescript-axios'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import { objectFlattener } from '@qovery/shared/util-js'
 import { useClusterAdvancedSettings } from '../hooks/use-cluster-advanced-settings/use-cluster-advanced-settings'
 import { useDefaultAdvancedSettings } from '../hooks/use-default-advanced-settings/use-default-advanced-settings'
 import { useEditClusterAdvancedSettings } from '../hooks/use-edit-cluster-advanced-settings/use-edit-cluster-advanced-settings'
+import { buildClusterAdvancedSettingsPayload } from './build-cluster-advanced-settings-payload'
 import { ClusterAdvancedSettings } from './cluster-advanced-settings'
 import { initFormValues } from './init-form-values'
 
@@ -19,57 +19,33 @@ export function ClusterAdvancedSettingsFeature() {
   const { mutateAsync: editClusterAdvancedSettings } = useEditClusterAdvancedSettings()
   const { data: defaultAdvancedSettings } = useDefaultAdvancedSettings()
 
-  const [keys, setKeys] = useState<string[]>([])
-
   const methods = useForm<{ [key: string]: string }>({ mode: 'onChange' })
+  const [formBaseline, setFormBaseline] = useState<ClusterAdvancedSettingsType>()
 
-  useEffect(() => {
-    if (clusterAdvancedSettings) {
-      setKeys(Object.keys(clusterAdvancedSettings).sort())
-    }
-  }, [clusterAdvancedSettings])
+  const keys = useMemo(() => Object.keys(clusterAdvancedSettings ?? {}).sort(), [clusterAdvancedSettings])
 
   useEffect(() => {
     if (clusterAdvancedSettings) {
       methods.reset(initFormValues(keys, clusterAdvancedSettings))
+      setFormBaseline(clusterAdvancedSettings)
     }
   }, [clusterAdvancedSettings, keys, methods])
 
   const onSubmit = methods.handleSubmit((data) => {
-    let dataFormatted: Record<string, string> = { ...data }
-
-    Object.keys(dataFormatted).forEach((key) => {
-      if (key.includes('.')) {
-        delete dataFormatted[key]
-      }
-    })
-
-    dataFormatted = objectFlattener(dataFormatted) as Record<string, string>
-
-    const payload: Record<string, unknown> = { ...dataFormatted }
-
-    Object.keys(dataFormatted).forEach((key) => {
-      try {
-        payload[key] = JSON.parse(dataFormatted[key])
-      } catch {
-        if (dataFormatted[key] === '') {
-          const defaultVal = defaultAdvancedSettings
-            ? defaultAdvancedSettings[key as keyof ClusterAdvancedSettingsType]
-            : ''
-          payload[key] = typeof defaultVal === 'object' ? defaultVal : defaultVal ?? ''
-        }
-      }
-    })
+    const payload = buildClusterAdvancedSettingsPayload(data, defaultAdvancedSettings)
 
     if (clusterAdvancedSettings) {
       editClusterAdvancedSettings(
         {
           organizationId,
           clusterId,
-          clusterAdvancedSettings: payload as ClusterAdvancedSettingsType,
+          clusterAdvancedSettings: payload,
         },
         {
-          onSuccess: () => methods.reset(data),
+          onSuccess: () => {
+            methods.reset(data)
+            setFormBaseline(payload)
+          },
         }
       )
     }
@@ -82,6 +58,7 @@ export function ClusterAdvancedSettingsFeature() {
         loading={isClusterAdvancedSettingsLoading}
         clusterAdvancedSettings={clusterAdvancedSettings}
         defaultAdvancedSettings={defaultAdvancedSettings}
+        formBaseline={formBaseline}
       />
     </FormProvider>
   )

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
@@ -1,7 +1,22 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
 import { type ClusterAdvancedSettings } from 'qovery-typescript-axios'
 import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { buildClusterAdvancedSettingsPayload } from './build-cluster-advanced-settings-payload'
 import { ClusterAdvancedSettings as ClusterAdvancedSettingsComponent } from './cluster-advanced-settings'
+
+jest.mock('./build-cluster-advanced-settings-payload', () => {
+  const actualModule = jest.requireActual('./build-cluster-advanced-settings-payload')
+
+  return {
+    ...actualModule,
+    buildClusterAdvancedSettingsPayload: jest.fn(actualModule.buildClusterAdvancedSettingsPayload),
+  }
+})
+
+const mockedBuildClusterAdvancedSettingsPayload = jest.mocked(buildClusterAdvancedSettingsPayload)
+const actualBuildClusterAdvancedSettingsPayload = jest.requireActual(
+  './build-cluster-advanced-settings-payload'
+).buildClusterAdvancedSettingsPayload
 
 const mockClusterAdvancedSettings = {
   key1: 'value1',
@@ -18,6 +33,7 @@ describe('ClusterAdvancedSettings', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedBuildClusterAdvancedSettingsPayload.mockImplementation(actualBuildClusterAdvancedSettingsPayload)
   })
 
   it('should render correctly', () => {
@@ -267,5 +283,32 @@ describe('ClusterAdvancedSettings', () => {
     )
 
     expect(screen.getByText('Show only overridden settings')).toBeInTheDocument()
+  })
+
+  it('should not rebuild the form payload when filtering overridden settings', async () => {
+    const { userEvent } = renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterAdvancedSettingsComponent
+          onSubmit={mockOnSubmit}
+          loading={false}
+          clusterAdvancedSettings={mockClusterAdvancedSettings}
+          defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
+        />,
+        {
+          defaultValues: {
+            key1: 'value1',
+            key2: 'value2',
+          },
+        }
+      )
+    )
+
+    await waitFor(() => expect(mockedBuildClusterAdvancedSettingsPayload).toHaveBeenCalled())
+    const callCount = mockedBuildClusterAdvancedSettingsPayload.mock.calls.length
+
+    await userEvent.click(screen.getByTestId('show-overriden-only-toggle'))
+
+    expect(mockedBuildClusterAdvancedSettingsPayload).toHaveBeenCalledTimes(callCount)
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
 import { type ClusterAdvancedSettings } from 'qovery-typescript-axios'
-import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { fireEvent, renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
 import { buildClusterAdvancedSettingsPayload } from './build-cluster-advanced-settings-payload'
 import { ClusterAdvancedSettings as ClusterAdvancedSettingsComponent } from './cluster-advanced-settings'
 
@@ -200,7 +200,10 @@ describe('ClusterAdvancedSettings', () => {
     await userEvent.clear(textarea)
     await userEvent.type(textarea, 'value1')
 
-    await waitFor(() => expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument())
+    const toaster = screen.getByTestId('sticky-action-form-toaster')
+    await waitFor(() => expect(toaster).toHaveClass('animate-action-bar-fade-out'))
+    fireEvent.animationEnd(toaster)
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
   })
 
   it('should compare current and saved values using the same normalization', async () => {

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
 import { type ClusterAdvancedSettings } from 'qovery-typescript-axios'
-import { fireEvent, renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import { buildClusterAdvancedSettingsPayload } from './build-cluster-advanced-settings-payload'
 import { ClusterAdvancedSettings as ClusterAdvancedSettingsComponent } from './cluster-advanced-settings'
 
@@ -200,10 +200,7 @@ describe('ClusterAdvancedSettings', () => {
     await userEvent.clear(textarea)
     await userEvent.type(textarea, 'value1')
 
-    const toaster = screen.getByTestId('sticky-action-form-toaster')
-    await waitFor(() => expect(toaster).toHaveClass('animate-action-bar-fade-out'))
-    fireEvent.animationEnd(toaster)
-    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+    await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
   })
 
   it('should compare current and saved values using the same normalization', async () => {

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
@@ -28,6 +28,7 @@ describe('ClusterAdvancedSettings', () => {
           loading={false}
           clusterAdvancedSettings={mockClusterAdvancedSettings}
           defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
         />,
         {
           defaultValues: {
@@ -77,7 +78,7 @@ describe('ClusterAdvancedSettings', () => {
     expect(spinners.length).toBeLessThanOrEqual(1)
   })
 
-  it('should show StickyActionFormToaster when form is dirty', async () => {
+  it('should show StickyActionFormToaster when the form payload changes quickly', async () => {
     const { userEvent, container } = renderWithProviders(
       wrapWithReactHookForm(
         <ClusterAdvancedSettingsComponent
@@ -85,27 +86,25 @@ describe('ClusterAdvancedSettings', () => {
           loading={false}
           clusterAdvancedSettings={mockClusterAdvancedSettings}
           defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
         />,
         {
           defaultValues: {
-            key1: '',
-            key2: '',
+            key1: 'value1',
+            key2: 'value2',
           },
         }
       )
     )
 
     const textarea = container.querySelector('textarea[name="key1"]') as HTMLTextAreaElement
-    if (textarea) {
-      await userEvent.type(textarea, 'modified')
-    }
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, 'modified quickly')
 
-    expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
-    const toaster = screen.getByTestId('sticky-action-form-toaster')
-    await waitFor(() => expect(toaster).toHaveClass('visible'))
+    await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible())
   })
 
-  it('should not show StickyActionFormToaster when form is not dirty', () => {
+  it('should not show StickyActionFormToaster when the form payload is unchanged', () => {
     renderWithProviders(
       wrapWithReactHookForm(
         <ClusterAdvancedSettingsComponent
@@ -113,20 +112,114 @@ describe('ClusterAdvancedSettings', () => {
           loading={false}
           clusterAdvancedSettings={mockClusterAdvancedSettings}
           defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
         />,
         {
           defaultValues: {
-            key1: '',
-            key2: '',
+            key1: 'value1',
+            key2: 'value2',
           },
         }
       )
     )
 
-    const toaster = screen.queryByTestId('sticky-action-form-toaster')
-    expect(toaster).toBeInTheDocument()
-    expect(toaster).toHaveClass('hidden')
-    expect(toaster).not.toHaveClass('visible')
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+  })
+
+  it('should not show StickyActionFormToaster when dirty form values produce the current payload', async () => {
+    const clusterAdvancedSettings = {
+      'cluster.setting': 1,
+      key2: 'value2',
+    } as ClusterAdvancedSettings
+
+    const { userEvent, container } = renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterAdvancedSettingsComponent
+          onSubmit={mockOnSubmit}
+          loading={false}
+          clusterAdvancedSettings={clusterAdvancedSettings}
+          defaultAdvancedSettings={clusterAdvancedSettings}
+          formBaseline={clusterAdvancedSettings}
+        />,
+        {
+          defaultValues: {
+            'cluster.setting': '1',
+            key2: 'value2',
+          },
+        }
+      )
+    )
+
+    const textarea = container.querySelector('textarea[name="cluster.setting"]') as HTMLTextAreaElement
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '1.0')
+
+    await waitFor(() => expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument())
+  })
+
+  it('should hide StickyActionFormToaster when all values are reverted', async () => {
+    const { userEvent, container } = renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterAdvancedSettingsComponent
+          onSubmit={mockOnSubmit}
+          loading={false}
+          clusterAdvancedSettings={mockClusterAdvancedSettings}
+          defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
+        />,
+        {
+          defaultValues: {
+            key1: 'value1',
+            key2: 'value2',
+          },
+        }
+      )
+    )
+
+    const textarea = container.querySelector('textarea[name="key1"]') as HTMLTextAreaElement
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, 'modified')
+    expect(await screen.findByTestId('sticky-action-form-toaster')).toBeVisible()
+
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, 'value1')
+
+    await waitFor(() => expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument())
+  })
+
+  it('should compare current and saved values using the same normalization', async () => {
+    const clusterAdvancedSettings = {
+      'cluster.setting': 1,
+      'empty.setting': '',
+    } as ClusterAdvancedSettings
+    const defaultAdvancedSettings = {
+      'cluster.setting': 1,
+      'empty.setting': 'default',
+    } as ClusterAdvancedSettings
+
+    const { userEvent, container } = renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterAdvancedSettingsComponent
+          onSubmit={mockOnSubmit}
+          loading={false}
+          clusterAdvancedSettings={clusterAdvancedSettings}
+          defaultAdvancedSettings={defaultAdvancedSettings}
+          formBaseline={clusterAdvancedSettings}
+        />,
+        {
+          defaultValues: {
+            'cluster.setting': '1',
+            'empty.setting': '',
+          },
+        }
+      )
+    )
+
+    const textarea = container.querySelector('textarea[name="cluster.setting"]') as HTMLTextAreaElement
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '1.0')
+
+    await waitFor(() => expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument())
   })
 
   it('should call onSubmit when form is submitted', () => {

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import equal from 'fast-deep-equal'
 import { type ClusterAdvancedSettings as ClusterAdvancedSettingsType } from 'qovery-typescript-axios'
 import { useMemo, useState } from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller, useFormContext, useFormState, useWatch } from 'react-hook-form'
 import {
   CopyToClipboardButtonIcon,
   Icon,
@@ -13,12 +13,17 @@ import {
   Tooltip,
 } from '@qovery/shared/ui'
 import { generateAdvancedSettingDocUrl, twMerge } from '@qovery/shared/util-js'
+import {
+  buildClusterAdvancedSettingsPayload,
+  normalizeClusterAdvancedSettings,
+} from './build-cluster-advanced-settings-payload'
 
 export interface ClusterAdvancedSettingsProps {
   onSubmit: () => void
   loading: boolean
   clusterAdvancedSettings?: ClusterAdvancedSettingsType
   defaultAdvancedSettings?: ClusterAdvancedSettingsType
+  formBaseline?: ClusterAdvancedSettingsType
 }
 
 function formatValue(value: unknown) {
@@ -27,13 +32,55 @@ function formatValue(value: unknown) {
 
 const { Table } = TablePrimitives
 
+interface ClusterAdvancedSettingsSaveActionProps {
+  onSubmit: () => void
+  loading: boolean
+  defaultAdvancedSettings?: ClusterAdvancedSettingsType
+  formBaseline?: ClusterAdvancedSettingsType
+}
+
+function ClusterAdvancedSettingsSaveAction({
+  onSubmit,
+  loading,
+  defaultAdvancedSettings,
+  formBaseline,
+}: ClusterAdvancedSettingsSaveActionProps) {
+  const { control, reset } = useFormContext<{ [key: string]: string }>()
+  const { isDirty, isValid } = useFormState({ control })
+  const formValues = useWatch({ control })
+  const normalizedBaseline = useMemo(
+    () =>
+      formBaseline === undefined ? undefined : normalizeClusterAdvancedSettings(formBaseline, defaultAdvancedSettings),
+    [defaultAdvancedSettings, formBaseline]
+  )
+
+  const hasChanged =
+    isDirty &&
+    normalizedBaseline !== undefined &&
+    !equal(
+      buildClusterAdvancedSettingsPayload(formValues as Record<string, unknown>, defaultAdvancedSettings),
+      normalizedBaseline
+    )
+
+  return (
+    <StickyActionFormToaster
+      visible={hasChanged}
+      onSubmit={onSubmit}
+      onReset={reset}
+      disabledValidation={!isValid}
+      loading={loading}
+    />
+  )
+}
+
 export function ClusterAdvancedSettings({
   onSubmit,
   loading,
   clusterAdvancedSettings,
   defaultAdvancedSettings,
+  formBaseline,
 }: ClusterAdvancedSettingsProps) {
-  const { control, formState, reset } = useFormContext<{ [key: string]: string }>()
+  const { control } = useFormContext<{ [key: string]: string }>()
   const [showOverriddenOnly, toggleShowOverriddenOnly] = useState(false)
 
   const keys = useMemo(() => {
@@ -169,12 +216,11 @@ export function ClusterAdvancedSettings({
               </Table.Root>
             </div>
           )}
-          <StickyActionFormToaster
-            visible={formState.isDirty}
+          <ClusterAdvancedSettingsSaveAction
             onSubmit={onSubmit}
-            onReset={reset}
-            disabledValidation={!formState.isValid}
             loading={loading}
+            defaultAdvancedSettings={defaultAdvancedSettings}
+            formBaseline={formBaseline}
           />
         </div>
       </form>

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.tsx
@@ -53,14 +53,14 @@ function ClusterAdvancedSettingsSaveAction({
       formBaseline === undefined ? undefined : normalizeClusterAdvancedSettings(formBaseline, defaultAdvancedSettings),
     [defaultAdvancedSettings, formBaseline]
   )
-
-  const hasChanged =
-    isDirty &&
-    normalizedBaseline !== undefined &&
-    !equal(
-      buildClusterAdvancedSettingsPayload(formValues as Record<string, unknown>, defaultAdvancedSettings),
-      normalizedBaseline
-    )
+  const currentPayload = useMemo(
+    () => buildClusterAdvancedSettingsPayload(formValues as Record<string, unknown>, defaultAdvancedSettings),
+    [defaultAdvancedSettings, formValues]
+  )
+  const hasChanged = useMemo(
+    () => isDirty && normalizedBaseline !== undefined && !equal(currentPayload, normalizedBaseline),
+    [currentPayload, isDirty, normalizedBaseline]
+  )
 
   return (
     <StickyActionFormToaster

--- a/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { type Application } from '@qovery/domains/services/data-access'
 import { applicationFactoryMock } from '@qovery/shared/factories'
-import { fireEvent, renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import { AdvancedSettings } from './service-advanced-settings'
 
 const mockMutateEdit = jest.fn()
@@ -173,9 +173,6 @@ describe('AdvancedSettings', () => {
 
     await userEvent.click(screen.getByTestId('submit-button'))
 
-    const toaster = screen.getByTestId('sticky-action-form-toaster')
-    await waitFor(() => expect(toaster).toHaveClass('animate-action-bar-fade-out'))
-    fireEvent.animationEnd(toaster)
-    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+    await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
   })
 })

--- a/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { type Application } from '@qovery/domains/services/data-access'
 import { applicationFactoryMock } from '@qovery/shared/factories'
-import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { fireEvent, renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
 import { AdvancedSettings } from './service-advanced-settings'
 
 const mockMutateEdit = jest.fn()
@@ -173,8 +173,9 @@ describe('AdvancedSettings', () => {
 
     await userEvent.click(screen.getByTestId('submit-button'))
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
-    })
+    const toaster = screen.getByTestId('sticky-action-form-toaster')
+    await waitFor(() => expect(toaster).toHaveClass('animate-action-bar-fade-out'))
+    fireEvent.animationEnd(toaster)
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
   })
 })

--- a/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
@@ -98,6 +98,11 @@ describe('AdvancedSettings', () => {
       await userEvent.type(input, '79')
       await userEvent.clear(input)
     }
+    const changedInput = container.querySelector('textarea[name="cronjob.success_jobs_history_limit"]')
+    if (changedInput) {
+      await userEvent.clear(changedInput)
+      await userEvent.type(changedInput, '4')
+    }
     expect(screen.getByTestId('submit-button')).toBeEnabled()
   })
 
@@ -169,7 +174,7 @@ describe('AdvancedSettings', () => {
     await userEvent.click(screen.getByTestId('submit-button'))
 
     await waitFor(() => {
-      expect(screen.getByTestId('sticky-action-form-toaster')).not.toHaveClass('animate-action-bar-fade-in')
+      expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
     })
   })
 })

--- a/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
+++ b/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
@@ -1525,38 +1525,6 @@ exports[`VariableList should match snapshot 1`] = `
         </div>
       </div>
     </section>
-    <div
-      class="flex justify-center sticky bottom-4"
-    >
-      <div
-        class="inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl animate-action-bar-fade-out hidden"
-        data-testid="sticky-action-form-toaster"
-      >
-        <span
-          class="text-sm font-medium text-neutralInvert"
-        >
-          0 selected variable
-        </span>
-        <div
-          class="flex gap-5"
-        >
-          <button
-            class="text-ssm font-medium underline"
-            type="button"
-          >
-            Deselect
-          </button>
-          <button
-            class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-negative-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-negative-solid hover:bg-surface-negative-solidHover border border-negative-component text-neutral-contrasted"
-            data-testid="submit-button"
-            disabled=""
-            type="button"
-          >
-            Delete selected
-          </button>
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 `;

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
@@ -17,11 +17,21 @@ describe('StickyActionFormToaster', () => {
     expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible()
   })
 
-  it.each([false, true])('should render above other floating elements when fixed is %s', (fixed) => {
-    renderWithProviders(<StickyActionFormToaster {...props} fixed={fixed} />)
+  it.each([
+    { fixed: false, positionClass: 'sticky', bottomClass: 'bottom-4' },
+    { fixed: true, positionClass: 'fixed', bottomClass: 'bottom-14' },
+  ])(
+    'should render above other floating elements with $positionClass positioning',
+    ({ fixed, positionClass, bottomClass }) => {
+      renderWithProviders(<StickyActionFormToaster {...props} fixed={fixed} />)
 
-    expect(screen.getByTestId('sticky-action-form-toaster').parentElement).toHaveClass('z-toast')
-  })
+      expect(screen.getByTestId('sticky-action-form-toaster').parentElement).toHaveClass(
+        'z-toast',
+        positionClass,
+        bottomClass
+      )
+    }
+  )
 
   it('should handle reset on click', async () => {
     const spy = jest.fn()

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { act, fireEvent, renderWithProviders, screen, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
+import { fireEvent, renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import StickyActionFormToaster, { type StickyActionFormToasterProps } from './sticky-action-form-toaster'
 
 const props: StickyActionFormToasterProps = {
@@ -11,7 +11,7 @@ const props: StickyActionFormToasterProps = {
   visible: true,
 }
 
-function StickyActionFormToasterHarness() {
+function StickyActionFormToasterHarness({ onReset = props.onReset }: Pick<StickyActionFormToasterProps, 'onReset'>) {
   const [visible, setVisible] = useState(false)
 
   return (
@@ -22,7 +22,7 @@ function StickyActionFormToasterHarness() {
       <button type="button" onClick={() => setVisible(false)}>
         Hide toaster
       </button>
-      <StickyActionFormToaster {...props} visible={visible} />
+      <StickyActionFormToaster {...props} visible={visible} onReset={onReset} />
     </>
   )
 }
@@ -102,8 +102,9 @@ describe('StickyActionFormToaster', () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
   })
 
-  it('should stay mounted when shown again during the exit animation', async () => {
-    renderWithProviders(<StickyActionFormToasterHarness />)
+  it('should remain interactive when shown again during the exit animation', async () => {
+    const onReset = jest.fn()
+    const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness onReset={onReset} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
     fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
@@ -112,10 +113,9 @@ describe('StickyActionFormToaster', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 250))
-    })
+    await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toHaveStyle('pointer-events: auto'))
+    await userEvent.click(screen.getByRole('button', { name: 'Reset' }))
 
-    expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible()
+    expect(onReset).toHaveBeenCalledTimes(1)
   })
 })

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
@@ -7,12 +7,20 @@ const props: StickyActionFormToasterProps = {
   resetLabel: 'Reset',
   submitLabel: 'Save modifications',
   description: 'Warning, there are still unsaved changes!',
+  visible: true,
 }
 
 describe('StickyActionFormToaster', () => {
   it('should render successfully', () => {
-    const { baseElement } = renderWithProviders(<StickyActionFormToaster {...props} />)
-    expect(baseElement).toBeTruthy()
+    renderWithProviders(<StickyActionFormToaster {...props} />)
+
+    expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible()
+  })
+
+  it.each([false, true])('should render above other floating elements when fixed is %s', (fixed) => {
+    renderWithProviders(<StickyActionFormToaster {...props} fixed={fixed} />)
+
+    expect(screen.getByTestId('sticky-action-form-toaster').parentElement).toHaveClass('z-toast')
   })
 
   it('should handle reset on click', async () => {
@@ -49,5 +57,18 @@ describe('StickyActionFormToaster', () => {
     renderWithProviders(<StickyActionFormToaster {...props} submitButtonColor="red" />)
 
     expect(screen.getByTestId('submit-button')).toHaveClass('bg-surface-negative-solid')
+  })
+
+  it('should immediately follow the visible prop without animation classes', () => {
+    const { rerender } = renderWithProviders(<StickyActionFormToaster {...props} visible={false} />)
+
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+
+    rerender(<StickyActionFormToaster {...props} visible />)
+
+    const toaster = screen.getByTestId('sticky-action-form-toaster')
+    expect(toaster).toBeVisible()
+    expect(toaster).not.toHaveClass('animate-action-bar-fade-in')
+    expect(toaster).not.toHaveClass('animate-action-bar-fade-out')
   })
 })

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { fireEvent, renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { act, fireEvent, renderWithProviders, screen, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import StickyActionFormToaster, { type StickyActionFormToasterProps } from './sticky-action-form-toaster'
 
 const props: StickyActionFormToasterProps = {
@@ -87,37 +87,35 @@ describe('StickyActionFormToaster', () => {
   })
 
   it('should animate in and out before unmounting', async () => {
-    const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness />)
+    renderWithProviders(<StickyActionFormToasterHarness />)
 
     expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
 
     const toaster = screen.getByTestId('sticky-action-form-toaster')
     expect(toaster).toBeVisible()
-    expect(toaster).toHaveClass('animate-action-bar-fade-in')
 
-    await userEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
 
-    const exitingToaster = screen.getByTestId('sticky-action-form-toaster')
-    expect(exitingToaster).toHaveClass('animate-action-bar-fade-out')
-    fireEvent.animationEnd(exitingToaster)
-    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+    expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
+    await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
   })
 
   it('should stay mounted when shown again during the exit animation', async () => {
-    const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness />)
+    renderWithProviders(<StickyActionFormToasterHarness />)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
-    await userEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
 
-    expect(screen.getByTestId('sticky-action-form-toaster')).toHaveClass('animate-action-bar-fade-out')
+    expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
 
-    const toaster = screen.getByTestId('sticky-action-form-toaster')
-    expect(toaster).toHaveClass('animate-action-bar-fade-in')
-    fireEvent.animationEnd(toaster)
-    expect(toaster).toBeInTheDocument()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    })
+
+    expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible()
   })
 })

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
@@ -1,4 +1,5 @@
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { useState } from 'react'
+import { fireEvent, renderWithProviders, screen } from '@qovery/shared/util-tests'
 import StickyActionFormToaster, { type StickyActionFormToasterProps } from './sticky-action-form-toaster'
 
 const props: StickyActionFormToasterProps = {
@@ -8,6 +9,22 @@ const props: StickyActionFormToasterProps = {
   submitLabel: 'Save modifications',
   description: 'Warning, there are still unsaved changes!',
   visible: true,
+}
+
+function StickyActionFormToasterHarness() {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <>
+      <button type="button" onClick={() => setVisible(true)}>
+        Show toaster
+      </button>
+      <button type="button" onClick={() => setVisible(false)}>
+        Hide toaster
+      </button>
+      <StickyActionFormToaster {...props} visible={visible} />
+    </>
+  )
 }
 
 describe('StickyActionFormToaster', () => {
@@ -69,16 +86,38 @@ describe('StickyActionFormToaster', () => {
     expect(screen.getByTestId('submit-button')).toHaveClass('bg-surface-negative-solid')
   })
 
-  it('should immediately follow the visible prop without animation classes', () => {
-    const { rerender } = renderWithProviders(<StickyActionFormToaster {...props} visible={false} />)
+  it('should animate in and out before unmounting', async () => {
+    const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness />)
 
     expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
 
-    rerender(<StickyActionFormToaster {...props} visible />)
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
 
     const toaster = screen.getByTestId('sticky-action-form-toaster')
     expect(toaster).toBeVisible()
-    expect(toaster).not.toHaveClass('animate-action-bar-fade-in')
-    expect(toaster).not.toHaveClass('animate-action-bar-fade-out')
+    expect(toaster).toHaveClass('animate-action-bar-fade-in')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+
+    const exitingToaster = screen.getByTestId('sticky-action-form-toaster')
+    expect(exitingToaster).toHaveClass('animate-action-bar-fade-out')
+    fireEvent.animationEnd(exitingToaster)
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+  })
+
+  it('should stay mounted when shown again during the exit animation', async () => {
+    const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+
+    expect(screen.getByTestId('sticky-action-form-toaster')).toHaveClass('animate-action-bar-fade-out')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+
+    const toaster = screen.getByTestId('sticky-action-form-toaster')
+    expect(toaster).toHaveClass('animate-action-bar-fade-in')
+    fireEvent.animationEnd(toaster)
+    expect(toaster).toBeInTheDocument()
   })
 })

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { twMerge } from '@qovery/shared/util-js'
 import Button, { type ButtonProps } from '../button/button'
 
@@ -28,21 +29,39 @@ export function StickyActionFormToaster(props: StickyActionFormToasterProps) {
     fixed = false,
   } = props
 
+  const [shouldRender, setShouldRender] = useState(visible)
+
+  useEffect(() => {
+    if (visible) {
+      setShouldRender(true)
+    }
+  }, [visible])
+
   const submitButtonColorValue = submitButtonColor ?? 'green'
 
-  if (!visible) return null
+  if (!shouldRender) return null
 
   return (
     <div
       className={twMerge(
         'z-toast flex justify-center',
         fixed ? 'fixed inset-x-0 bottom-14' : 'sticky bottom-4',
+        !visible && 'pointer-events-none',
         className
       )}
+      aria-hidden={!visible}
     >
       <div
         data-testid="sticky-action-form-toaster"
-        className="inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl"
+        className={twMerge(
+          'inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl',
+          visible ? 'animate-action-bar-fade-in' : 'animate-action-bar-fade-out'
+        )}
+        onAnimationEnd={(event) => {
+          if (!visible && event.currentTarget === event.target) {
+            setShouldRender(false)
+          }
+        }}
       >
         {description && <span className="text-sm font-medium text-neutralInvert">{description}</span>}
         <div className="flex gap-5">

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
@@ -22,17 +22,10 @@ const TOASTER_MOTION = {
 
 const REDUCED_TOASTER_MOTION = {
   initial: { opacity: 0 },
-  animate: {
-    opacity: 1,
-    pointerEvents: 'auto',
-    transition: { duration: 0.35, ease: [0.25, 0.46, 0.45, 0.94] },
-  },
-  exit: {
-    opacity: 0,
-    pointerEvents: 'none',
-    transition: { duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] },
-  },
-} satisfies Pick<MotionProps, 'initial' | 'animate' | 'exit'>
+  animate: { opacity: 1, pointerEvents: 'auto' },
+  exit: { opacity: 0, pointerEvents: 'none' },
+  transition: { duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] },
+} satisfies Pick<MotionProps, 'initial' | 'animate' | 'exit' | 'transition'>
 
 export interface StickyActionFormToasterProps {
   visible?: boolean

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
@@ -8,6 +8,7 @@ const TOASTER_MOTION = {
     opacity: 1,
     y: 0,
     scale: 1,
+    pointerEvents: 'auto',
     transition: { duration: 0.35, ease: [0.165, 0.84, 0.44, 1] },
   },
   exit: {
@@ -23,6 +24,7 @@ const REDUCED_TOASTER_MOTION = {
   initial: { opacity: 0 },
   animate: {
     opacity: 1,
+    pointerEvents: 'auto',
     transition: { duration: 0.35, ease: [0.25, 0.46, 0.45, 0.94] },
   },
   exit: {

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { twMerge } from '@qovery/shared/util-js'
 import Button, { type ButtonProps } from '../button/button'
 
@@ -29,34 +28,21 @@ export function StickyActionFormToaster(props: StickyActionFormToasterProps) {
     fixed = false,
   } = props
 
-  const [visibleState, setVisibleState] = useState(visible)
-
-  useEffect(() => {
-    if (visible) {
-      setVisibleState(true)
-    } else {
-      // we want to give the animation the time to play before removing the bloc from the flow with a display none
-      setTimeout(() => {
-        setVisibleState(false)
-      }, 500)
-    }
-  }, [visible])
-
   const submitButtonColorValue = submitButtonColor ?? 'green'
+
+  if (!visible) return null
 
   return (
     <div
       className={twMerge(
-        'flex justify-center',
-        fixed ? twMerge('fixed inset-x-0 bottom-14 z-30', !visibleState && 'hidden') : 'sticky bottom-4',
+        'z-toast flex justify-center',
+        fixed ? 'fixed inset-x-0 bottom-14' : 'sticky bottom-4',
         className
       )}
     >
       <div
         data-testid="sticky-action-form-toaster"
-        className={`inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl ${
-          visible ? 'animate-action-bar-fade-in' : 'animate-action-bar-fade-out'
-        } ${visibleState ? 'visible' : 'hidden'}`}
+        className="inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl"
       >
         {description && <span className="text-sm font-medium text-neutralInvert">{description}</span>}
         <div className="flex gap-5">

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
@@ -1,6 +1,36 @@
-import { useEffect, useState } from 'react'
+import { AnimatePresence, type MotionProps, motion, useReducedMotion } from 'framer-motion'
 import { twMerge } from '@qovery/shared/util-js'
 import Button, { type ButtonProps } from '../button/button'
+
+const TOASTER_MOTION = {
+  initial: { opacity: 0.5, y: '50%', scale: 0.6 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { duration: 0.35, ease: [0.165, 0.84, 0.44, 1] },
+  },
+  exit: {
+    opacity: 0,
+    y: '50%',
+    scale: 0.8,
+    pointerEvents: 'none',
+    transition: { duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] },
+  },
+} satisfies Pick<MotionProps, 'initial' | 'animate' | 'exit'>
+
+const REDUCED_TOASTER_MOTION = {
+  initial: { opacity: 0 },
+  animate: {
+    opacity: 1,
+    transition: { duration: 0.35, ease: [0.25, 0.46, 0.45, 0.94] },
+  },
+  exit: {
+    opacity: 0,
+    pointerEvents: 'none',
+    transition: { duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] },
+  },
+} satisfies Pick<MotionProps, 'initial' | 'animate' | 'exit'>
 
 export interface StickyActionFormToasterProps {
   visible?: boolean
@@ -28,64 +58,51 @@ export function StickyActionFormToaster(props: StickyActionFormToasterProps) {
     submitButtonColor,
     fixed = false,
   } = props
-
-  const [shouldRender, setShouldRender] = useState(visible)
-
-  useEffect(() => {
-    if (visible) {
-      setShouldRender(true)
-    }
-  }, [visible])
+  const reducedMotion = useReducedMotion()
 
   const submitButtonColorValue = submitButtonColor ?? 'green'
 
-  if (!shouldRender) return null
-
   return (
-    <div
-      className={twMerge(
-        'z-toast flex justify-center',
-        fixed ? 'fixed inset-x-0 bottom-14' : 'sticky bottom-4',
-        !visible && 'pointer-events-none',
-        className
-      )}
-      aria-hidden={!visible}
-    >
-      <div
-        data-testid="sticky-action-form-toaster"
-        className={twMerge(
-          'inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl',
-          visible ? 'animate-action-bar-fade-in' : 'animate-action-bar-fade-out'
-        )}
-        onAnimationEnd={(event) => {
-          if (!visible && event.currentTarget === event.target) {
-            setShouldRender(false)
-          }
-        }}
-      >
-        {description && <span className="text-sm font-medium text-neutralInvert">{description}</span>}
-        <div className="flex gap-5">
-          {resetLabel && onReset && (
-            <button type="button" className="text-ssm font-medium underline" onClick={() => onReset()}>
-              {resetLabel}
-            </button>
+    <AnimatePresence>
+      {visible ? (
+        <div
+          key="sticky-action-form-toaster"
+          className={twMerge(
+            'z-toast flex justify-center',
+            fixed ? 'fixed inset-x-0 bottom-14' : 'sticky bottom-4',
+            className
           )}
-          {submitLabel && onSubmit && (
-            <Button
-              color={submitButtonColorValue}
-              size="md"
-              data-testid="submit-button"
-              onClick={() => onSubmit()}
-              loading={props.loading}
-              disabled={props.disabledValidation}
-              type="button"
-            >
-              {submitLabel}
-            </Button>
-          )}
+        >
+          <motion.div
+            data-testid="sticky-action-form-toaster"
+            className="inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl"
+            {...(reducedMotion ? REDUCED_TOASTER_MOTION : TOASTER_MOTION)}
+          >
+            {description && <span className="text-sm font-medium text-neutralInvert">{description}</span>}
+            <div className="flex gap-5">
+              {resetLabel && onReset && (
+                <button type="button" className="text-ssm font-medium underline" onClick={() => onReset()}>
+                  {resetLabel}
+                </button>
+              )}
+              {submitLabel && onSubmit && (
+                <Button
+                  color={submitButtonColorValue}
+                  size="md"
+                  data-testid="submit-button"
+                  onClick={() => onSubmit()}
+                  loading={props.loading}
+                  disabled={props.disabledValidation}
+                  type="button"
+                >
+                  {submitLabel}
+                </Button>
+              )}
+            </div>
+          </motion.div>
         </div>
-      </div>
-    </div>
+      ) : null}
+    </AnimatePresence>
   )
 }
 


### PR DESCRIPTION
## Summary

**Issue**: Fixed the Advanced Settings save banner to reliably show up only when the payload changes.

Jira ticket : [QOV-2209](https://qovery.atlassian.net/browse/QOV-2209)

- Compare normalized advanced-settings payloads instead of raw form dirtiness.
- Preserve the current payload as the form baseline after loading and saving.
- Extract payload construction into a reusable helper.
- Keep the sticky action toaster visible when visibility changes during its exit delay.
- Add regression coverage for payload-equivalent edits, form reset behavior, and toaster transitions.

## Screenshots / Recordings

There are 2 non-significant UI changes:
- The removal of the animation when the banner appears/disappears. It was causing an extra re-renders and did not bring any value
- The addition of a z-index to fix an issue where the "save" banner would overlap with the "cluster deployment progress cards"

<img width="869" height="338" alt="SCR-20260831-ocfz" src="https://github.com/user-attachments/assets/ccafbecc-97bb-4e1f-97ae-d39d30b6fa4f" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code

[QOV-2209]: https://qovery.atlassian.net/browse/QOV-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ