### PR TITLE
chore(release): promote staging to production

### DIFF
--- a/.agents/skills/qovery-console-standards/AGENTS.md
+++ b/.agents/skills/qovery-console-standards/AGENTS.md
@@ -117,7 +117,8 @@ libs/
 ### Test Setup
 
 - Use `renderWithProviders` from `@qovery/shared/util-tests`.
-- Prefer `userEvent` over `fireEvent`.
+- In React tests, do not use `fireEvent`; treat it as deprecated in this repository. Use awaited `userEvent` interactions instead.
+- Allow exceptions only when `userEvent` cannot represent the browser event, and document why.
 - Unit tests are mandatory for business logic.
 - Snapshots for complex UI components.
 

--- a/.agents/skills/qovery-console-standards/SKILL.md
+++ b/.agents/skills/qovery-console-standards/SKILL.md
@@ -56,7 +56,8 @@ Reference these guidelines when:
 ### Testing
 
 - `renderWithProviders` from `@qovery/shared/util-tests`
-- `userEvent` over `fireEvent`, Arrange-Act-Assert pattern
+- Await `userEvent` interactions; treat `fireEvent` as deprecated unless `userEvent` cannot represent the event and the exception is documented
+- Arrange-Act-Assert pattern
 - Cover success, error, and edge states
 
 ### Naming

--- a/.agents/skills/qovery-console-standards/rules/testing-standards.md
+++ b/.agents/skills/qovery-console-standards/rules/testing-standards.md
@@ -9,7 +9,8 @@ tags: [testing, jest, unit-tests, mocking, coverage]
 ## Test Setup
 
 - Use `renderWithProviders` from `@qovery/shared/util-tests`
-- Prefer `userEvent` over `fireEvent`
+- In React tests, do not use `fireEvent`; treat it as deprecated in this repository. Use awaited `userEvent` interactions instead.
+- Allow exceptions only when `userEvent` cannot represent the browser event, and document why.
 - Unit tests are mandatory for business logic
 - Snapshots for complex UI components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ Symlinks: `.cursor/skills/` and `.claude/skills/` point to `.agents/skills/`.
 - `ts-pattern` for branching logic. React Query for server state.
 - Shared utilities live in `@qovery/shared/util-js`.
 
+## Testing
+
+- In React tests, do not use `fireEvent`; treat it as deprecated in this repository. Use awaited `userEvent` interactions instead.
+- Allow exceptions only when `userEvent` cannot represent the browser event, and document why.
+
 ## Agent Behavior
 
 - Do not revert changes you did not author.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ First use
 
     yarn && yarn setup
 
+### Environment variables
+
+By default, the Console loads its environment variables from the repository's `.env` file. To share one environment configuration across Git worktrees, move the file to a stable directory and pass that directory when starting the Console:
+
+    QOVERY_CONSOLE_ENV_DIR="$HOME/.config/qovery-console" yarn start
+
+Vite loads `.env`, `.env.local`, and mode-specific environment files from that directory. When `QOVERY_CONSOLE_ENV_DIR` is not set, the repository root remains the default.
+
 Start the project on http://localhost:4200
 
     yarn start

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -2,15 +2,18 @@
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { defineConfig, loadEnv } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig(({ mode }) => {
-  const clientEnv = loadEnv(mode, process.cwd(), '')
+  const envDir = resolve(process.env.QOVERY_CONSOLE_ENV_DIR ?? process.cwd())
+  const clientEnv = loadEnv(mode, envDir, '')
+  delete clientEnv.QOVERY_CONSOLE_ENV_DIR
 
   return {
     root: __dirname,
+    envDir,
     cacheDir: '../../node_modules/.vite/apps/console',
     server: {
       port: 4200,

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.spec.ts
@@ -1,0 +1,69 @@
+import { buildClusterAdvancedSettingsPayload } from './build-cluster-advanced-settings-payload'
+
+describe('buildClusterAdvancedSettingsPayload', () => {
+  it('should preserve already flattened settings', () => {
+    expect(
+      buildClusterAdvancedSettingsPayload({
+        'cluster.setting': '1.0',
+      })
+    ).toEqual({
+      'cluster.setting': 1,
+    })
+  })
+
+  it('should normalize a trailing decimal point as a number', () => {
+    expect(
+      buildClusterAdvancedSettingsPayload({
+        'cluster.setting': '1.',
+      })
+    ).toEqual({
+      'cluster.setting': 1,
+    })
+  })
+
+  it.each(['1.0', 'true', 'null', '1e3'])(
+    'should preserve the JSON-parseable value %s when the setting default is a string',
+    (value) => {
+      expect(
+        buildClusterAdvancedSettingsPayload(
+          {
+            'load_balancer.size': value,
+          },
+          {
+            'load_balancer.size': 'lb-s',
+          }
+        )
+      ).toEqual({
+        'load_balancer.size': value,
+      })
+    }
+  )
+
+  it('should fall back to the default when a string setting is empty', () => {
+    expect(
+      buildClusterAdvancedSettingsPayload(
+        {
+          'load_balancer.size': '',
+        },
+        {
+          'load_balancer.size': 'lb-s',
+        }
+      )
+    ).toEqual({
+      'load_balancer.size': 'lb-s',
+    })
+  })
+
+  it('should prefer nested form values over stale flattened values', () => {
+    expect(
+      buildClusterAdvancedSettingsPayload({
+        'cluster.setting': '1',
+        cluster: {
+          setting: '2',
+        },
+      })
+    ).toEqual({
+      'cluster.setting': 2,
+    })
+  })
+})

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/build-cluster-advanced-settings-payload.ts
@@ -1,0 +1,51 @@
+import { type ClusterAdvancedSettings } from 'qovery-typescript-axios'
+import { objectFlattener } from '@qovery/shared/util-js'
+
+function normalizeClusterAdvancedSettingValue(value: unknown, defaultValue: unknown): unknown {
+  if (typeof value === 'string') {
+    if (value === '') {
+      return typeof defaultValue === 'object' ? defaultValue : defaultValue ?? ''
+    }
+
+    if (typeof defaultValue === 'string') {
+      return value
+    }
+
+    try {
+      return JSON.parse(value)
+    } catch {
+      const numericValue = Number(value)
+      if (Number.isFinite(numericValue)) {
+        return numericValue
+      }
+    }
+  }
+
+  return value
+}
+
+export function normalizeClusterAdvancedSettings(
+  advancedSettings: ClusterAdvancedSettings | Record<string, unknown>,
+  defaultAdvancedSettings?: ClusterAdvancedSettings
+): ClusterAdvancedSettings {
+  return Object.fromEntries(
+    Object.entries(advancedSettings).map(([key, value]) => [
+      key,
+      normalizeClusterAdvancedSettingValue(value, defaultAdvancedSettings?.[key as keyof ClusterAdvancedSettings]),
+    ])
+  ) as ClusterAdvancedSettings
+}
+
+export function buildClusterAdvancedSettingsPayload(
+  data: Record<string, unknown>,
+  defaultAdvancedSettings?: ClusterAdvancedSettings
+): ClusterAdvancedSettings {
+  const flatData = Object.fromEntries(Object.entries(data).filter(([key]) => key.includes('.')))
+  const nestedData = Object.fromEntries(Object.entries(data).filter(([key]) => !key.includes('.')))
+  const dataFormatted = {
+    ...flatData,
+    ...objectFlattener(nestedData),
+  }
+
+  return normalizeClusterAdvancedSettings(dataFormatted, defaultAdvancedSettings)
+}

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.spec.tsx
@@ -1,0 +1,87 @@
+import { renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
+import { ClusterAdvancedSettingsFeature } from './cluster-advanced-settings-feature'
+
+const mockUseClusterAdvancedSettings = jest.fn()
+const mockUseDefaultAdvancedSettings = jest.fn()
+const mockUseEditClusterAdvancedSettings = jest.fn()
+const mockEditClusterAdvancedSettings = jest.fn()
+
+jest.mock('@tanstack/react-router', () => ({
+  useParams: () => ({ organizationId: 'organization-id', clusterId: 'cluster-id' }),
+}))
+
+jest.mock('../hooks/use-cluster-advanced-settings/use-cluster-advanced-settings', () => ({
+  useClusterAdvancedSettings: () => mockUseClusterAdvancedSettings(),
+}))
+
+jest.mock('../hooks/use-default-advanced-settings/use-default-advanced-settings', () => ({
+  useDefaultAdvancedSettings: () => mockUseDefaultAdvancedSettings(),
+}))
+
+jest.mock('../hooks/use-edit-cluster-advanced-settings/use-edit-cluster-advanced-settings', () => ({
+  useEditClusterAdvancedSettings: () => mockUseEditClusterAdvancedSettings(),
+}))
+
+describe('ClusterAdvancedSettingsFeature', () => {
+  beforeEach(() => {
+    mockEditClusterAdvancedSettings.mockReset()
+    mockUseClusterAdvancedSettings.mockReturnValue({
+      data: { 'cluster.setting': 1 },
+      isLoading: false,
+    })
+    mockUseDefaultAdvancedSettings.mockReturnValue({
+      data: { 'cluster.setting': 1 },
+    })
+    mockUseEditClusterAdvancedSettings.mockReturnValue({ mutateAsync: mockEditClusterAdvancedSettings })
+  })
+
+  it('should keep the save banner hidden until the payload changes after the form reset', async () => {
+    const { userEvent } = renderWithProviders(<ClusterAdvancedSettingsFeature />)
+
+    const textarea = await screen.findByRole('textbox')
+    await waitFor(() => expect(textarea).toHaveValue('1'))
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '2')
+
+    await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible())
+  })
+
+  it('should keep the save banner hidden for a payload-equivalent edit', async () => {
+    const { userEvent } = renderWithProviders(<ClusterAdvancedSettingsFeature />)
+
+    const textarea = await screen.findByRole('textbox')
+    await waitFor(() => expect(textarea).toHaveValue('1'))
+
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '1.')
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('1.')
+      expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+    })
+
+    await userEvent.type(textarea, '0')
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('1.0')
+      expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+    })
+  })
+
+  it('should hide the save banner after the settings are saved', async () => {
+    mockEditClusterAdvancedSettings.mockImplementation((_variables: unknown, options?: { onSuccess?: () => void }) =>
+      options?.onSuccess?.()
+    )
+    const { userEvent } = renderWithProviders(<ClusterAdvancedSettingsFeature />)
+
+    const textarea = await screen.findByRole('textbox')
+    await waitFor(() => expect(textarea).toHaveValue('1'))
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '2')
+    await userEvent.click(await screen.findByTestId('submit-button'))
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
+  })
+})

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings-feature.tsx
@@ -1,11 +1,11 @@
 import { useParams } from '@tanstack/react-router'
 import { type ClusterAdvancedSettings as ClusterAdvancedSettingsType } from 'qovery-typescript-axios'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import { objectFlattener } from '@qovery/shared/util-js'
 import { useClusterAdvancedSettings } from '../hooks/use-cluster-advanced-settings/use-cluster-advanced-settings'
 import { useDefaultAdvancedSettings } from '../hooks/use-default-advanced-settings/use-default-advanced-settings'
 import { useEditClusterAdvancedSettings } from '../hooks/use-edit-cluster-advanced-settings/use-edit-cluster-advanced-settings'
+import { buildClusterAdvancedSettingsPayload } from './build-cluster-advanced-settings-payload'
 import { ClusterAdvancedSettings } from './cluster-advanced-settings'
 import { initFormValues } from './init-form-values'
 
@@ -19,57 +19,33 @@ export function ClusterAdvancedSettingsFeature() {
   const { mutateAsync: editClusterAdvancedSettings } = useEditClusterAdvancedSettings()
   const { data: defaultAdvancedSettings } = useDefaultAdvancedSettings()
 
-  const [keys, setKeys] = useState<string[]>([])
-
   const methods = useForm<{ [key: string]: string }>({ mode: 'onChange' })
+  const [formBaseline, setFormBaseline] = useState<ClusterAdvancedSettingsType>()
 
-  useEffect(() => {
-    if (clusterAdvancedSettings) {
-      setKeys(Object.keys(clusterAdvancedSettings).sort())
-    }
-  }, [clusterAdvancedSettings])
+  const keys = useMemo(() => Object.keys(clusterAdvancedSettings ?? {}).sort(), [clusterAdvancedSettings])
 
   useEffect(() => {
     if (clusterAdvancedSettings) {
       methods.reset(initFormValues(keys, clusterAdvancedSettings))
+      setFormBaseline(clusterAdvancedSettings)
     }
   }, [clusterAdvancedSettings, keys, methods])
 
   const onSubmit = methods.handleSubmit((data) => {
-    let dataFormatted: Record<string, string> = { ...data }
-
-    Object.keys(dataFormatted).forEach((key) => {
-      if (key.includes('.')) {
-        delete dataFormatted[key]
-      }
-    })
-
-    dataFormatted = objectFlattener(dataFormatted) as Record<string, string>
-
-    const payload: Record<string, unknown> = { ...dataFormatted }
-
-    Object.keys(dataFormatted).forEach((key) => {
-      try {
-        payload[key] = JSON.parse(dataFormatted[key])
-      } catch {
-        if (dataFormatted[key] === '') {
-          const defaultVal = defaultAdvancedSettings
-            ? defaultAdvancedSettings[key as keyof ClusterAdvancedSettingsType]
-            : ''
-          payload[key] = typeof defaultVal === 'object' ? defaultVal : defaultVal ?? ''
-        }
-      }
-    })
+    const payload = buildClusterAdvancedSettingsPayload(data, defaultAdvancedSettings)
 
     if (clusterAdvancedSettings) {
       editClusterAdvancedSettings(
         {
           organizationId,
           clusterId,
-          clusterAdvancedSettings: payload as ClusterAdvancedSettingsType,
+          clusterAdvancedSettings: payload,
         },
         {
-          onSuccess: () => methods.reset(data),
+          onSuccess: () => {
+            methods.reset(data)
+            setFormBaseline(payload)
+          },
         }
       )
     }
@@ -82,6 +58,7 @@ export function ClusterAdvancedSettingsFeature() {
         loading={isClusterAdvancedSettingsLoading}
         clusterAdvancedSettings={clusterAdvancedSettings}
         defaultAdvancedSettings={defaultAdvancedSettings}
+        formBaseline={formBaseline}
       />
     </FormProvider>
   )

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.spec.tsx
@@ -1,7 +1,22 @@
 import { wrapWithReactHookForm } from '__tests__/utils/wrap-with-react-hook-form'
 import { type ClusterAdvancedSettings } from 'qovery-typescript-axios'
-import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
+import { buildClusterAdvancedSettingsPayload } from './build-cluster-advanced-settings-payload'
 import { ClusterAdvancedSettings as ClusterAdvancedSettingsComponent } from './cluster-advanced-settings'
+
+jest.mock('./build-cluster-advanced-settings-payload', () => {
+  const actualModule = jest.requireActual('./build-cluster-advanced-settings-payload')
+
+  return {
+    ...actualModule,
+    buildClusterAdvancedSettingsPayload: jest.fn(actualModule.buildClusterAdvancedSettingsPayload),
+  }
+})
+
+const mockedBuildClusterAdvancedSettingsPayload = jest.mocked(buildClusterAdvancedSettingsPayload)
+const actualBuildClusterAdvancedSettingsPayload = jest.requireActual(
+  './build-cluster-advanced-settings-payload'
+).buildClusterAdvancedSettingsPayload
 
 const mockClusterAdvancedSettings = {
   key1: 'value1',
@@ -18,6 +33,7 @@ describe('ClusterAdvancedSettings', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedBuildClusterAdvancedSettingsPayload.mockImplementation(actualBuildClusterAdvancedSettingsPayload)
   })
 
   it('should render correctly', () => {
@@ -28,6 +44,7 @@ describe('ClusterAdvancedSettings', () => {
           loading={false}
           clusterAdvancedSettings={mockClusterAdvancedSettings}
           defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
         />,
         {
           defaultValues: {
@@ -77,7 +94,7 @@ describe('ClusterAdvancedSettings', () => {
     expect(spinners.length).toBeLessThanOrEqual(1)
   })
 
-  it('should show StickyActionFormToaster when form is dirty', async () => {
+  it('should show StickyActionFormToaster when the form payload changes quickly', async () => {
     const { userEvent, container } = renderWithProviders(
       wrapWithReactHookForm(
         <ClusterAdvancedSettingsComponent
@@ -85,27 +102,25 @@ describe('ClusterAdvancedSettings', () => {
           loading={false}
           clusterAdvancedSettings={mockClusterAdvancedSettings}
           defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
         />,
         {
           defaultValues: {
-            key1: '',
-            key2: '',
+            key1: 'value1',
+            key2: 'value2',
           },
         }
       )
     )
 
     const textarea = container.querySelector('textarea[name="key1"]') as HTMLTextAreaElement
-    if (textarea) {
-      await userEvent.type(textarea, 'modified')
-    }
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, 'modified quickly')
 
-    expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
-    const toaster = screen.getByTestId('sticky-action-form-toaster')
-    await waitFor(() => expect(toaster).toHaveClass('visible'))
+    await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible())
   })
 
-  it('should not show StickyActionFormToaster when form is not dirty', () => {
+  it('should not show StickyActionFormToaster when the form payload is unchanged', () => {
     renderWithProviders(
       wrapWithReactHookForm(
         <ClusterAdvancedSettingsComponent
@@ -113,20 +128,114 @@ describe('ClusterAdvancedSettings', () => {
           loading={false}
           clusterAdvancedSettings={mockClusterAdvancedSettings}
           defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
         />,
         {
           defaultValues: {
-            key1: '',
-            key2: '',
+            key1: 'value1',
+            key2: 'value2',
           },
         }
       )
     )
 
-    const toaster = screen.queryByTestId('sticky-action-form-toaster')
-    expect(toaster).toBeInTheDocument()
-    expect(toaster).toHaveClass('hidden')
-    expect(toaster).not.toHaveClass('visible')
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+  })
+
+  it('should not show StickyActionFormToaster when dirty form values produce the current payload', async () => {
+    const clusterAdvancedSettings = {
+      'cluster.setting': 1,
+      key2: 'value2',
+    } as ClusterAdvancedSettings
+
+    const { userEvent, container } = renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterAdvancedSettingsComponent
+          onSubmit={mockOnSubmit}
+          loading={false}
+          clusterAdvancedSettings={clusterAdvancedSettings}
+          defaultAdvancedSettings={clusterAdvancedSettings}
+          formBaseline={clusterAdvancedSettings}
+        />,
+        {
+          defaultValues: {
+            'cluster.setting': '1',
+            key2: 'value2',
+          },
+        }
+      )
+    )
+
+    const textarea = container.querySelector('textarea[name="cluster.setting"]') as HTMLTextAreaElement
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '1.0')
+
+    await waitFor(() => expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument())
+  })
+
+  it('should hide StickyActionFormToaster when all values are reverted', async () => {
+    const { userEvent, container } = renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterAdvancedSettingsComponent
+          onSubmit={mockOnSubmit}
+          loading={false}
+          clusterAdvancedSettings={mockClusterAdvancedSettings}
+          defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
+        />,
+        {
+          defaultValues: {
+            key1: 'value1',
+            key2: 'value2',
+          },
+        }
+      )
+    )
+
+    const textarea = container.querySelector('textarea[name="key1"]') as HTMLTextAreaElement
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, 'modified')
+    expect(await screen.findByTestId('sticky-action-form-toaster')).toBeVisible()
+
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, 'value1')
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
+  })
+
+  it('should compare current and saved values using the same normalization', async () => {
+    const clusterAdvancedSettings = {
+      'cluster.setting': 1,
+      'empty.setting': '',
+    } as ClusterAdvancedSettings
+    const defaultAdvancedSettings = {
+      'cluster.setting': 1,
+      'empty.setting': 'default',
+    } as ClusterAdvancedSettings
+
+    const { userEvent, container } = renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterAdvancedSettingsComponent
+          onSubmit={mockOnSubmit}
+          loading={false}
+          clusterAdvancedSettings={clusterAdvancedSettings}
+          defaultAdvancedSettings={defaultAdvancedSettings}
+          formBaseline={clusterAdvancedSettings}
+        />,
+        {
+          defaultValues: {
+            'cluster.setting': '1',
+            'empty.setting': '',
+          },
+        }
+      )
+    )
+
+    const textarea = container.querySelector('textarea[name="cluster.setting"]') as HTMLTextAreaElement
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, '1.0')
+
+    await waitFor(() => expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument())
   })
 
   it('should call onSubmit when form is submitted', () => {
@@ -174,5 +283,32 @@ describe('ClusterAdvancedSettings', () => {
     )
 
     expect(screen.getByText('Show only overridden settings')).toBeInTheDocument()
+  })
+
+  it('should not rebuild the form payload when filtering overridden settings', async () => {
+    const { userEvent } = renderWithProviders(
+      wrapWithReactHookForm(
+        <ClusterAdvancedSettingsComponent
+          onSubmit={mockOnSubmit}
+          loading={false}
+          clusterAdvancedSettings={mockClusterAdvancedSettings}
+          defaultAdvancedSettings={mockDefaultAdvancedSettings}
+          formBaseline={mockClusterAdvancedSettings}
+        />,
+        {
+          defaultValues: {
+            key1: 'value1',
+            key2: 'value2',
+          },
+        }
+      )
+    )
+
+    await waitFor(() => expect(mockedBuildClusterAdvancedSettingsPayload).toHaveBeenCalled())
+    const callCount = mockedBuildClusterAdvancedSettingsPayload.mock.calls.length
+
+    await userEvent.click(screen.getByTestId('show-overriden-only-toggle'))
+
+    expect(mockedBuildClusterAdvancedSettingsPayload).toHaveBeenCalledTimes(callCount)
   })
 })

--- a/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-advanced-settings/cluster-advanced-settings.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import equal from 'fast-deep-equal'
 import { type ClusterAdvancedSettings as ClusterAdvancedSettingsType } from 'qovery-typescript-axios'
 import { useMemo, useState } from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller, useFormContext, useFormState, useWatch } from 'react-hook-form'
 import {
   CopyToClipboardButtonIcon,
   Icon,
@@ -13,12 +13,17 @@ import {
   Tooltip,
 } from '@qovery/shared/ui'
 import { generateAdvancedSettingDocUrl, twMerge } from '@qovery/shared/util-js'
+import {
+  buildClusterAdvancedSettingsPayload,
+  normalizeClusterAdvancedSettings,
+} from './build-cluster-advanced-settings-payload'
 
 export interface ClusterAdvancedSettingsProps {
   onSubmit: () => void
   loading: boolean
   clusterAdvancedSettings?: ClusterAdvancedSettingsType
   defaultAdvancedSettings?: ClusterAdvancedSettingsType
+  formBaseline?: ClusterAdvancedSettingsType
 }
 
 function formatValue(value: unknown) {
@@ -27,13 +32,55 @@ function formatValue(value: unknown) {
 
 const { Table } = TablePrimitives
 
+interface ClusterAdvancedSettingsSaveActionProps {
+  onSubmit: () => void
+  loading: boolean
+  defaultAdvancedSettings?: ClusterAdvancedSettingsType
+  formBaseline?: ClusterAdvancedSettingsType
+}
+
+function ClusterAdvancedSettingsSaveAction({
+  onSubmit,
+  loading,
+  defaultAdvancedSettings,
+  formBaseline,
+}: ClusterAdvancedSettingsSaveActionProps) {
+  const { control, reset } = useFormContext<{ [key: string]: string }>()
+  const { isDirty, isValid } = useFormState({ control })
+  const formValues = useWatch({ control })
+  const normalizedBaseline = useMemo(
+    () =>
+      formBaseline === undefined ? undefined : normalizeClusterAdvancedSettings(formBaseline, defaultAdvancedSettings),
+    [defaultAdvancedSettings, formBaseline]
+  )
+  const currentPayload = useMemo(
+    () => buildClusterAdvancedSettingsPayload(formValues as Record<string, unknown>, defaultAdvancedSettings),
+    [defaultAdvancedSettings, formValues]
+  )
+  const hasChanged = useMemo(
+    () => isDirty && normalizedBaseline !== undefined && !equal(currentPayload, normalizedBaseline),
+    [currentPayload, isDirty, normalizedBaseline]
+  )
+
+  return (
+    <StickyActionFormToaster
+      visible={hasChanged}
+      onSubmit={onSubmit}
+      onReset={reset}
+      disabledValidation={!isValid}
+      loading={loading}
+    />
+  )
+}
+
 export function ClusterAdvancedSettings({
   onSubmit,
   loading,
   clusterAdvancedSettings,
   defaultAdvancedSettings,
+  formBaseline,
 }: ClusterAdvancedSettingsProps) {
-  const { control, formState, reset } = useFormContext<{ [key: string]: string }>()
+  const { control } = useFormContext<{ [key: string]: string }>()
   const [showOverriddenOnly, toggleShowOverriddenOnly] = useState(false)
 
   const keys = useMemo(() => {
@@ -169,12 +216,11 @@ export function ClusterAdvancedSettings({
               </Table.Root>
             </div>
           )}
-          <StickyActionFormToaster
-            visible={formState.isDirty}
+          <ClusterAdvancedSettingsSaveAction
             onSubmit={onSubmit}
-            onReset={reset}
-            disabledValidation={!formState.isValid}
             loading={loading}
+            defaultAdvancedSettings={defaultAdvancedSettings}
+            formBaseline={formBaseline}
           />
         </div>
       </form>

--- a/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.spec.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.spec.tsx
@@ -53,6 +53,13 @@ describe('ClusterHeaderLogs', () => {
     expect(refScrollSection?.current?.scroll).toHaveBeenCalledWith(0, refScrollSection?.current?.scrollHeight)
   })
 
+  it('should render scroll controls without a gap', () => {
+    renderWithProviders(<ClusterHeaderLogs {...props} />)
+
+    expect(screen.getByTestId('scroll-up-button').parentElement).toHaveClass('gap-0')
+    expect(screen.getByTestId('scroll-down-button')).not.toHaveClass('mr-2')
+  })
+
   it('should trigger download on click', async () => {
     const { userEvent } = renderWithProviders(<ClusterHeaderLogs {...props} />)
     const buttons = screen.getAllByRole('button')

--- a/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-logs/cluster-header-logs/cluster-header-logs.tsx
@@ -95,30 +95,32 @@ export function ClusterHeaderLogs({ cluster, clusterStatus, refScrollSection, da
             Launch diagnostic for this error
           </Button>
         )}
-        <Button
-          data-testid="scroll-up-button"
-          className="rounded-br-none rounded-tr-none border-r-0"
-          type="button"
-          variant="outline"
-          color="neutral"
-          size="sm"
-          iconOnly
-          onClick={() => forcedScroll()}
-        >
-          <Icon iconName="arrow-up-to-line" />
-        </Button>
-        <Button
-          data-testid="scroll-down-button"
-          className="mr-2 rounded-bl-none rounded-tl-none"
-          variant="outline"
-          type="button"
-          color="neutral"
-          size="sm"
-          iconOnly
-          onClick={() => forcedScroll(true)}
-        >
-          <Icon iconName="arrow-down-to-line" />
-        </Button>
+        <div className="flex items-center gap-0">
+          <Button
+            data-testid="scroll-up-button"
+            className="rounded-br-none rounded-tr-none border-r-0"
+            type="button"
+            variant="outline"
+            color="neutral"
+            size="sm"
+            iconOnly
+            onClick={() => forcedScroll()}
+          >
+            <Icon iconName="arrow-up-to-line" />
+          </Button>
+          <Button
+            data-testid="scroll-down-button"
+            className="rounded-bl-none rounded-tl-none"
+            variant="outline"
+            type="button"
+            color="neutral"
+            size="sm"
+            iconOnly
+            onClick={() => forcedScroll(true)}
+          >
+            <Icon iconName="arrow-down-to-line" />
+          </Button>
+        </div>
         <Button
           type="button"
           variant="outline"

--- a/libs/domains/clusters/feature/src/lib/scaleway-static-ip/scaleway-static-ip.tsx
+++ b/libs/domains/clusters/feature/src/lib/scaleway-static-ip/scaleway-static-ip.tsx
@@ -64,7 +64,7 @@ export function ScalewayStaticIp({
                     }}
                     disabled={disabled}
                     title="Static IP / Nat Gateways"
-                    description="Your cluster will only be visible from a fixed number of public IP. On Scaleway, Nat Gateways and Elastic IPs will be setup."
+                    description="Your cluster's outbound traffic will originate from a fixed number of public IPs. On Scaleway, Nat Gateways and Elastic IPs will be setup."
                     align="top"
                     small
                   />

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal.tsx
@@ -41,6 +41,7 @@ export function SecretManagerIntegrationModal({
   )
   const { navigation, layout, aws, defaultAuthenticationMode } = constraints
   const { isManualOnlyGcpIntegration, isManualOnlyAwsIntegration } = layout
+  const isEdit = mode === 'edit'
   const providerTabs = getActiveProviderConstraints(constraints)
   const automaticTab = providerTabs?.automatic
 
@@ -126,12 +127,13 @@ export function SecretManagerIntegrationModal({
 
   const manualSections = isGcpManualTabOnGcpSecretManager ? (
     <div className="flex flex-col gap-3">
-      <GcpSecretManagerManualSections methods={methods} regions={gcpRegions} />
+      <GcpSecretManagerManualSections isEdit={isEdit} methods={methods} regions={gcpRegions} />
     </div>
   ) : (
     <AwsSecretManagerManualSections
       authenticationTypeSelect={aws?.manual.authenticationTypeSelect}
       cluster={cluster}
+      isEdit={isEdit}
       isManualOnlyIntegration={isManualOnlyAwsIntegration}
       methods={methods}
       option={option}
@@ -151,7 +153,7 @@ export function SecretManagerIntegrationModal({
       >
         <div className={`flex flex-col ${isManualOnlyGcpIntegration ? 'gap-3' : 'gap-4'} px-5 pb-6 pt-4`}>
           {isManualOnlyGcpIntegration ? (
-            <GcpSecretManagerManualSections methods={methods} regions={gcpRegions} />
+            <GcpSecretManagerManualSections isEdit={isEdit} methods={methods} regions={gcpRegions} />
           ) : (
             manualSections
           )}
@@ -208,7 +210,7 @@ export function SecretManagerIntegrationModal({
       </div>
       <div className="p-5">
         {activeTab === 'automatic' ? (
-          <SecretManagerAutomaticSections methods={methods} option={option} regions={regions} />
+          <SecretManagerAutomaticSections isEdit={isEdit} methods={methods} option={option} regions={regions} />
         ) : (
           manualSections
         )}

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/aws-secret-manager-manual-sections.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/aws-secret-manager-manual-sections.tsx
@@ -5,11 +5,16 @@ import { type Value } from '@qovery/shared/interfaces'
 import { ExternalLink, Heading, InputSelect, InputText, Section, Tooltip } from '@qovery/shared/ui'
 import { type AwsManualAuthenticationTypeSelect } from '../secret-manager-integration-constraints'
 import { type SecretManagerOption } from '../secret-manager-integration.types'
-import { SecretManagerNameField, SecretManagerRegionField } from './secret-manager-integration-fields'
+import {
+  SecretManagerIdField,
+  SecretManagerNameField,
+  SecretManagerRegionField,
+} from './secret-manager-integration-fields'
 
 interface AwsSecretManagerManualSectionsProps {
   authenticationTypeSelect?: AwsManualAuthenticationTypeSelect
   cluster?: Cluster
+  isEdit: boolean
   isManualOnlyIntegration: boolean
   methods: UseFormReturn<SecretManagerAccess>
   option: SecretManagerOption
@@ -19,6 +24,7 @@ interface AwsSecretManagerManualSectionsProps {
 export function AwsSecretManagerManualSections({
   authenticationTypeSelect,
   cluster,
+  isEdit,
   isManualOnlyIntegration,
   methods,
   option,
@@ -27,7 +33,7 @@ export function AwsSecretManagerManualSections({
   if (isManualOnlyIntegration) {
     return (
       <div className="flex flex-col gap-4">
-        <AwsStaticCredentialsSections methods={methods} regions={regions} />
+        <AwsStaticCredentialsSections isEdit={isEdit} methods={methods} regions={regions} />
       </div>
     )
   }
@@ -35,7 +41,13 @@ export function AwsSecretManagerManualSections({
   return (
     <div className="flex flex-col gap-4">
       <AwsAuthenticationTypeSelect authenticationTypeSelect={authenticationTypeSelect} methods={methods} />
-      <AwsManualAuthenticationModeSections cluster={cluster} methods={methods} option={option} regions={regions} />
+      <AwsManualAuthenticationModeSections
+        cluster={cluster}
+        isEdit={isEdit}
+        methods={methods}
+        option={option}
+        regions={regions}
+      />
     </div>
   )
 }
@@ -55,12 +67,14 @@ function AwsCredentialsInstructions() {
 }
 
 interface AwsStaticCredentialsSectionsProps {
+  isEdit: boolean
   methods: UseFormReturn<SecretManagerAccess>
   regions: Value[]
   syncAuthenticationRegion?: boolean
 }
 
 function AwsStaticCredentialsSections({
+  isEdit,
   methods,
   regions,
   syncAuthenticationRegion = false,
@@ -72,6 +86,7 @@ function AwsStaticCredentialsSections({
         <Heading level={3} className="text-sm font-medium text-neutral">
           2. Fill in these information
         </Heading>
+        {isEdit && <SecretManagerIdField methods={methods} />}
         <SecretManagerRegionField
           methods={methods}
           regions={regions}
@@ -156,6 +171,7 @@ function AwsAuthenticationTypeSelect({ authenticationTypeSelect, methods }: AwsA
 
 interface AwsManualAuthenticationModeSectionsProps {
   cluster?: Cluster
+  isEdit: boolean
   methods: UseFormReturn<SecretManagerAccess>
   option: SecretManagerOption
   regions: Value[]
@@ -163,6 +179,7 @@ interface AwsManualAuthenticationModeSectionsProps {
 
 function AwsManualAuthenticationModeSections({
   cluster,
+  isEdit,
   methods,
   option,
   regions,
@@ -174,13 +191,19 @@ function AwsManualAuthenticationModeSections({
   }
 
   if (authenticationMode === 'AWS_STATIC_CREDENTIALS') {
-    return <AwsStaticCredentialsSections methods={methods} regions={regions} syncAuthenticationRegion />
+    return <AwsStaticCredentialsSections isEdit={isEdit} methods={methods} regions={regions} syncAuthenticationRegion />
   }
 
-  return <AwsAssumeRoleSections cluster={cluster} methods={methods} option={option} regions={regions} />
+  return <AwsAssumeRoleSections cluster={cluster} isEdit={isEdit} methods={methods} option={option} regions={regions} />
 }
 
-function AwsAssumeRoleSections({ cluster, methods, option, regions }: AwsManualAuthenticationModeSectionsProps) {
+function AwsAssumeRoleSections({
+  cluster,
+  isEdit,
+  methods,
+  option,
+  regions,
+}: AwsManualAuthenticationModeSectionsProps) {
   const templateURL =
     option.value === 'AWS_PARAMETER_STORE'
       ? 'https://s3.amazonaws.com/cloudformation-aws-parameter-store-role/template.json'
@@ -220,6 +243,7 @@ function AwsAssumeRoleSections({ cluster, methods, option, regions }: AwsManualA
         <Heading level={3} className="text-sm font-medium text-neutral">
           3. Provide your credentials info
         </Heading>
+        {isEdit && <SecretManagerIdField methods={methods} />}
         <SecretManagerRegionField methods={methods} regions={regions} />
         <Controller
           name="authentication.role_arn"

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/gcp-secret-manager-manual-sections.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/gcp-secret-manager-manual-sections.tsx
@@ -6,16 +6,18 @@ import { type Value } from '@qovery/shared/interfaces'
 import { Button, CopyButton, Dropzone, ExternalLink, Heading, Icon, Section } from '@qovery/shared/ui'
 import {
   GcpProjectIdField,
+  SecretManagerIdField,
   SecretManagerNameField,
   SecretManagerRegionField,
 } from './secret-manager-integration-fields'
 
 interface GcpSecretManagerManualSectionsProps {
+  isEdit: boolean
   methods: UseFormReturn<SecretManagerAccess>
   regions: Value[]
 }
 
-export function GcpSecretManagerManualSections({ methods, regions }: GcpSecretManagerManualSectionsProps) {
+export function GcpSecretManagerManualSections({ isEdit, methods, regions }: GcpSecretManagerManualSectionsProps) {
   const [fileDetails, setFileDetails] = useState<{ name: string; size: number }>()
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     maxFiles: 1,
@@ -112,6 +114,7 @@ export function GcpSecretManagerManualSections({ methods, regions }: GcpSecretMa
             return <div />
           }}
         />
+        {isEdit && <SecretManagerIdField methods={methods} />}
         <GcpProjectIdField methods={methods} />
         <SecretManagerRegionField methods={methods} regions={regions} />
         <SecretManagerNameField methods={methods} />

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-automatic-sections.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-automatic-sections.tsx
@@ -5,17 +5,24 @@ import { Callout, Icon } from '@qovery/shared/ui'
 import { type SecretManagerOption } from '../secret-manager-integration.types'
 import {
   GcpProjectIdField,
+  SecretManagerIdField,
   SecretManagerNameField,
   SecretManagerRegionField,
 } from './secret-manager-integration-fields'
 
 interface SecretManagerAutomaticSectionsProps {
+  isEdit: boolean
   methods: UseFormReturn<SecretManagerAccess>
   option: SecretManagerOption
   regions: Value[]
 }
 
-export function SecretManagerAutomaticSections({ methods, option, regions }: SecretManagerAutomaticSectionsProps) {
+export function SecretManagerAutomaticSections({
+  isEdit,
+  methods,
+  option,
+  regions,
+}: SecretManagerAutomaticSectionsProps) {
   return (
     <div className="flex flex-col gap-4">
       <div>
@@ -25,6 +32,7 @@ export function SecretManagerAutomaticSections({ methods, option, regions }: Sec
         </p>
       </div>
       <div className="flex flex-col gap-4">
+        {isEdit && <SecretManagerIdField methods={methods} />}
         {option.icon === 'GCP' && <GcpProjectIdField methods={methods} />}
         <SecretManagerRegionField methods={methods} regions={regions} />
         <SecretManagerNameField methods={methods} />

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-integration-fields.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-integration-fields.tsx
@@ -18,7 +18,7 @@ export function SecretManagerIdField({ methods }: SecretManagerIntegrationFields
           name={field.name}
           value={field.value}
           error={error?.message}
-          disabled
+          readOnly
           hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
         />
       )}

--- a/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-integration-fields.tsx
+++ b/libs/domains/clusters/feature/src/lib/secret-manager-modals/secret-manager-integration-modal/secret-manager-integration-fields.tsx
@@ -7,6 +7,25 @@ interface SecretManagerIntegrationFieldsProps {
   methods: UseFormReturn<SecretManagerAccess>
 }
 
+export function SecretManagerIdField({ methods }: SecretManagerIntegrationFieldsProps) {
+  return (
+    <Controller
+      name="id"
+      control={methods.control}
+      render={({ field, fieldState: { error } }) => (
+        <InputText
+          label="Qovery ID"
+          name={field.name}
+          value={field.value}
+          error={error?.message}
+          disabled
+          hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
+        />
+      )}
+    />
+  )
+}
+
 export function SecretManagerNameField({ methods }: SecretManagerIntegrationFieldsProps) {
   return (
     <Controller

--- a/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
+++ b/libs/domains/organizations/feature/src/lib/container-registry-form/container-registry-form.tsx
@@ -117,7 +117,7 @@ export function ContainerRegistryForm({
               name={field.name}
               value={registry?.id}
               error={error?.message}
-              disabled
+              readOnly
               hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
             />
           )}

--- a/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/git-token-create-edit-modal/git-token-create-edit-modal.tsx
@@ -134,7 +134,7 @@ export function GitTokenCreateEditModal({ isEdit, gitToken, organizationId, onCl
                 name={field.name}
                 value={field.value}
                 error={error?.message}
-                disabled
+                readOnly
                 hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
               />
             )}

--- a/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.tsx
+++ b/libs/domains/organizations/feature/src/lib/helm-repository-create-edit-modal/helm-repository-create-edit-modal.tsx
@@ -184,7 +184,7 @@ export function HelmRepositoryCreateEditModal({
                   name={field.name}
                   value={field.value || ''}
                   error={error?.message}
-                  disabled
+                  readOnly
                   hint="This is the ID to be used to interact with Qovery via the API, CLI or Terraform"
                 />
               )}

--- a/libs/domains/organizations/feature/src/lib/settings-members/row-member/row-member.tsx
+++ b/libs/domains/organizations/feature/src/lib/settings-members/row-member/row-member.tsx
@@ -87,12 +87,29 @@ export function RowMember(props: RowMemberProps) {
   const [roleOverrideId, setRoleOverrideId] = useState<string | null>(null)
   const displayedRoleValue = roleOverrideId && roleOverrideId !== selectedRoleValue ? roleOverrideId : selectedRoleValue
   const selectedRoleLabel = roleOptions.find((role) => role.value === displayedRoleValue)?.label ?? 'Select role'
+  const displayedRoleLabel = isOwner ? 'Owner' : selectedRoleLabel
 
   const handleRoleChange = (roleId: string | undefined) => {
     if (!roleId) return
     setRoleOverrideId(roleId)
     editMemberRole?.(member.id, roleId)
   }
+
+  const roleButton = (
+    <Button
+      type="button"
+      data-testid="input"
+      aria-label="Member role"
+      variant="outline"
+      color="neutral"
+      size="md"
+      className="h-9 w-44 justify-between"
+      disabled={!canEditRole || loadingUpdateRole}
+    >
+      <span className="truncate">{displayedRoleLabel}</span>
+      {!isOwner && <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />}
+    </Button>
+  )
 
   return (
     <Table.Row>
@@ -238,19 +255,13 @@ export function RowMember(props: RowMemberProps) {
         <div data-testid="row-member-menu" className="flex items-center">
           <DropdownMenu.Root>
             <DropdownMenu.Trigger asChild>
-              <Button
-                type="button"
-                data-testid="input"
-                aria-label="Member role"
-                variant="outline"
-                color="neutral"
-                size="md"
-                className="h-9 w-44 justify-between"
-                disabled={!canEditRole || loadingUpdateRole}
-              >
-                <span className="truncate">{selectedRoleLabel}</span>
-                <Icon iconName="angle-down" iconStyle="solid" className="text-sm text-neutral-subtle" />
-              </Button>
+              {isOwner ? (
+                <Tooltip content="There can only be one owner. Only the owner can transfer ownership to another member via the action menu.">
+                  <span>{roleButton}</span>
+                </Tooltip>
+              ) : (
+                roleButton
+              )}
             </DropdownMenu.Trigger>
             <DropdownMenu.Content align="start">
               {roleOptions.map((role) => (

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
 import { useLinks, useService } from '@qovery/domains/services/feature'
-import { renderWithProviders, screen, within } from '@qovery/shared/util-tests'
+import { act, renderWithProviders, screen, within } from '@qovery/shared/util-tests'
 import { HeaderLogs, type HeaderLogsProps } from './header-logs'
 
 jest.mock('@tanstack/react-router', () => ({
@@ -25,6 +25,7 @@ jest.mock('@qovery/domains/services/feature', () => ({
   useLinks: jest.fn(),
   ServiceAvatar: () => <div data-testid="service-avatar" />,
   ServiceLinksPopover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ServiceActions: () => <div />,
 }))
 
 const mockProps: HeaderLogsProps = {
@@ -47,6 +48,10 @@ const mockProps: HeaderLogsProps = {
 }
 
 describe('HeaderLogs', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   beforeEach(() => {
     useService.mockReturnValue({
       data: {
@@ -98,5 +103,234 @@ describe('HeaderLogs', () => {
       </HeaderLogs>
     )
     expect(screen.getByTestId('child-content')).toBeInTheDocument()
+  })
+
+  it('excludes non-computing overhead from a completed deployment duration', () => {
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'SUCCESS', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 47,
+            total_duration_sec: 53,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 4 },
+              { step_name: 'DEPLOYMENT', status: 'SUCCESS', duration_sec: 43 },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+    expect(screen.queryByText('0m : 53s')).not.toBeInTheDocument()
+  })
+
+  it('adds the elapsed ongoing step duration to the completed step durations', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 2 },
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 15 },
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 48s')).toBeInTheDocument()
+  })
+
+  it('excludes queueing steps from an ongoing deployment computing duration', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 12 },
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 48s')).toBeInTheDocument()
+    expect(screen.queryByText('1m : 0s')).not.toBeInTheDocument()
+  })
+
+  it('does not use the last deployment date as computing time when step details are empty', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: { total_computing_duration_sec: 0, total_duration_sec: null, details: [] },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
+  })
+
+  it('uses recorded computing time when no step has a live start time', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 2 },
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 15 },
+              { step_name: 'DEPLOYMENT', status: 'ONGOING', duration_sec: 0 },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+  })
+
+  it('starts ticking when a computing step follows queueing', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    const { rerender } = renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              {
+                step_name: 'DEPLOYMENT_QUEUEING',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    rerender(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 31 },
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:30:01Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 18s')).toBeInTheDocument()
+  })
+
+  it('falls back to the recorded computing duration without timing data', () => {
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: { total_computing_duration_sec: 17, total_duration_sec: null, details: [] },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
   })
 })

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -14,6 +14,7 @@ import { dateUTCString } from '@qovery/shared/util-dates'
 import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { pluralize, trimId } from '@qovery/shared/util-js'
 import { PodHealthChips } from '../pod-health-chips/pod-health-chips'
+import { getServiceStepsComputingDurationSec, hasLiveServiceStepComputingDuration } from '../service-step-metrics'
 
 export interface HeaderLogsProps extends PropsWithChildren {
   type: 'DEPLOYMENT' | 'SERVICE'
@@ -21,6 +22,14 @@ export interface HeaderLogsProps extends PropsWithChildren {
   environment: Environment
   serviceStatus: Status
   environmentStatus?: EnvironmentStatus
+}
+
+function getOngoingDeploymentComputingDurationSec(serviceStatus: Status, nowMs: number) {
+  const steps = serviceStatus.steps?.details ?? []
+  const stepsComputingDurationSec = getServiceStepsComputingDurationSec(steps, nowMs)
+  const recordedComputingDurationSec = serviceStatus.steps?.total_computing_duration_sec ?? 0
+
+  return Math.max(stepsComputingDurationSec, recordedComputingDurationSec)
 }
 
 export function HeaderLogs({
@@ -51,13 +60,13 @@ export function HeaderLogs({
   const isOngoing = match(serviceStatus?.status_details?.status)
     .with('ONGOING', 'CANCELING', () => true)
     .otherwise(() => false)
+  const hasLiveComputingDuration = hasLiveServiceStepComputingDuration(serviceStatus.steps?.details ?? [])
 
-  useIntervalTick(isOngoing)
+  useIntervalTick(isOngoing && hasLiveComputingDuration)
 
-  const totalDurationSec =
-    isOngoing && serviceStatus?.last_deployment_date
-      ? Math.floor((Date.now() - new Date(serviceStatus.last_deployment_date).getTime()) / 1000)
-      : serviceStatus?.steps?.total_computing_duration_sec ?? 0
+  const computingDurationSec = isOngoing
+    ? getOngoingDeploymentComputingDurationSec(serviceStatus, Date.now())
+    : serviceStatus.steps?.total_computing_duration_sec ?? 0
 
   if (!service) return null
 
@@ -120,7 +129,7 @@ export function HeaderLogs({
                     title={dateUTCString(serviceStatus.last_deployment_date ?? '')}
                   >
                     <Icon iconName="stopwatch" iconStyle="regular" className="text-base text-neutral-subtle" />
-                    {Math.floor(totalDurationSec / 60)}m : {totalDurationSec % 60}s
+                    {Math.floor(computingDurationSec / 60)}m : {computingDurationSec % 60}s
                   </span>
                   <svg xmlns="http://www.w3.org/2000/svg" width="5" height="6" fill="none" viewBox="0 0 5 6">
                     <circle cx="2.5" cy="2.955" r="2.5" fill="var(--neutral-6)"></circle>

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.spec.tsx
@@ -1,6 +1,6 @@
 import { StateEnum, type Status } from 'qovery-typescript-axios'
 import { type Terraform } from '@qovery/domains/services/data-access'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { act, renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { FiltersStageStep, type FiltersStageStepProps } from './filters-stage-step'
 
 const mockToggleColumnFilter = jest.fn()
@@ -27,6 +27,11 @@ jest.mock('@tanstack/react-router', () => ({
 describe('FiltersStageStep', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it('renders BUILD and DEPLOY buttons', () => {
@@ -64,5 +69,59 @@ describe('FiltersStageStep', () => {
     renderWithProviders(<FiltersStageStep {...defaultProps} />)
     expect(screen.getByText('1m : 0s')).toBeInTheDocument() // BUILD duration
     expect(screen.getByText('2m : 0s')).toBeInTheDocument() // DEPLOY duration
+  })
+
+  it('ticks the current step duration locally from its backend start time', () => {
+    jest.setSystemTime(new Date('2026-08-25T10:05:00Z'))
+    const props = {
+      ...defaultProps,
+      serviceStatus: {
+        ...defaultProps.serviceStatus,
+        steps: {
+          details: [
+            { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 60 },
+            {
+              step_name: 'BUILD',
+              status: 'ONGOING',
+              duration_sec: 0,
+              started_at: '2026-08-25T10:00:00Z',
+            },
+            { step_name: 'DEPLOYMENT', status: 'SUCCESS', duration_sec: 120 },
+          ],
+        },
+      },
+    }
+
+    renderWithProviders(<FiltersStageStep {...props} />)
+
+    expect(screen.getByText('6m : 0s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('6m : 1s')).toBeInTheDocument()
+  })
+
+  it('uses the recorded duration once a step is completed', () => {
+    jest.setSystemTime(new Date('2026-08-25T11:00:00Z'))
+    const props = {
+      ...defaultProps,
+      serviceStatus: {
+        ...defaultProps.serviceStatus,
+        steps: {
+          details: [
+            {
+              step_name: 'BUILD',
+              status: 'SUCCESS',
+              duration_sec: 300,
+              started_at: '2026-08-25T10:00:00Z',
+            },
+          ],
+        },
+      },
+    }
+
+    renderWithProviders(<FiltersStageStep {...props} />)
+
+    expect(screen.getByText('5m : 0s')).toBeInTheDocument()
   })
 })

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
@@ -6,10 +6,20 @@ import { P, match } from 'ts-pattern'
 import { type AnyService } from '@qovery/domains/services/data-access'
 import { isHelmRepositorySource, isJobContainerSource } from '@qovery/shared/enums'
 import { Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
+import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
+import {
+  getServiceStepDurationSec,
+  getServiceStepsDurationSec,
+  isServiceStepDurationLive,
+} from '../../service-step-metrics'
 import { type FilterType } from '../list-deployment-logs'
 
-type StepMetricType = { build: ServiceStepMetric[]; deploy: ServiceStepMetric[]; executing: ServiceStepMetric[] }
+type StepMetricType = {
+  build: ServiceStepMetric[]
+  deploy: ServiceStepMetric[]
+  executing: ServiceStepMetric[]
+}
 
 interface StageStepProps {
   type: Extract<FilterType, 'BUILD' | 'DEPLOY' | 'EXECUTING'>
@@ -21,7 +31,9 @@ interface StageStepProps {
 
 function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: StageStepProps) {
   const { hash } = useLocation()
-  const totalDurationSec = steps.reduce((acc, step) => acc + (step.duration_sec || 0), 0)
+  const nowMs = Date.now()
+  const totalDurationSec = getServiceStepsDurationSec(steps, nowMs)
+  const hasLiveDuration = steps.some(isServiceStepDurationLive)
 
   const buildStep = steps.find((s) => s.step_name === 'BUILD')
   const deployStep = steps.find((s) => s.step_name === 'DEPLOYMENT')
@@ -29,16 +41,16 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
 
   const status = match({ type, state, buildStep, deployStep })
     .with({ type: 'BUILD' }, () => {
-      if (state === 'BUILDING') return 'BUILDING'
+      if (state === 'BUILDING' || hasLiveDuration) return 'BUILDING'
       return buildStep?.status
     })
     .with({ type: 'DEPLOY' }, () => {
       if (state === 'BUILDING') return 'READY'
-      if (state === 'DEPLOYING') return 'DEPLOYING'
+      if (state === 'DEPLOYING' || hasLiveDuration) return 'DEPLOYING'
       return deployStep?.status
     })
     .with({ type: 'EXECUTING' }, () => {
-      if (state === 'EXECUTING') return 'EXECUTING'
+      if (state === 'EXECUTING' || hasLiveDuration) return 'EXECUTING'
       return executingStep?.status
     })
     .exhaustive()
@@ -58,16 +70,21 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
     }
     // On the first load, if status is 'ERROR', the column filter is toggled
     // For all subsequent renders, the column filter is toggled only if the status is 'ERROR'
-  }, [status, toggleColumnFilter, isFirstLoad, hash])
+  }, [status, toggleColumnFilter, isFirstLoad, hash, type])
 
-  const isBuildingOrDeploying =
-    (type === 'BUILD' && status === 'BUILDING') || (type === 'DEPLOY' && status === 'DEPLOYING')
+  const isStepRunning =
+    (type === 'BUILD' && status === 'BUILDING') ||
+    (type === 'DEPLOY' && status === 'DEPLOYING') ||
+    (type === 'EXECUTING' && status === 'EXECUTING')
+  useIntervalTick(hasLiveDuration)
+
+  const shouldDisplayDuration = hasLiveDuration || totalDurationSec > 0
 
   const buttonClasses = clsx(
     'flex h-8 items-center gap-1.5 rounded-lg border border-neutral bg-surface-neutral px-2.5 text-sm font-medium text-neutral-subtle transition hover:border-neutral-subtle hover:bg-surface-neutral-component',
     {
       'border-neutral-strong bg-surface-neutral-subtle text-neutral': isFilterActive(type),
-      'border-brand-component bg-surface-brand-subtle': isBuildingOrDeploying && isFilterActive(type),
+      'border-brand-component bg-surface-brand-subtle': isStepRunning && isFilterActive(type),
       'border-positive-strong bg-surface-positive-subtle': status === 'SUCCESS' && isFilterActive(type),
       'border-negative-strong bg-surface-negative-subtle': status === 'ERROR' && isFilterActive(type),
     }
@@ -77,7 +94,7 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
     <button className={twMerge(buttonClasses)} onClick={() => toggleColumnFilter(type)}>
       <StatusChip status={status} />
       {upperCaseFirstLetter(type.toLowerCase())}
-      {totalDurationSec > 0 ? (
+      {shouldDisplayDuration ? (
         <>
           <svg xmlns="http://www.w3.org/2000/svg" width="5" height="6" fill="none" viewBox="0 0 5 6">
             <circle cx="2.5" cy="3" r="2.5" fill="#383E50" />
@@ -91,18 +108,22 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
         content={
           <span className="flex flex-col gap-0.5">
             {steps.length > 0 ? (
-              steps.map((step) => (
-                <span key={step.step_name} className="font-medium">
-                  {upperCaseFirstLetter(step.step_name)?.replace(/_/g, ' ')}:{' '}
-                  {step.duration_sec ? (
-                    <>
-                      {Math.floor(step.duration_sec / 60)}m {step.duration_sec % 60}s
-                    </>
-                  ) : (
-                    '0s'
-                  )}
-                </span>
-              ))
+              steps.map((step, index) => {
+                const durationSec = getServiceStepDurationSec(step, nowMs)
+
+                return (
+                  <span key={`${step.step_name}-${index}`} className="font-medium">
+                    {upperCaseFirstLetter(step.step_name)?.replace(/_/g, ' ')}:{' '}
+                    {durationSec ? (
+                      <>
+                        {Math.floor(durationSec / 60)}m {durationSec % 60}s
+                      </>
+                    ) : (
+                      '0s'
+                    )}
+                  </span>
+                )
+              })
             ) : (
               <span>No detail available</span>
             )}
@@ -133,7 +154,7 @@ export function FiltersStageStep({
 }: FiltersStageStepProps) {
   if (!steps?.details) return <div />
 
-  const categorizedSteps = steps.details.reduce(
+  const categorizedSteps = steps.details.reduce<StepMetricType>(
     (acc, step) => {
       if (!step.step_name) return acc
 
@@ -145,7 +166,7 @@ export function FiltersStageStep({
 
       return acc
     },
-    { build: [], deploy: [], executing: [] } as StepMetricType
+    { build: [], deploy: [], executing: [] }
   )
 
   return (

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
@@ -1,0 +1,157 @@
+import {
+  getServiceStepDurationSec,
+  getServiceStepsComputingDurationSec,
+  getServiceStepsDurationSec,
+  hasLiveServiceStepComputingDuration,
+  isServiceStepDurationLive,
+  isServiceStepIncludedInComputingDuration,
+} from './service-step-metrics'
+
+const nowMs = Date.parse('2026-08-28T13:30:00Z')
+
+describe('isServiceStepDurationLive', () => {
+  it('returns true for an ongoing step with a valid start time', () => {
+    expect(isServiceStepDurationLive({ status: 'ONGOING', started_at: '2026-08-28T13:29:30Z' })).toBe(true)
+  })
+
+  it.each([
+    { status: 'ONGOING', started_at: 'invalid' },
+    { status: 'ONGOING' },
+    { status: 'SUCCESS', started_at: '2026-08-28T13:29:30Z' },
+  ])('returns false without both ongoing status and a valid start time', (step) => {
+    expect(isServiceStepDurationLive(step)).toBe(false)
+  })
+})
+
+describe('isServiceStepIncludedInComputingDuration', () => {
+  it.each(['BUILD_QUEUEING', 'DEPLOYMENT_QUEUEING'] as const)('excludes the %s step', (stepName) => {
+    expect(isServiceStepIncludedInComputingDuration({ step_name: stepName })).toBe(false)
+  })
+
+  it.each([
+    'REGISTRY_CREATE_REPOSITORY',
+    'GIT_CLONE',
+    'BUILD',
+    'MIRROR_IMAGE',
+    'DEPLOYMENT',
+    'ROUTER_DEPLOYMENT',
+    'EXECUTING',
+  ] as const)('includes the %s step', (stepName) => {
+    expect(isServiceStepIncludedInComputingDuration({ step_name: stepName })).toBe(true)
+  })
+
+  it('excludes a metric without a step name', () => {
+    expect(isServiceStepIncludedInComputingDuration({})).toBe(false)
+  })
+})
+
+describe('getServiceStepDurationSec', () => {
+  it('returns the recorded duration for a completed step', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'SUCCESS', duration_sec: 15 }, nowMs)
+
+    expect(durationSec).toBe(15)
+  })
+
+  it('returns the elapsed duration for an ongoing step', () => {
+    const durationSec = getServiceStepDurationSec(
+      {
+        status: 'ONGOING',
+        duration_sec: 0,
+        started_at: '2026-08-28T13:29:29.500Z',
+      },
+      nowMs
+    )
+
+    expect(durationSec).toBe(30)
+  })
+
+  it('returns the recorded duration when an ongoing step has no start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', duration_sec: 12 }, nowMs)
+
+    expect(durationSec).toBe(12)
+  })
+
+  it('returns zero for an invalid start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', started_at: 'invalid' }, nowMs)
+
+    expect(durationSec).toBe(0)
+  })
+
+  it('returns the recorded duration when the start time is invalid', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', duration_sec: 12, started_at: 'invalid' }, nowMs)
+
+    expect(durationSec).toBe(12)
+  })
+
+  it('does not return a negative duration for a future start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', started_at: '2026-08-28T13:31:00Z' }, nowMs)
+
+    expect(durationSec).toBe(0)
+  })
+})
+
+describe('getServiceStepsDurationSec', () => {
+  it('adds completed step durations to the elapsed ongoing step duration', () => {
+    const durationSec = getServiceStepsDurationSec(
+      [
+        { status: 'SUCCESS', duration_sec: 2 },
+        { status: 'SUCCESS', duration_sec: 15 },
+        { status: 'ONGOING', duration_sec: 0, started_at: '2026-08-28T13:29:30Z' },
+      ],
+      nowMs
+    )
+
+    expect(durationSec).toBe(47)
+  })
+
+  it('returns zero for an empty step list', () => {
+    expect(getServiceStepsDurationSec([], nowMs)).toBe(0)
+  })
+})
+
+describe('getServiceStepsComputingDurationSec', () => {
+  it('excludes completed queueing steps from the live computing duration', () => {
+    const durationSec = getServiceStepsComputingDurationSec(
+      [
+        { step_name: 'BUILD_QUEUEING', status: 'SUCCESS', duration_sec: 12 },
+        { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 4 },
+        { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 8 },
+        {
+          step_name: 'DEPLOYMENT',
+          status: 'ONGOING',
+          duration_sec: 0,
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ],
+      nowMs
+    )
+
+    expect(durationSec).toBe(34)
+  })
+})
+
+describe('hasLiveServiceStepComputingDuration', () => {
+  it('returns false when only a queueing step is live', () => {
+    expect(
+      hasLiveServiceStepComputingDuration([
+        {
+          step_name: 'DEPLOYMENT_QUEUEING',
+          status: 'ONGOING',
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ])
+    ).toBe(false)
+  })
+
+  it('returns true when a computing step is live', () => {
+    expect(
+      hasLiveServiceStepComputingDuration([
+        {
+          step_name: 'DEPLOYMENT',
+          status: 'ONGOING',
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ])
+    ).toBe(true)
+  })
+})

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
@@ -1,0 +1,62 @@
+import { type ServiceStepMetric } from 'qovery-typescript-axios'
+
+const NON_COMPUTING_STEP_NAMES = new Set<ServiceStepMetric['step_name']>(['BUILD_QUEUEING', 'DEPLOYMENT_QUEUEING'])
+
+/**
+ * Returns whether a step contributes to the header's computing timer and q-core's `total_computing_duration_sec`.
+ * Unlike stage and wall-clock durations, computing time excludes build and deployment queueing.
+ */
+export function isServiceStepIncludedInComputingDuration(step: ServiceStepMetric) {
+  return step.step_name !== undefined && !NON_COMPUTING_STEP_NAMES.has(step.step_name)
+}
+
+/**
+ * Returns whether an individual step should advance from its backend `started_at` timestamp.
+ * Completed steps may retain this timestamp, so the `ONGOING` status is essential to keep their final duration frozen.
+ */
+export function isServiceStepDurationLive(step: ServiceStepMetric) {
+  if (step.status !== 'ONGOING' || !step.started_at) return false
+
+  return Number.isFinite(Date.parse(step.started_at))
+}
+
+/**
+ * Returns an individual step's live elapsed time while ongoing, or its backend-recorded duration otherwise.
+ * This also provides a stable fallback when `started_at` is missing or malformed.
+ */
+export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number) {
+  if (!isServiceStepDurationLive(step)) return step.duration_sec || 0
+
+  const startedAtMs = Date.parse(step.started_at ?? '')
+  return Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000))
+}
+
+/**
+ * Calculates a Build, Deploy, or Executing stage timer by adding every step assigned to that stage.
+ * Queueing is intentionally included because these timers represent the complete elapsed time of each stage.
+ */
+export function getServiceStepsDurationSec(steps: ServiceStepMetric[], nowMs: number) {
+  return steps.reduce((totalDurationSec, step) => totalDurationSec + getServiceStepDurationSec(step, nowMs), 0)
+}
+
+/**
+ * Calculates the live header timer by adding completed and ongoing computing steps while excluding queueing.
+ * This keeps it comparable with q-core's completed computing total rather than the deployment history's wall-clock total.
+ */
+export function getServiceStepsComputingDurationSec(steps: ServiceStepMetric[], nowMs: number) {
+  return steps.reduce(
+    (totalDurationSec, step) =>
+      isServiceStepIncludedInComputingDuration(step)
+        ? totalDurationSec + getServiceStepDurationSec(step, nowMs)
+        : totalDurationSec,
+    0
+  )
+}
+
+/**
+ * Returns whether the header needs a one-second client-side update for an ongoing computing step.
+ * Queue-only and completed deployments remain stable because they do not change the displayed computing duration.
+ */
+export function hasLiveServiceStepComputingDuration(steps: ServiceStepMetric[]) {
+  return steps.some((step) => isServiceStepIncludedInComputingDuration(step) && isServiceStepDurationLive(step))
+}

--- a/libs/domains/services/feature/src/lib/hooks/use-blueprint-update-preview-socket/use-blueprint-update-preview-socket.spec.tsx
+++ b/libs/domains/services/feature/src/lib/hooks/use-blueprint-update-preview-socket/use-blueprint-update-preview-socket.spec.tsx
@@ -95,6 +95,28 @@ describe('useBlueprintUpdatePreviewSocket', () => {
     expect(result.current.outcome).toEqual({ type: 'error', message: 'terraform init failed' })
   })
 
+  it('should surface the reason of a timeout result', () => {
+    const { result, config } = renderPreviewSocket()
+    const reason = 'Terraform command (`terraform plan -no-color`) ran out of time and was stopped after 480s.'
+
+    act(() => {
+      config()?.onMessage?.({} as QueryClient, { type: 'timeout', message: reason })
+    })
+
+    expect(result.current.outcome).toEqual({ type: 'timeout', message: reason })
+  })
+
+  it('should settle on a timeout with no reason when the frame carries none', () => {
+    const { result, config } = renderPreviewSocket()
+
+    // The gateway sends its own reason-less timeout frame when no result reaches it.
+    act(() => {
+      config()?.onMessage?.({} as QueryClient, { type: 'timeout', message: null })
+    })
+
+    expect(result.current.outcome).toEqual({ type: 'timeout' })
+  })
+
   it.each([{ type: 'cancelled' }, { type: 'timeout' }] as const)('should settle on the $type outcome', ({ type }) => {
     const { result, config } = renderPreviewSocket()
 

--- a/libs/domains/services/feature/src/lib/hooks/use-blueprint-update-preview-socket/use-blueprint-update-preview-socket.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-blueprint-update-preview-socket/use-blueprint-update-preview-socket.ts
@@ -19,7 +19,8 @@ export type BlueprintUpdatePreviewOutcome =
   | { type: 'no-changes' }
   | { type: 'error'; message?: string }
   | { type: 'cancelled' }
-  | { type: 'timeout' }
+  // `message` is absent when nothing reported a reason: the watchdog below, or a gateway frame.
+  | { type: 'timeout'; message?: string }
 
 export interface BlueprintUpdatePreviewSocketData {
   outcome: BlueprintUpdatePreviewOutcome
@@ -71,7 +72,7 @@ export function useBlueprintUpdatePreviewSocket({
           )
           .with({ type: 'error' }, ({ message: reason }) => ({ type: 'error', message: reason }))
           .with({ type: 'cancelled' }, () => ({ type: 'cancelled' }))
-          .with({ type: 'timeout' }, () => ({ type: 'timeout' }))
+          .with({ type: 'timeout' }, ({ message }) => ({ type: 'timeout', message: message ?? undefined }))
           .exhaustive()
       )
     },

--- a/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-advanced-settings/service-advanced-settings.spec.tsx
@@ -1,6 +1,6 @@
 import { type Application } from '@qovery/domains/services/data-access'
 import { applicationFactoryMock } from '@qovery/shared/factories'
-import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import { AdvancedSettings } from './service-advanced-settings'
 
 const mockMutateEdit = jest.fn()
@@ -98,6 +98,11 @@ describe('AdvancedSettings', () => {
       await userEvent.type(input, '79')
       await userEvent.clear(input)
     }
+    const changedInput = container.querySelector('textarea[name="cronjob.success_jobs_history_limit"]')
+    if (changedInput) {
+      await userEvent.clear(changedInput)
+      await userEvent.type(changedInput, '4')
+    }
     expect(screen.getByTestId('submit-button')).toBeEnabled()
   })
 
@@ -168,8 +173,6 @@ describe('AdvancedSettings', () => {
 
     await userEvent.click(screen.getByTestId('submit-button'))
 
-    await waitFor(() => {
-      expect(screen.getByTestId('sticky-action-form-toaster')).not.toHaveClass('animate-action-bar-fade-in')
-    })
+    await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
   })
 })

--- a/libs/domains/services/feature/src/lib/service-blueprint-update-flow/blueprint-update-preview-step.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-blueprint-update-flow/blueprint-update-preview-step.spec.tsx
@@ -100,6 +100,17 @@ describe('BlueprintUpdatePreviewStep', () => {
     expect(confirmButton()).toBeDisabled()
   })
 
+  it('surfaces the reason a timeout happened and blocks confirmation', () => {
+    const reason = 'Terraform command (`terraform plan -no-color`) ran out of time and was stopped after 480s.'
+    mockPreview({ outcome: { type: 'timeout', message: reason } })
+
+    renderWithProviders(<BlueprintUpdatePreviewStep onBack={jest.fn()} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The preview timed out before completing.')
+    expect(screen.getByText(reason)).toBeInTheDocument()
+    expect(confirmButton()).toBeDisabled()
+  })
+
   it.each([
     [{ type: 'cancelled' } as const, 'The preview was cancelled.'],
     [{ type: 'timeout' } as const, 'The preview timed out before completing.'],

--- a/libs/domains/services/feature/src/lib/service-blueprint-update-flow/blueprint-update-preview-step.tsx
+++ b/libs/domains/services/feature/src/lib/service-blueprint-update-flow/blueprint-update-preview-step.tsx
@@ -155,8 +155,12 @@ function BlueprintUpdatePreviewContent({
               .with({ type: 'cancelled' }, () => (
                 <BlueprintUpdatePreviewFailure onRetry={onRetry} summary="The preview was cancelled." />
               ))
-              .with({ type: 'timeout' }, () => (
-                <BlueprintUpdatePreviewFailure onRetry={onRetry} summary="The preview timed out before completing." />
+              .with({ type: 'timeout' }, ({ message }) => (
+                <BlueprintUpdatePreviewFailure
+                  onRetry={onRetry}
+                  reason={message}
+                  summary="The preview timed out before completing."
+                />
               ))
               .exhaustive()}
           </div>

--- a/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
+++ b/libs/domains/variables/feature/src/lib/variable-list/__snapshots__/variable-list.spec.tsx.snap
@@ -1525,38 +1525,6 @@ exports[`VariableList should match snapshot 1`] = `
         </div>
       </div>
     </section>
-    <div
-      class="flex justify-center sticky bottom-4"
-    >
-      <div
-        class="inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl animate-action-bar-fade-out hidden"
-        data-testid="sticky-action-form-toaster"
-      >
-        <span
-          class="text-sm font-medium text-neutralInvert"
-        >
-          0 selected variable
-        </span>
-        <div
-          class="flex gap-5"
-        >
-          <button
-            class="text-ssm font-medium underline"
-            type="button"
-          >
-            Deselect
-          </button>
-          <button
-            class="inline-flex items-center shrink-0 font-medium transition-[background-color,transform] active:scale-[0.97] disabled:scale-100 disabled:pointer-events-none disabled:border disabled:border-neutral disabled:text-neutral-disabled disabled:bg-surface-neutral-component focus-visible:[&:not(:active)]:outline-2 outline-0 select-none outline-negative-strong text-sm h-8 px-2.5 gap-x-1.5 rounded-md bg-surface-negative-solid hover:bg-surface-negative-solidHover border border-negative-component text-neutral-contrasted"
-            data-testid="submit-button"
-            disabled=""
-            type="button"
-          >
-            Delete selected
-          </button>
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 `;

--- a/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
+++ b/libs/shared/ui/src/lib/components/inputs/input-text/input-text.tsx
@@ -20,6 +20,7 @@ export interface InputTextProps {
   hint?: ReactNode
   error?: string
   disabled?: boolean
+  readOnly?: boolean
   dataTestId?: string
   rightElement?: ReactNode
   placeholder?: string
@@ -38,6 +39,7 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
     error,
     className = '',
     disabled,
+    readOnly,
     rightElement,
     dataTestId,
     placeholder,
@@ -74,8 +76,13 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
   const hasValue = Boolean(currentValue?.toString().length)
   const hasLabelUp = hasFocus || hasValue || Boolean(placeholder) ? 'input--label-up' : ''
   const hasError = error && error.length > 0 ? 'input--error' : ''
-  const inputActions = hasFocus ? 'input--focused' : disabled ? 'input--disabled' : ''
-  const isDisabled = disabled ? 'input--disabled !border-neutral' : ''
+  const disabledClass = disabled ? 'input--disabled' : readOnly ? 'input--readonly' : ''
+  const inputActions = hasFocus ? 'input--focused' : disabledClass
+  const isDisabled = disabled
+    ? 'input--disabled !border-neutral'
+    : readOnly
+      ? 'input--readonly !border-neutral hover:!border-neutral !cursor-default'
+      : ''
 
   const displayPicker = () => {
     const input = inputRef.current?.querySelector('input')
@@ -117,9 +124,14 @@ export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function I
               ref={ref}
               name={name}
               id={label}
-              className={twMerge('input__value', rightElement && '!pr-9')}
+              className={twMerge(
+                'input__value',
+                rightElement && '!pr-9',
+                readOnly && '!cursor-default caret-transparent'
+              )}
               type={currentType}
               disabled={disabled}
+              readOnly={readOnly}
               value={currentValue}
               placeholder={placeholder}
               autoFocus={autoFocus}

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { fireEvent, renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
+import { renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import StickyActionFormToaster, { type StickyActionFormToasterProps } from './sticky-action-form-toaster'
 
 const props: StickyActionFormToasterProps = {
@@ -87,16 +87,16 @@ describe('StickyActionFormToaster', () => {
   })
 
   it('should animate in and out before unmounting', async () => {
-    renderWithProviders(<StickyActionFormToasterHarness />)
+    const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness />)
 
     expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
 
     const toaster = screen.getByTestId('sticky-action-form-toaster')
     expect(toaster).toBeVisible()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
 
     expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
     await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
@@ -106,12 +106,12 @@ describe('StickyActionFormToaster', () => {
     const onReset = jest.fn()
     const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness onReset={onReset} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
 
     expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
 
     await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toHaveStyle('pointer-events: auto'))
     await userEvent.click(screen.getByRole('button', { name: 'Reset' }))

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.spec.tsx
@@ -1,4 +1,5 @@
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { useState } from 'react'
+import { fireEvent, renderWithProviders, screen, waitFor, waitForElementToBeRemoved } from '@qovery/shared/util-tests'
 import StickyActionFormToaster, { type StickyActionFormToasterProps } from './sticky-action-form-toaster'
 
 const props: StickyActionFormToasterProps = {
@@ -7,13 +8,47 @@ const props: StickyActionFormToasterProps = {
   resetLabel: 'Reset',
   submitLabel: 'Save modifications',
   description: 'Warning, there are still unsaved changes!',
+  visible: true,
+}
+
+function StickyActionFormToasterHarness({ onReset = props.onReset }: Pick<StickyActionFormToasterProps, 'onReset'>) {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <>
+      <button type="button" onClick={() => setVisible(true)}>
+        Show toaster
+      </button>
+      <button type="button" onClick={() => setVisible(false)}>
+        Hide toaster
+      </button>
+      <StickyActionFormToaster {...props} visible={visible} onReset={onReset} />
+    </>
+  )
 }
 
 describe('StickyActionFormToaster', () => {
   it('should render successfully', () => {
-    const { baseElement } = renderWithProviders(<StickyActionFormToaster {...props} />)
-    expect(baseElement).toBeTruthy()
+    renderWithProviders(<StickyActionFormToaster {...props} />)
+
+    expect(screen.getByTestId('sticky-action-form-toaster')).toBeVisible()
   })
+
+  it.each([
+    { fixed: false, positionClass: 'sticky', bottomClass: 'bottom-4' },
+    { fixed: true, positionClass: 'fixed', bottomClass: 'bottom-14' },
+  ])(
+    'should render above other floating elements with $positionClass positioning',
+    ({ fixed, positionClass, bottomClass }) => {
+      renderWithProviders(<StickyActionFormToaster {...props} fixed={fixed} />)
+
+      expect(screen.getByTestId('sticky-action-form-toaster').parentElement).toHaveClass(
+        'z-toast',
+        positionClass,
+        bottomClass
+      )
+    }
+  )
 
   it('should handle reset on click', async () => {
     const spy = jest.fn()
@@ -49,5 +84,38 @@ describe('StickyActionFormToaster', () => {
     renderWithProviders(<StickyActionFormToaster {...props} submitButtonColor="red" />)
 
     expect(screen.getByTestId('submit-button')).toHaveClass('bg-surface-negative-solid')
+  })
+
+  it('should animate in and out before unmounting', async () => {
+    renderWithProviders(<StickyActionFormToasterHarness />)
+
+    expect(screen.queryByTestId('sticky-action-form-toaster')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+
+    const toaster = screen.getByTestId('sticky-action-form-toaster')
+    expect(toaster).toBeVisible()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+
+    expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
+    await waitForElementToBeRemoved(() => screen.queryByTestId('sticky-action-form-toaster'))
+  })
+
+  it('should remain interactive when shown again during the exit animation', async () => {
+    const onReset = jest.fn()
+    const { userEvent } = renderWithProviders(<StickyActionFormToasterHarness onReset={onReset} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Hide toaster' }))
+
+    expect(screen.getByTestId('sticky-action-form-toaster')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show toaster' }))
+
+    await waitFor(() => expect(screen.getByTestId('sticky-action-form-toaster')).toHaveStyle('pointer-events: auto'))
+    await userEvent.click(screen.getByRole('button', { name: 'Reset' }))
+
+    expect(onReset).toHaveBeenCalledTimes(1)
   })
 })

--- a/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
+++ b/libs/shared/ui/src/lib/components/sticky-action-form-toaster/sticky-action-form-toaster.tsx
@@ -1,6 +1,31 @@
-import { useEffect, useState } from 'react'
+import { AnimatePresence, type MotionProps, motion, useReducedMotion } from 'framer-motion'
 import { twMerge } from '@qovery/shared/util-js'
 import Button, { type ButtonProps } from '../button/button'
+
+const TOASTER_MOTION = {
+  initial: { opacity: 0.5, y: '50%', scale: 0.6 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    pointerEvents: 'auto',
+    transition: { duration: 0.35, ease: [0.165, 0.84, 0.44, 1] },
+  },
+  exit: {
+    opacity: 0,
+    y: '50%',
+    scale: 0.8,
+    pointerEvents: 'none',
+    transition: { duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] },
+  },
+} satisfies Pick<MotionProps, 'initial' | 'animate' | 'exit'>
+
+const REDUCED_TOASTER_MOTION = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, pointerEvents: 'auto' },
+  exit: { opacity: 0, pointerEvents: 'none' },
+  transition: { duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] },
+} satisfies Pick<MotionProps, 'initial' | 'animate' | 'exit' | 'transition'>
 
 export interface StickyActionFormToasterProps {
   visible?: boolean
@@ -28,59 +53,51 @@ export function StickyActionFormToaster(props: StickyActionFormToasterProps) {
     submitButtonColor,
     fixed = false,
   } = props
-
-  const [visibleState, setVisibleState] = useState(visible)
-
-  useEffect(() => {
-    if (visible) {
-      setVisibleState(true)
-    } else {
-      // we want to give the animation the time to play before removing the bloc from the flow with a display none
-      setTimeout(() => {
-        setVisibleState(false)
-      }, 500)
-    }
-  }, [visible])
+  const reducedMotion = useReducedMotion()
 
   const submitButtonColorValue = submitButtonColor ?? 'green'
 
   return (
-    <div
-      className={twMerge(
-        'flex justify-center',
-        fixed ? twMerge('fixed inset-x-0 bottom-14 z-30', !visibleState && 'hidden') : 'sticky bottom-4',
-        className
-      )}
-    >
-      <div
-        data-testid="sticky-action-form-toaster"
-        className={`inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl ${
-          visible ? 'animate-action-bar-fade-in' : 'animate-action-bar-fade-out'
-        } ${visibleState ? 'visible' : 'hidden'}`}
-      >
-        {description && <span className="text-sm font-medium text-neutralInvert">{description}</span>}
-        <div className="flex gap-5">
-          {resetLabel && onReset && (
-            <button type="button" className="text-ssm font-medium underline" onClick={() => onReset()}>
-              {resetLabel}
-            </button>
+    <AnimatePresence>
+      {visible ? (
+        <div
+          key="sticky-action-form-toaster"
+          className={twMerge(
+            'z-toast flex justify-center',
+            fixed ? 'fixed inset-x-0 bottom-14' : 'sticky bottom-4',
+            className
           )}
-          {submitLabel && onSubmit && (
-            <Button
-              color={submitButtonColorValue}
-              size="md"
-              data-testid="submit-button"
-              onClick={() => onSubmit()}
-              loading={props.loading}
-              disabled={props.disabledValidation}
-              type="button"
-            >
-              {submitLabel}
-            </Button>
-          )}
+        >
+          <motion.div
+            data-testid="sticky-action-form-toaster"
+            className="inline-flex items-center gap-10 rounded-md border border-neutral bg-surface-neutralInvert-component p-2 pl-4 text-neutralInvert shadow-xl"
+            {...(reducedMotion ? REDUCED_TOASTER_MOTION : TOASTER_MOTION)}
+          >
+            {description && <span className="text-sm font-medium text-neutralInvert">{description}</span>}
+            <div className="flex gap-5">
+              {resetLabel && onReset && (
+                <button type="button" className="text-ssm font-medium underline" onClick={() => onReset()}>
+                  {resetLabel}
+                </button>
+              )}
+              {submitLabel && onSubmit && (
+                <Button
+                  color={submitButtonColorValue}
+                  size="md"
+                  data-testid="submit-button"
+                  onClick={() => onSubmit()}
+                  loading={props.loading}
+                  disabled={props.disabledValidation}
+                  type="button"
+                >
+                  {submitLabel}
+                </Button>
+              )}
+            </div>
+          </motion.div>
         </div>
-      </div>
-    </div>
+      ) : null}
+    </AnimatePresence>
   )
 }
 

--- a/libs/shared/ui/src/lib/styles/components/input.scss
+++ b/libs/shared/ui/src/lib/styles/components/input.scss
@@ -103,6 +103,25 @@
   }
 }
 
+// Same look as .input--disabled, but keeps pointer-events on so the value stays selectable/copyable.
+// Firefox (unlike Chrome) refuses to let users select text inside a pointer-events-none element.
+.input--readonly {
+  @apply border-neutral bg-surface-neutral-subtle;
+  box-shadow: none !important;
+
+  label {
+    @apply text-neutral-subtle;
+  }
+
+  .input__value {
+    @apply text-neutral-subtle;
+  }
+}
+
+.input--readonly.input--focused {
+  outline: none;
+}
+
 .input--error,
 .input--error .input__button {
   @apply border-negative-strong;

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "prettier": "3.2.5",
     "prettier-plugin-tailwindcss": "0.5.14",
     "pretty-quick": "4.0.0",
-    "qovery-ws-typescript-axios": "0.1.644",
+    "qovery-ws-typescript-axios": "0.1.646",
     "react-docgen-typescript-plugin": "1.0.6",
     "react-flat-providers": "2.2.0",
     "react-refresh": "0.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6344,7 +6344,7 @@ __metadata:
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
     qovery-typescript-axios: 1.1.962
-    qovery-ws-typescript-axios: 0.1.644
+    qovery-ws-typescript-axios: 0.1.646
     react: 18.3.1
     react-country-flag: 3.0.2
     react-datepicker: 4.12.0
@@ -25872,12 +25872,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-ws-typescript-axios@npm:0.1.644":
-  version: 0.1.644
-  resolution: "qovery-ws-typescript-axios@npm:0.1.644"
+"qovery-ws-typescript-axios@npm:0.1.646":
+  version: 0.1.646
+  resolution: "qovery-ws-typescript-axios@npm:0.1.646"
   dependencies:
     axios: 1.18.1
-  checksum: e4ef2b3ff3d70f3566b4efafd3f71978810b816b5526e608e888c097c36be1fe6fb9dfcbd19ab50b0b1b2737484df76d1e7da896251948e9347b575a9be1ec9e
+  checksum: e9d4be31695558009d0a0169164e4f4b94a808bc19654d852aebfd3b68dc80f50af0d272d0acebd60786bfcbe4f0b7e7231047ae9ab6ec1f6621986de7eaa2ff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Opens the production promotion path from staging to main. Merging this PR triggers semantic-release, then the existing production deployment workflow.

Do not squash this PR. Use a merge commit to preserve the original conventional commits for semantic-release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the accumulated staging changes through the production path so merging this PR runs semantic-release followed by the existing production deployment workflow. The release includes fixes and usability improvements across clusters, blueprints, organization settings, and shared UI.

**Highlights**

- Timed-out blueprint previews now show the gateway or Terraform reason when available.
- Cluster advanced settings compare normalized payloads, so equivalent edits no longer show a save action.
- Deployment timers exclude queueing time and tick live while a computing step runs.
- Adds shared environment directory support through `QOVERY_CONSOLE_ENV_DIR`.
- Adds selectable Qovery IDs to secret-manager edit forms for QOV-2153.
- Includes updates to owner roles, static IP guidance, log controls, sticky action animations, and React test conventions.

**Migration**

- Merge with a merge commit and do not squash, so semantic-release can read the original conventional commits.

<sup>Written for commit 38855621e5dc4ccf3aaea6eac1f70302c5300297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

