### PR TITLE
chore(ui): replace fireEvent and standardize userEvent usage

### DIFF
--- a/.agents/skills/qovery-console-standards/AGENTS.md
+++ b/.agents/skills/qovery-console-standards/AGENTS.md
@@ -117,7 +117,8 @@ libs/
 ### Test Setup
 
 - Use `renderWithProviders` from `@qovery/shared/util-tests`.
-- Prefer `userEvent` over `fireEvent`.
+- In React tests, do not use `fireEvent`; treat it as deprecated in this repository. Use awaited `userEvent` interactions instead.
+- Allow exceptions only when `userEvent` cannot represent the browser event, and document why.
 - Unit tests are mandatory for business logic.
 - Snapshots for complex UI components.
 

--- a/.agents/skills/qovery-console-standards/SKILL.md
+++ b/.agents/skills/qovery-console-standards/SKILL.md
@@ -56,7 +56,8 @@ Reference these guidelines when:
 ### Testing
 
 - `renderWithProviders` from `@qovery/shared/util-tests`
-- `userEvent` over `fireEvent`, Arrange-Act-Assert pattern
+- Await `userEvent` interactions; treat `fireEvent` as deprecated unless `userEvent` cannot represent the event and the exception is documented
+- Arrange-Act-Assert pattern
 - Cover success, error, and edge states
 
 ### Naming

--- a/.agents/skills/qovery-console-standards/rules/testing-standards.md
+++ b/.agents/skills/qovery-console-standards/rules/testing-standards.md
@@ -9,7 +9,8 @@ tags: [testing, jest, unit-tests, mocking, coverage]
 ## Test Setup
 
 - Use `renderWithProviders` from `@qovery/shared/util-tests`
-- Prefer `userEvent` over `fireEvent`
+- In React tests, do not use `fireEvent`; treat it as deprecated in this repository. Use awaited `userEvent` interactions instead.
+- Allow exceptions only when `userEvent` cannot represent the browser event, and document why.
 - Unit tests are mandatory for business logic
 - Snapshots for complex UI components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ Symlinks: `.cursor/skills/` and `.claude/skills/` point to `.agents/skills/`.
 - `ts-pattern` for branching logic. React Query for server state.
 - Shared utilities live in `@qovery/shared/util-js`.
 
+## Testing
+
+- In React tests, do not use `fireEvent`; treat it as deprecated in this repository. Use awaited `userEvent` interactions instead.
+- Allow exceptions only when `userEvent` cannot represent the browser event, and document why.
+
 ## Agent Behavior
 
 - Do not revert changes you did not author.

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { fireEvent, renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import StickyActionFormToaster, { type StickyActionFormToasterProps } from './sticky-action-form-toaster'
 
 const props: StickyActionFormToasterProps = {
@@ -87,16 +87,16 @@ describe('StickyActionFormToaster', () => {
   })
 
   it('should animate in and out before unmounting', async () => {
-    renderWithProviders(<StickyActionFormToasterHarness />)
+    const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness />)
 
     expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
 
     const toaster = screen.getByTestId('sticky-action-form-toaster')
     expect(toaster).toBeVisible()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
 
     expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
     await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
@@ -106,12 +106,12 @@ describe('StickyActionFormToaster', () => {
     const onReset = jest.fn()
     const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness onReset={onReset} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
 
     expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
 
     await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toHaveStyle('pointer-events: auto'))
     await userEvent.click(screen.getByRole('button', { name: 'Reset' }))


### PR DESCRIPTION
## Summary

**Issue**: <!-- QOV-1234 -->

- Remove the read-only input mode and use disabled fields for non-editable resource IDs.
- Simplify secret manager forms by removing the edit-only Qovery ID field.
- Keep member role controls consistent by always rendering the role dropdown.
- Improve Scaleway static IP description copy.
- Update sticky action toaster tests to use awaited `userEvent` interactions.
- Preserve toaster animations, cluster advanced-settings behavior, and related regression coverage.

## Screenshots / Recordings

Not applicable.

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code

Base branch: staging

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates sticky action toaster interaction tests to awaited `userEvent` and documents `fireEvent` as deprecated in React tests across repo standards.

- Toaster animation and reset tests now use awaited `userEvent.click` instead of `fireEvent.click`.
- Test standards in `.agents/skills` and `AGENTS.md` now require awaited `userEvent` and allow `fireEvent` exceptions only when `userEvent` cannot represent the event.

<sup>Written for commit 875deeec483677ac79b117d52365419d9c257ec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

