### PR TITLE
feat(qov-2153): Add Qovery ID field for secret manager access

### DIFF
--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal.tsx
@@ -41,6 +41,7 @@ export function SecretManagerIntegrationModal({
   )
   const { navigation, layout, aws, defaultAuthenticationMode } = constraints
   const { isManualOnlyGcpIntegration, isManualOnlyAwsIntegration } = layout
+  const isEdit = mode === 'edit'
   const providerTabs = getActiveProviderConstraints(constraints)
   const automaticTab = providerTabs?.automatic
 
@@ -126,12 +127,13 @@ export function SecretManagerIntegrationModal({
 
   const manualSections = isGcpManualTabOnGcpSecretManager ? (
     <div className="flex flex-col gap-3">
-      <GcpSecretManagerManualSections methods={methods} regions={gcpRegions} />
+      <GcpSecretManagerManualSections isEdit={isEdit} methods={methods} regions={gcpRegions} />
     </div>
   ) : (
     <AwsSecretManagerManualSections
       authenticationTypeSelect={aws?.manual.authenticationTypeSelect}
       cluster={cluster}
+      isEdit={isEdit}
       isManualOnlyIntegration={isManualOnlyAwsIntegration}
       methods={methods}
       option={option}
@@ -151,7 +153,7 @@ export function SecretManagerIntegrationModal({
       >
         <div className={`flex flex-col ${isManualOnlyGcpIntegration ? 'gap-3' : 'gap-4'} px-5 pb-6 pt-4`}>
           {isManualOnlyGcpIntegration ? (
-            <GcpSecretManagerManualSections methods={methods} regions={gcpRegions} />
+            <GcpSecretManagerManualSections isEdit={isEdit} methods={methods} regions={gcpRegions} />
           ) : (
             manualSections
           )}
@@ -208,7 +210,7 @@ export function SecretManagerIntegrationModal({
       </div>
       <div className="p-5">
         {activeTab === 'automatic' ? (
-          <SecretManagerAutomaticSections methods={methods} option={option} regions={regions} />
+          <SecretManagerAutomaticSections isEdit={isEdit} methods={methods} option={option} regions={regions} />
         ) : (
           manualSections
         )}

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/aws-secret-manager-manual-sections.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/aws-secret-manager-manual-sections.tsx
@@ -5,11 +5,16 @@ import { type Value } from '@qovery/shared/interfaces'
 import { ExternalLink, Heading, InputSelect, InputText, Section, Tooltip } from '@qovery/shared/ui'
 import { type AwsManualAuthenticationTypeSelect } from '../secret-manager-integration-constraints'
 import { type SecretManagerOption } from '../secret-manager-integration.types'
-import { SecretManagerNameField, SecretManagerRegionField } from './secret-manager-integration-fields'
+import {
+  SecretManagerIdField,
+  SecretManagerNameField,
+  SecretManagerRegionField,
+} from './secret-manager-integration-fields'
 
 interface AwsSecretManagerManualSectionsProps {
   authenticationTypeSelect?: AwsManualAuthenticationTypeSelect
   cluster?: Cluster
+  isEdit: boolean
   isManualOnlyIntegration: boolean
   methods: UseFormReturn<SecretManagerAccess>
   option: SecretManagerOption
@@ -19,6 +24,7 @@ interface AwsSecretManagerManualSectionsProps {
 export function AwsSecretManagerManualSections({
   authenticationTypeSelect,
   cluster,
+  isEdit,
   isManualOnlyIntegration,
   methods,
   option,
@@ -27,7 +33,7 @@ export function AwsSecretManagerManualSections({
   if (isManualOnlyIntegration) {
     return (
       <div className="flex flex-col gap-4">
-        <AwsStaticCredentialsSections methods={methods} regions={regions} />
+        <AwsStaticCredentialsSections isEdit={isEdit} methods={methods} regions={regions} />
       </div>
     )
   }
@@ -35,7 +41,13 @@ export function AwsSecretManagerManualSections({
   return (
     <div className="flex flex-col gap-4">
       <AwsAuthenticationTypeSelect authenticationTypeSelect={authenticationTypeSelect} methods={methods} />
-      <AwsManualAuthenticationModeSections cluster={cluster} methods={methods} option={option} regions={regions} />
+      <AwsManualAuthenticationModeSections
+        cluster={cluster}
+        isEdit={isEdit}
+        methods={methods}
+        option={option}
+        regions={regions}
+      />
     </div>
   )
 }
@@ -55,12 +67,14 @@ function AwsCredentialsInstructions() {
 }
 
 interface AwsStaticCredentialsSectionsProps {
+  isEdit: boolean
   methods: UseFormReturn<SecretManagerAccess>
   regions: Value[]
   syncAuthenticationRegion?: boolean
 }
 
 function AwsStaticCredentialsSections({
+  isEdit,
   methods,
   regions,
   syncAuthenticationRegion = false,
@@ -72,6 +86,7 @@ function AwsStaticCredentialsSections({
         <Heading level={3} className="text-sm font-medium text-neutral">
           2. Fill in these information
         </Heading>
+        {isEdit && <SecretManagerIdField methods={methods} />}
         <SecretManagerRegionField
           methods={methods}
           regions={regions}
@@ -156,6 +171,7 @@ function AwsAuthenticationTypeSelect({ authenticationTypeSelect, methods }: AwsA
 
 interface AwsManualAuthenticationModeSectionsProps {
   cluster?: Cluster
+  isEdit: boolean
   methods: UseFormReturn<SecretManagerAccess>
   option: SecretManagerOption
   regions: Value[]
@@ -163,6 +179,7 @@ interface AwsManualAuthenticationModeSectionsProps {
 
 function AwsManualAuthenticationModeSections({
   cluster,
+  isEdit,
   methods,
   option,
   regions,
@@ -174,13 +191,19 @@ function AwsManualAuthenticationModeSections({
   }
 
   if (authenticationMode === 'AWS_STATIC_CREDENTIALS') {
-    return <AwsStaticCredentialsSections methods={methods} regions={regions} syncAuthenticationRegion />
+    return <AwsStaticCredentialsSections isEdit={isEdit} methods={methods} regions={regions} syncAuthenticationRegion />
   }
 
-  return <AwsAssumeRoleSections cluster={cluster} methods={methods} option={option} regions={regions} />
+  return <AwsAssumeRoleSections cluster={cluster} isEdit={isEdit} methods={methods} option={option} regions={regions} />
 }
 
-function AwsAssumeRoleSections({ cluster, methods, option, regions }: AwsManualAuthenticationModeSectionsProps) {
+function AwsAssumeRoleSections({
+  cluster,
+  isEdit,
+  methods,
+  option,
+  regions,
+}: AwsManualAuthenticationModeSectionsProps) {
   const templateURL =
     option.value === 'AWS_PARAMETER_STORE'
       ? 'https://s3.amazonaws.com/cloudformation-aws-parameter-store-role/template.json'
@@ -220,6 +243,7 @@ function AwsAssumeRoleSections({ cluster, methods, option, regions }: AwsManualA
         <Heading level={3} className="text-sm font-medium text-neutral">
           3. Provide your credentials info
         </Heading>
+        {isEdit && <SecretManagerIdField methods={methods} />}
         <SecretManagerRegionField methods={methods} regions={regions} />
         <Controller
           name="authentication.role_arn"

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/gcp-secret-manager-manual-sections.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/gcp-secret-manager-manual-sections.tsx
@@ -6,16 +6,18 @@ import { type Value } from '@qovery/shared/interfaces'
 import { Button, CopyButton, Dropzone, ExternalLink, Heading, Icon, Section } from '@qovery/shared/ui'
 import {
   GcpProjectIdField,
+  SecretManagerIdField,
   SecretManagerNameField,
   SecretManagerRegionField,
 } from './secret-manager-integration-fields'
 
 interface GcpSecretManagerManualSectionsProps {
+  isEdit: boolean
   methods: UseFormReturn<SecretManagerAccess>
   regions: Value[]
 }
 
-export function GcpSecretManagerManualSections({ methods, regions }: GcpSecretManagerManualSectionsProps) {
+export function GcpSecretManagerManualSections({ isEdit, methods, regions }: GcpSecretManagerManualSectionsProps) {
   const [fileDetails, setFileDetails] = useState<{ name: string; size: number }>()
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     maxFiles: 1,
@@ -112,6 +114,7 @@ export function GcpSecretManagerManualSections({ methods, regions }: GcpSecretMa
             return <div />
           }}
         />
+        {isEdit && <SecretManagerIdField methods={methods} />}
         <GcpProjectIdField methods={methods} />
         <SecretManagerRegionField methods={methods} regions={regions} />
         <SecretManagerNameField methods={methods} />

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-automatic-sections.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-automatic-sections.tsx
@@ -5,17 +5,24 @@ import { Callout, Icon } from '@qovery/shared/ui'
 import { type SecretManagerOption } from '../secret-manager-integration.types'
 import {
   GcpProjectIdField,
+  SecretManagerIdField,
   SecretManagerNameField,
   SecretManagerRegionField,
 } from './secret-manager-integration-fields'
 
 interface SecretManagerAutomaticSectionsProps {
+  isEdit: boolean
   methods: UseFormReturn<SecretManagerAccess>
   option: SecretManagerOption
   regions: Value[]
 }
 
-export function SecretManagerAutomaticSections({ methods, option, regions }: SecretManagerAutomaticSectionsProps) {
+export function SecretManagerAutomaticSections({
+  isEdit,
+  methods,
+  option,
+  regions,
+}: SecretManagerAutomaticSectionsProps) {
   return (
     <div className="flex flex-col gap-4">
       <div>
@@ -25,6 +32,7 @@ export function SecretManagerAutomaticSections({ methods, option, regions }: Sec
         </p>
       </div>
       <div className="flex flex-col gap-4">
+        {isEdit && <SecretManagerIdField methods={methods} />}
         {option.icon === 'GCP' && <GcpProjectIdField methods={methods} />}
         <SecretManagerRegionField methods={methods} regions={regions} />
         <SecretManagerNameField methods={methods} />

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-integration-fields.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-integration-fields.tsx
@@ -7,6 +7,25 @@ interface SecretManagerIntegrationFieldsProps {
   methods: UseFormReturn<SecretManagerAccess>
 }
 
+export function SecretManagerIdField({ methods }: SecretManagerIntegrationFieldsProps) {
+  return (
+    <Controller
+      name="id"
+      control={methods.control}
+      render={({ field, fieldState: { error } }) => (
+        <InputText
+          label="Qovery ID"
+          name={field.name}
+          value={field.value}
+          error={error?.message}
+          disabled
+          hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
+        />
+      )}
+    />
+  )
+}
+
 export function SecretManagerNameField({ methods }: SecretManagerIntegrationFieldsProps) {
   return (
     <Controller


### PR DESCRIPTION

## Summary

Add Qovery ID field in the modal of Secret Manager Access

## Screenshots / Recordings

<img width="653" height="909" alt="image" src="https://github.com/user-attachments/assets/cad57e84-5669-49ef-b05e-329a2dfb199f" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Qovery ID field to the Secret Manager access modal so users can find the ID used for API, CLI, or Terraform interactions.

- Shows the ID in the AWS manual (static credentials and assume role), GCP manual, and automatic sections.
- The field only renders when editing an existing integration and is disabled.

<sup>Written for commit 8d344ec2b4f2ceb65bcc548132455258ad54af59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

