### PR TITLE
fix(organizations): display "Owner" label for owner members

### DIFF
--- a/libs/domains/organizations/feature/src/lib/settings-members/row-member/row-member.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-members/row-member/row-member.tsx
@@ -95,6 +95,22 @@ export function RowMember(props: RowMemberProps) {
     editMemberRole?.(member.id, roleId)
   }
 
+  const roleButton = (
+    <Button
+      type="button"
+      data-testid="input"
+      aria-label="Member role"
+      variant="outline"
+      color="neutral"
+      size="md"
+      className="h-9 w-44 justify-between"
+      disabled={!canEditRole || loadingUpdateRole}
+    >
+      <span className="truncate">{displayedRoleLabel}</span>
+      {!isOwner && <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />}
+    </Button>
+  )
+
   return (
     <Table.Row>
       <Table.Cell className="border-r border-neutral px-0" style={{ width: `${columnSizes[0]}%` }}>
@@ -241,36 +257,10 @@ export function RowMember(props: RowMemberProps) {
             <DropdownMenu.Trigger asChild>
               {isOwner ? (
                 <Tooltip content="There can only be one owner. Only the owner can transfer ownership to another member via the action menu.">
-                  <span>
-                    <Button
-                      type="button"
-                      data-testid="input"
-                      aria-label="Member role"
-                      variant="outline"
-                      color="neutral"
-                      size="md"
-                      className="h-9 w-44 justify-between"
-                      disabled={!canEditRole || loadingUpdateRole}
-                    >
-                      <span className="truncate">{displayedRoleLabel}</span>
-                      <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />
-                    </Button>
-                  </span>
+                  <span>{roleButton}</span>
                 </Tooltip>
               ) : (
-                <Button
-                  type="button"
-                  data-testid="input"
-                  aria-label="Member role"
-                  variant="outline"
-                  color="neutral"
-                  size="md"
-                  className="h-9 w-44 justify-between"
-                  disabled={!canEditRole || loadingUpdateRole}
-                >
-                  <span className="truncate">{displayedRoleLabel}</span>
-                  <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />
-                </Button>
+                roleButton
               )}
             </DropdownMenu.Trigger>
             <DropdownMenu.Content align="start">

--- a/libs/domains/organizations/feature/src/lib/settings-members/row-member/row-member.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-members/row-member/row-member.tsx
@@ -87,6 +87,7 @@ export function RowMember(props: RowMemberProps) {
   const [roleOverrideId, setRoleOverrideId] = useState<string | null>(null)
   const displayedRoleValue = roleOverrideId && roleOverrideId !== selectedRoleValue ? roleOverrideId : selectedRoleValue
   const selectedRoleLabel = roleOptions.find((role) => role.value === displayedRoleValue)?.label ?? 'Select role'
+  const displayedRoleLabel = isOwner ? 'Owner' : selectedRoleLabel
 
   const handleRoleChange = (roleId: string | undefined) => {
     if (!roleId) return
@@ -248,7 +249,7 @@ export function RowMember(props: RowMemberProps) {
                 className="h-9 w-44 justify-between"
                 disabled={!canEditRole || loadingUpdateRole}
               >
-                <span className="truncate">{selectedRoleLabel}</span>
+                <span className="truncate">{displayedRoleLabel}</span>
                 <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />
               </Button>
             </DropdownMenu.Trigger>

--- a/libs/domains/organizations/feature/src/lib/settings-members/row-member/row-member.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-members/row-member/row-member.tsx
@@ -239,19 +239,39 @@ export function RowMember(props: RowMemberProps) {
         <div data-testid="row-member-menu" className="flex items-center">
           <DropdownMenu.Root>
             <DropdownMenu.Trigger asChild>
-              <Button
-                type="button"
-                data-testid="input"
-                aria-label="Member role"
-                variant="outline"
-                color="neutral"
-                size="md"
-                className="h-9 w-44 justify-between"
-                disabled={!canEditRole || loadingUpdateRole}
-              >
-                <span className="truncate">{displayedRoleLabel}</span>
-                <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />
-              </Button>
+              {isOwner ? (
+                <Tooltip content="There can only be one owner. Only the owner can transfer ownership to another member via the action menu.">
+                  <span>
+                    <Button
+                      type="button"
+                      data-testid="input"
+                      aria-label="Member role"
+                      variant="outline"
+                      color="neutral"
+                      size="md"
+                      className="h-9 w-44 justify-between"
+                      disabled={!canEditRole || loadingUpdateRole}
+                    >
+                      <span className="truncate">{displayedRoleLabel}</span>
+                      <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />
+                    </Button>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Button
+                  type="button"
+                  data-testid="input"
+                  aria-label="Member role"
+                  variant="outline"
+                  color="neutral"
+                  size="md"
+                  className="h-9 w-44 justify-between"
+                  disabled={!canEditRole || loadingUpdateRole}
+                >
+                  <span className="truncate">{displayedRoleLabel}</span>
+                  <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />
+                </Button>
+              )}
             </DropdownMenu.Trigger>
             <DropdownMenu.Content align="start">
               {roleOptions.map((role) => (


### PR DESCRIPTION
## Summary

**Issue**: Member role display not reflecting owner status

- Added `displayedRoleLabel` computed value that shows "Owner" when `isOwner` is true, otherwise shows the selected role label
- Updated the role dropdown button to display `displayedRoleLabel` instead of `selectedRoleLabel`
- Ensures owner members display their correct role designation in the UI

## Testing

- Changes tested locally in the member settings page
- Existing tests pass
- `yarn format` and `yarn lint` verified

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules
- [x] I performed a self-review
- [x] I titled the PR using Conventional Commits with scope
- [x] I confirmed CI is green

https://claude.ai/code/session_01F7mY21ejd7yjdADPEnzEuM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Members page role dropdown so owner members see "Owner" instead of their selected role label, and hides the dropdown chevron for owner rows. Adds a tooltip explaining that ownership can only be transferred to another member via the action menu.

<sup>Written for commit bfda85ff774f95c4c3b4d06a4dd93c4cd46e5a43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

