### PR TITLE
fix: Enable selecting Qovery ID value in firefox

### DIFF
--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-integration-fields.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-integration-fields.tsx
@@ -18,7 +18,7 @@ export function SecretManagerIdField({ methods }: SecretManagerIntegrationFields
           name={field.name}
           value={field.value}
           error={error?.message}
-          disabled
+          readOnly
           hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
         />
       )}

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -117,7 +117,7 @@ export function ContainerRegistryForm({
               name={field.name}
               value={registry?.id}
               error={error?.message}
-              disabled
+              readOnly
               hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
             />
           )}

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
@@ -134,7 +134,7 @@ export function GitTokenCreateEditModal({ isEdit, gitToken, organizationId, onCl
                 name={field.name}
                 value={field.value}
                 error={error?.message}
-                disabled
+                readOnly
                 hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
               />
             )}

--- a/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.tsx
@@ -184,7 +184,7 @@ export function HelmRepositoryCreateEditModal({
                   name={field.name}
                   value={field.value || ''}
                   error={error?.message}
-                  disabled
+                  readOnly
                   hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
                 />
               )}

--- a/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
@@ -20,6 +20,7 @@ export interface InputTextProps {
   hint?: ReactNode
   error?: string
   disabled?: boolean
+  readOnly?: boolean
   dataTestId?: string
   rightElement?: ReactNode
   placeholder?: string
@@ -38,6 +39,7 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
     error,
     className = '',
     disabled,
+    readOnly,
     rightElement,
     dataTestId,
     placeholder,
@@ -74,8 +76,13 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
   const hasValue = Boolean(currentValue?.toString().length)
   const hasLabelUp = hasFocus || hasValue || Boolean(placeholder) ? 'input--label-up' : ''
   const hasError = error && error.length > 0 ? 'input--error' : ''
-  const inputActions = hasFocus ? 'input--focused' : disabled ? 'input--disabled' : ''
-  const isDisabled = disabled ? 'input--disabled !border-neutral' : ''
+  const disabledClass = disabled ? 'input--disabled' : readOnly ? 'input--readonly' : ''
+  const inputActions = hasFocus ? 'input--focused' : disabledClass
+  const isDisabled = disabled
+    ? 'input--disabled !border-neutral'
+    : readOnly
+      ? 'input--readonly !border-neutral hover:!border-neutral !cursor-default'
+      : ''
 
   const displayPicker = () => {
     const input = inputRef.current?.querySelector('input')
@@ -117,9 +124,14 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
               ref={ref}
               name={name}
               id={label}
-              className={twMerge('input__value', rightElement && '!pr-9')}
+              className={twMerge(
+                'input__value',
+                rightElement && '!pr-9',
+                readOnly && '!cursor-default caret-transparent'
+              )}
               type={currentType}
               disabled={disabled}
+              readOnly={readOnly}
               value={currentValue}
               placeholder={placeholder}
               autoFocus={autoFocus}

--- a/libs/shared/ui/src/lib/styles/components/input.scss
+++ b/libs/shared/ui/src/lib/styles/components/input.scss
@@ -103,6 +103,25 @@
   }
 }
 
+// Same look as .input--disabled, but keeps pointer-events on so the value stays selectable/copyable.
+// Firefox (unlike Chrome) refuses to let users select text inside a pointer-events-none element.
+.input--readonly {
+  @apply border-neutral bg-surface-neutral-subtle;
+  box-shadow: none !important;
+
+  label {
+    @apply text-neutral-subtle;
+  }
+
+  .input__value {
+    @apply text-neutral-subtle;
+  }
+}
+
+.input--readonly.input--focused {
+  outline: none;
+}
+
 .input--error,
 .input--error .input__button {
   @apply border-negative-strong;


### PR DESCRIPTION
## Summary

On firefox, we can't select the Qovery ID to copy it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Qovery ID fields being unselectable in Firefox. Replaces `disabled` with `readOnly` on the ID inputs in the secret manager, container registry, git token, and helm repository modals, and adds a `readOnly` prop to the shared `InputText` component that keeps the same disabled look while allowing text selection.

<sup>Written for commit 6ae64123fe6aeac7023881c116c5fa8e5bad0f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

