### PR TITLE
fix: restore deployment timer bug fix

### DIFF
--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
@@ -91,6 +91,12 @@ describe('HeaderLogs', () => {
     expect(screen.queryByText('2m : 5s')).not.toBeInTheDocument()
   })
 
+  it('renders service logs when the service status is not available', () => {
+    renderWithProviders(<HeaderLogs {...mockProps} type="SERVICE" serviceStatus={null} />)
+
+    expect(screen.getByText('Test Service')).toBeInTheDocument()
+  })
+
   it('displays correct number of links', () => {
     renderWithProviders(<HeaderLogs {...mockProps} type="SERVICE" />)
     expect(screen.getByText('Link')).toBeInTheDocument()

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.spec.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
 import { useLinks, useService } from '@qovery/domains/services/feature'
-import { renderWithProviders, screen, within } from '@qovery/shared/util-tests'
+import { act, renderWithProviders, screen, within } from '@qovery/shared/util-tests'
 import { HeaderLogs, type HeaderLogsProps } from './header-logs'
 
 jest.mock('@tanstack/react-router', () => ({
@@ -25,6 +25,7 @@ jest.mock('@qovery/domains/services/feature', () => ({
   useLinks: jest.fn(),
   ServiceAvatar: () => <div data-testid="service-avatar" />,
   ServiceLinksPopover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ServiceActions: () => <div />,
 }))
 
 const mockProps: HeaderLogsProps = {
@@ -47,6 +48,10 @@ const mockProps: HeaderLogsProps = {
 }
 
 describe('HeaderLogs', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   beforeEach(() => {
     useService.mockReturnValue({
       data: {
@@ -98,5 +103,234 @@ describe('HeaderLogs', () => {
       </HeaderLogs>
     )
     expect(screen.getByTestId('child-content')).toBeInTheDocument()
+  })
+
+  it('excludes non-computing overhead from a completed deployment duration', () => {
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'SUCCESS', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 47,
+            total_duration_sec: 53,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 4 },
+              { step_name: 'DEPLOYMENT', status: 'SUCCESS', duration_sec: 43 },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+    expect(screen.queryByText('0m : 53s')).not.toBeInTheDocument()
+  })
+
+  it('adds the elapsed ongoing step duration to the completed step durations', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 2 },
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 15 },
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 48s')).toBeInTheDocument()
+  })
+
+  it('excludes queueing steps from an ongoing deployment computing duration', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 12 },
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 47s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 48s')).toBeInTheDocument()
+    expect(screen.queryByText('1m : 0s')).not.toBeInTheDocument()
+  })
+
+  it('does not use the last deployment date as computing time when step details are empty', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: { total_computing_duration_sec: 0, total_duration_sec: null, details: [] },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 0s')).toBeInTheDocument()
+  })
+
+  it('uses recorded computing time when no step has a live start time', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 2 },
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 15 },
+              { step_name: 'DEPLOYMENT', status: 'ONGOING', duration_sec: 0 },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+  })
+
+  it('starts ticking when a computing step follows queueing', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-28T13:30:00Z'))
+
+    const { rerender } = renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              {
+                step_name: 'DEPLOYMENT_QUEUEING',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:29:30Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    rerender(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          last_deployment_date: '2026-08-28T13:29:30Z',
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: {
+            total_computing_duration_sec: 17,
+            total_duration_sec: null,
+            details: [
+              { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 17 },
+              { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 31 },
+              {
+                step_name: 'DEPLOYMENT',
+                status: 'ONGOING',
+                duration_sec: 0,
+                started_at: '2026-08-28T13:30:01Z',
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('0m : 18s')).toBeInTheDocument()
+  })
+
+  it('falls back to the recorded computing duration without timing data', () => {
+    renderWithProviders(
+      <HeaderLogs
+        {...mockProps}
+        serviceStatus={{
+          ...mockProps.serviceStatus,
+          status_details: { action: 'DEPLOY', status: 'ONGOING', sub_action: 'NONE' },
+          steps: { total_computing_duration_sec: 17, total_duration_sec: null, details: [] },
+        }}
+      />
+    )
+
+    expect(screen.getByText('0m : 17s')).toBeInTheDocument()
   })
 })

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -20,14 +20,14 @@ export interface HeaderLogsProps extends PropsWithChildren {
   type: 'DEPLOYMENT' | 'SERVICE'
   serviceId: string
   environment: Environment
-  serviceStatus: Status
+  serviceStatus: Status | null
   environmentStatus?: EnvironmentStatus
 }
 
-function getOngoingDeploymentComputingDurationSec(serviceStatus: Status, nowMs: number) {
-  const steps = serviceStatus.steps?.details ?? []
+function getOngoingDeploymentComputingDurationSec(serviceStatus: Status | null, nowMs: number) {
+  const steps = serviceStatus?.steps?.details ?? []
   const stepsComputingDurationSec = getServiceStepsComputingDurationSec(steps, nowMs)
-  const recordedComputingDurationSec = serviceStatus.steps?.total_computing_duration_sec ?? 0
+  const recordedComputingDurationSec = serviceStatus?.steps?.total_computing_duration_sec ?? 0
 
   return Math.max(stepsComputingDurationSec, recordedComputingDurationSec)
 }
@@ -60,13 +60,13 @@ export function HeaderLogs({
   const isOngoing = match(serviceStatus?.status_details?.status)
     .with('ONGOING', 'CANCELING', () => true)
     .otherwise(() => false)
-  const hasLiveComputingDuration = hasLiveServiceStepComputingDuration(serviceStatus.steps?.details ?? [])
+  const hasLiveComputingDuration = hasLiveServiceStepComputingDuration(serviceStatus?.steps?.details ?? [])
 
   useIntervalTick(isOngoing && hasLiveComputingDuration)
 
   const computingDurationSec = isOngoing
     ? getOngoingDeploymentComputingDurationSec(serviceStatus, Date.now())
-    : serviceStatus.steps?.total_computing_duration_sec ?? 0
+    : serviceStatus?.steps?.total_computing_duration_sec ?? 0
 
   if (!service) return null
 
@@ -81,9 +81,9 @@ export function HeaderLogs({
         <div className="flex h-full items-center gap-3 py-2.5 pl-4 pr-0.5 text-sm font-medium text-neutral">
           {match(type)
             .with('DEPLOYMENT', () => {
-              const subAction = serviceStatus.status_details?.sub_action
-              const triggerAction = subAction !== 'NONE' ? subAction : serviceStatus.status_details?.action
-              const actionStatus = serviceStatus.status_details?.status
+              const subAction = serviceStatus?.status_details?.sub_action
+              const triggerAction = subAction !== 'NONE' ? subAction : serviceStatus?.status_details?.action
+              const actionStatus = serviceStatus?.status_details?.status
 
               return (
                 <div className="flex items-center gap-3">
@@ -126,7 +126,7 @@ export function HeaderLogs({
                   </svg>
                   <span
                     className="flex items-center gap-1.5 truncate font-normal"
-                    title={dateUTCString(serviceStatus.last_deployment_date ?? '')}
+                    title={dateUTCString(serviceStatus?.last_deployment_date ?? '')}
                   >
                     <Icon iconName="stopwatch" iconStyle="regular" className="text-base text-neutral-subtle" />
                     {Math.floor(computingDurationSec / 60)}m : {computingDurationSec % 60}s

--- a/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/header-logs/header-logs.tsx
@@ -14,6 +14,7 @@ import { dateUTCString } from '@qovery/shared/util-dates'
 import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { pluralize, trimId } from '@qovery/shared/util-js'
 import { PodHealthChips } from '../pod-health-chips/pod-health-chips'
+import { getServiceStepsComputingDurationSec, hasLiveServiceStepComputingDuration } from '../service-step-metrics'
 
 export interface HeaderLogsProps extends PropsWithChildren {
   type: 'DEPLOYMENT' | 'SERVICE'
@@ -21,6 +22,14 @@ export interface HeaderLogsProps extends PropsWithChildren {
   environment: Environment
   serviceStatus: Status
   environmentStatus?: EnvironmentStatus
+}
+
+function getOngoingDeploymentComputingDurationSec(serviceStatus: Status, nowMs: number) {
+  const steps = serviceStatus.steps?.details ?? []
+  const stepsComputingDurationSec = getServiceStepsComputingDurationSec(steps, nowMs)
+  const recordedComputingDurationSec = serviceStatus.steps?.total_computing_duration_sec ?? 0
+
+  return Math.max(stepsComputingDurationSec, recordedComputingDurationSec)
 }
 
 export function HeaderLogs({
@@ -51,13 +60,13 @@ export function HeaderLogs({
   const isOngoing = match(serviceStatus?.status_details?.status)
     .with('ONGOING', 'CANCELING', () => true)
     .otherwise(() => false)
+  const hasLiveComputingDuration = hasLiveServiceStepComputingDuration(serviceStatus.steps?.details ?? [])
 
-  useIntervalTick(isOngoing)
+  useIntervalTick(isOngoing && hasLiveComputingDuration)
 
-  const totalDurationSec =
-    isOngoing && serviceStatus?.last_deployment_date
-      ? Math.floor((Date.now() - new Date(serviceStatus.last_deployment_date).getTime()) / 1000)
-      : serviceStatus?.steps?.total_computing_duration_sec ?? 0
+  const computingDurationSec = isOngoing
+    ? getOngoingDeploymentComputingDurationSec(serviceStatus, Date.now())
+    : serviceStatus.steps?.total_computing_duration_sec ?? 0
 
   if (!service) return null
 
@@ -120,7 +129,7 @@ export function HeaderLogs({
                     title={dateUTCString(serviceStatus.last_deployment_date ?? '')}
                   >
                     <Icon iconName="stopwatch" iconStyle="regular" className="text-base text-neutral-subtle" />
-                    {Math.floor(totalDurationSec / 60)}m : {totalDurationSec % 60}s
+                    {Math.floor(computingDurationSec / 60)}m : {computingDurationSec % 60}s
                   </span>
                   <svg xmlns="http://www.w3.org/2000/svg" width="5" height="6" fill="none" viewBox="0 0 5 6">
                     <circle cx="2.5" cy="2.955" r="2.5" fill="var(--neutral-6)"></circle>

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.spec.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.spec.tsx
@@ -1,6 +1,6 @@
 import { StateEnum, type Status } from 'qovery-typescript-axios'
 import { type Terraform } from '@qovery/domains/services/data-access'
-import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { act, renderWithProviders, screen } from '@qovery/shared/util-tests'
 import { FiltersStageStep, type FiltersStageStepProps } from './filters-stage-step'
 
 const mockToggleColumnFilter = jest.fn()
@@ -27,6 +27,11 @@ jest.mock('@tanstack/react-router', () => ({
 describe('FiltersStageStep', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it('renders BUILD and DEPLOY buttons', () => {
@@ -64,5 +69,59 @@ describe('FiltersStageStep', () => {
     renderWithProviders(<FiltersStageStep {...defaultProps} />)
     expect(screen.getByText('1m : 0s')).toBeInTheDocument() // BUILD duration
     expect(screen.getByText('2m : 0s')).toBeInTheDocument() // DEPLOY duration
+  })
+
+  it('ticks the current step duration locally from its backend start time', () => {
+    jest.setSystemTime(new Date('2026-08-25T10:05:00Z'))
+    const props = {
+      ...defaultProps,
+      serviceStatus: {
+        ...defaultProps.serviceStatus,
+        steps: {
+          details: [
+            { step_name: 'GIT_CLONE', status: 'SUCCESS', duration_sec: 60 },
+            {
+              step_name: 'BUILD',
+              status: 'ONGOING',
+              duration_sec: 0,
+              started_at: '2026-08-25T10:00:00Z',
+            },
+            { step_name: 'DEPLOYMENT', status: 'SUCCESS', duration_sec: 120 },
+          ],
+        },
+      },
+    }
+
+    renderWithProviders(<FiltersStageStep {...props} />)
+
+    expect(screen.getByText('6m : 0s')).toBeInTheDocument()
+
+    act(() => jest.advanceTimersByTime(1_000))
+
+    expect(screen.getByText('6m : 1s')).toBeInTheDocument()
+  })
+
+  it('uses the recorded duration once a step is completed', () => {
+    jest.setSystemTime(new Date('2026-08-25T11:00:00Z'))
+    const props = {
+      ...defaultProps,
+      serviceStatus: {
+        ...defaultProps.serviceStatus,
+        steps: {
+          details: [
+            {
+              step_name: 'BUILD',
+              status: 'SUCCESS',
+              duration_sec: 300,
+              started_at: '2026-08-25T10:00:00Z',
+            },
+          ],
+        },
+      },
+    }
+
+    renderWithProviders(<FiltersStageStep {...props} />)
+
+    expect(screen.getByText('5m : 0s')).toBeInTheDocument()
   })
 })

--- a/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-deployment-logs/filters-stage-step/filters-stage-step.tsx
@@ -6,10 +6,20 @@ import { P, match } from 'ts-pattern'
 import { type AnyService } from '@qovery/domains/services/data-access'
 import { isHelmRepositorySource, isJobContainerSource } from '@qovery/shared/enums'
 import { Icon, StatusChip, Tooltip } from '@qovery/shared/ui'
+import { useIntervalTick } from '@qovery/shared/util-hooks'
 import { twMerge, upperCaseFirstLetter } from '@qovery/shared/util-js'
+import {
+  getServiceStepDurationSec,
+  getServiceStepsDurationSec,
+  isServiceStepDurationLive,
+} from '../../service-step-metrics'
 import { type FilterType } from '../list-deployment-logs'
 
-type StepMetricType = { build: ServiceStepMetric[]; deploy: ServiceStepMetric[]; executing: ServiceStepMetric[] }
+type StepMetricType = {
+  build: ServiceStepMetric[]
+  deploy: ServiceStepMetric[]
+  executing: ServiceStepMetric[]
+}
 
 interface StageStepProps {
   type: Extract<FilterType, 'BUILD' | 'DEPLOY' | 'EXECUTING'>
@@ -21,7 +31,9 @@ interface StageStepProps {
 
 function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: StageStepProps) {
   const { hash } = useLocation()
-  const totalDurationSec = steps.reduce((acc, step) => acc + (step.duration_sec || 0), 0)
+  const nowMs = Date.now()
+  const totalDurationSec = getServiceStepsDurationSec(steps, nowMs)
+  const hasLiveDuration = steps.some(isServiceStepDurationLive)
 
   const buildStep = steps.find((s) => s.step_name === 'BUILD')
   const deployStep = steps.find((s) => s.step_name === 'DEPLOYMENT')
@@ -29,16 +41,16 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
 
   const status = match({ type, state, buildStep, deployStep })
     .with({ type: 'BUILD' }, () => {
-      if (state === 'BUILDING') return 'BUILDING'
+      if (state === 'BUILDING' || hasLiveDuration) return 'BUILDING'
       return buildStep?.status
     })
     .with({ type: 'DEPLOY' }, () => {
       if (state === 'BUILDING') return 'READY'
-      if (state === 'DEPLOYING') return 'DEPLOYING'
+      if (state === 'DEPLOYING' || hasLiveDuration) return 'DEPLOYING'
       return deployStep?.status
     })
     .with({ type: 'EXECUTING' }, () => {
-      if (state === 'EXECUTING') return 'EXECUTING'
+      if (state === 'EXECUTING' || hasLiveDuration) return 'EXECUTING'
       return executingStep?.status
     })
     .exhaustive()
@@ -58,16 +70,21 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
     }
     // On the first load, if status is 'ERROR', the column filter is toggled
     // For all subsequent renders, the column filter is toggled only if the status is 'ERROR'
-  }, [status, toggleColumnFilter, isFirstLoad, hash])
+  }, [status, toggleColumnFilter, isFirstLoad, hash, type])
 
-  const isBuildingOrDeploying =
-    (type === 'BUILD' && status === 'BUILDING') || (type === 'DEPLOY' && status === 'DEPLOYING')
+  const isStepRunning =
+    (type === 'BUILD' && status === 'BUILDING') ||
+    (type === 'DEPLOY' && status === 'DEPLOYING') ||
+    (type === 'EXECUTING' && status === 'EXECUTING')
+  useIntervalTick(hasLiveDuration)
+
+  const shouldDisplayDuration = hasLiveDuration || totalDurationSec > 0
 
   const buttonClasses = clsx(
     'flex h-8 items-center gap-1.5 rounded-lg border border-neutral bg-surface-neutral px-2.5 text-sm font-medium text-neutral-subtle transition hover:border-neutral-subtle hover:bg-surface-neutral-component',
     {
       'border-neutral-strong bg-surface-neutral-subtle text-neutral': isFilterActive(type),
-      'border-brand-component bg-surface-brand-subtle': isBuildingOrDeploying && isFilterActive(type),
+      'border-brand-component bg-surface-brand-subtle': isStepRunning && isFilterActive(type),
       'border-positive-strong bg-surface-positive-subtle': status === 'SUCCESS' && isFilterActive(type),
       'border-negative-strong bg-surface-negative-subtle': status === 'ERROR' && isFilterActive(type),
     }
@@ -77,7 +94,7 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
     <button className={twMerge(buttonClasses)} onClick={() => toggleColumnFilter(type)}>
       <StatusChip status={status} />
       {upperCaseFirstLetter(type.toLowerCase())}
-      {totalDurationSec > 0 ? (
+      {shouldDisplayDuration ? (
         <>
           <svg xmlns="http://www.w3.org/2000/svg" width="5" height="6" fill="none" viewBox="0 0 5 6">
             <circle cx="2.5" cy="3" r="2.5" fill="#383E50" />
@@ -91,18 +108,22 @@ function StageStep({ type, state, steps, toggleColumnFilter, isFilterActive }: S
         content={
           <span className="flex flex-col gap-0.5">
             {steps.length > 0 ? (
-              steps.map((step) => (
-                <span key={step.step_name} className="font-medium">
-                  {upperCaseFirstLetter(step.step_name)?.replace(/_/g, ' ')}:{' '}
-                  {step.duration_sec ? (
-                    <>
-                      {Math.floor(step.duration_sec / 60)}m {step.duration_sec % 60}s
-                    </>
-                  ) : (
-                    '0s'
-                  )}
-                </span>
-              ))
+              steps.map((step, index) => {
+                const durationSec = getServiceStepDurationSec(step, nowMs)
+
+                return (
+                  <span key={`${step.step_name}-${index}`} className="font-medium">
+                    {upperCaseFirstLetter(step.step_name)?.replace(/_/g, ' ')}:{' '}
+                    {durationSec ? (
+                      <>
+                        {Math.floor(durationSec / 60)}m {durationSec % 60}s
+                      </>
+                    ) : (
+                      '0s'
+                    )}
+                  </span>
+                )
+              })
             ) : (
               <span>No detail available</span>
             )}
@@ -133,7 +154,7 @@ export function FiltersStageStep({
 }: FiltersStageStepProps) {
   if (!steps?.details) return <div />
 
-  const categorizedSteps = steps.details.reduce(
+  const categorizedSteps = steps.details.reduce<StepMetricType>(
     (acc, step) => {
       if (!step.step_name) return acc
 
@@ -145,7 +166,7 @@ export function FiltersStageStep({
 
       return acc
     },
-    { build: [], deploy: [], executing: [] } as StepMetricType
+    { build: [], deploy: [], executing: [] }
   )
 
   return (

--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/list-service-logs.tsx
@@ -335,7 +335,7 @@ function ListServiceLogsContent({ cluster, environment }: { cluster: Cluster; en
 
 export interface ListServiceLogsProps {
   environment: Environment
-  serviceStatus: Status
+  serviceStatus: Status | null
   cluster: Cluster
   environmentStatus?: EnvironmentStatus
 }

--- a/libs/domains/service-logs/feature/src/lib/list-service-logs/service-logs-context/service-logs-context.tsx
+++ b/libs/domains/service-logs/feature/src/lib/list-service-logs/service-logs-context/service-logs-context.tsx
@@ -13,7 +13,7 @@ interface ServiceLogsContextType {
   // Service info
   environment: Environment
   serviceId: string
-  serviceStatus: Status
+  serviceStatus: Status | null
   environmentStatus?: EnvironmentStatus
 
   // Time format preferences
@@ -46,7 +46,7 @@ export const ServiceLogsContext = createContext<ServiceLogsContextType | undefin
 interface ServiceLogsProviderProps extends PropsWithChildren {
   environment: Environment
   serviceId: string
-  serviceStatus: Status
+  serviceStatus: Status | null
   environmentStatus?: EnvironmentStatus
 }
 

--- a/libs/domains/service-logs/feature/src/lib/pod-logs-feature/pod-logs-feature.tsx
+++ b/libs/domains/service-logs/feature/src/lib/pod-logs-feature/pod-logs-feature.tsx
@@ -3,7 +3,6 @@ import {
   type DeploymentStageWithServicesStatuses,
   type Environment,
   type EnvironmentStatus,
-  type Status,
 } from 'qovery-typescript-axios'
 import { memo } from 'react'
 import { useCluster } from '@qovery/domains/clusters/feature'
@@ -33,7 +32,8 @@ export function PodLogsFeature({ environment, deploymentStages, environmentStatu
 
   useDocumentTitle(`Service logs ${service ? `- ${service.name}` : '- Loading...'}`)
 
-  const serviceStatus = getServiceStatusesById(deploymentStages, serviceId) as Status
+  const serviceStatusResult = getServiceStatusesById(deploymentStages, serviceId)
+  const serviceStatus = serviceStatusResult && 'state' in serviceStatusResult ? serviceStatusResult : null
 
   if (!cluster) return null
 

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.spec.ts
@@ -1,0 +1,157 @@
+import {
+  getServiceStepDurationSec,
+  getServiceStepsComputingDurationSec,
+  getServiceStepsDurationSec,
+  hasLiveServiceStepComputingDuration,
+  isServiceStepDurationLive,
+  isServiceStepIncludedInComputingDuration,
+} from './service-step-metrics'
+
+const nowMs = Date.parse('2026-08-28T13:30:00Z')
+
+describe('isServiceStepDurationLive', () => {
+  it('returns true for an ongoing step with a valid start time', () => {
+    expect(isServiceStepDurationLive({ status: 'ONGOING', started_at: '2026-08-28T13:29:30Z' })).toBe(true)
+  })
+
+  it.each([
+    { status: 'ONGOING', started_at: 'invalid' },
+    { status: 'ONGOING' },
+    { status: 'SUCCESS', started_at: '2026-08-28T13:29:30Z' },
+  ])('returns false without both ongoing status and a valid start time', (step) => {
+    expect(isServiceStepDurationLive(step)).toBe(false)
+  })
+})
+
+describe('isServiceStepIncludedInComputingDuration', () => {
+  it.each(['BUILD_QUEUEING', 'DEPLOYMENT_QUEUEING'] as const)('excludes the %s step', (stepName) => {
+    expect(isServiceStepIncludedInComputingDuration({ step_name: stepName })).toBe(false)
+  })
+
+  it.each([
+    'REGISTRY_CREATE_REPOSITORY',
+    'GIT_CLONE',
+    'BUILD',
+    'MIRROR_IMAGE',
+    'DEPLOYMENT',
+    'ROUTER_DEPLOYMENT',
+    'EXECUTING',
+  ] as const)('includes the %s step', (stepName) => {
+    expect(isServiceStepIncludedInComputingDuration({ step_name: stepName })).toBe(true)
+  })
+
+  it('excludes a metric without a step name', () => {
+    expect(isServiceStepIncludedInComputingDuration({})).toBe(false)
+  })
+})
+
+describe('getServiceStepDurationSec', () => {
+  it('returns the recorded duration for a completed step', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'SUCCESS', duration_sec: 15 }, nowMs)
+
+    expect(durationSec).toBe(15)
+  })
+
+  it('returns the elapsed duration for an ongoing step', () => {
+    const durationSec = getServiceStepDurationSec(
+      {
+        status: 'ONGOING',
+        duration_sec: 0,
+        started_at: '2026-08-28T13:29:29.500Z',
+      },
+      nowMs
+    )
+
+    expect(durationSec).toBe(30)
+  })
+
+  it('returns the recorded duration when an ongoing step has no start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', duration_sec: 12 }, nowMs)
+
+    expect(durationSec).toBe(12)
+  })
+
+  it('returns zero for an invalid start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', started_at: 'invalid' }, nowMs)
+
+    expect(durationSec).toBe(0)
+  })
+
+  it('returns the recorded duration when the start time is invalid', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', duration_sec: 12, started_at: 'invalid' }, nowMs)
+
+    expect(durationSec).toBe(12)
+  })
+
+  it('does not return a negative duration for a future start time', () => {
+    const durationSec = getServiceStepDurationSec({ status: 'ONGOING', started_at: '2026-08-28T13:31:00Z' }, nowMs)
+
+    expect(durationSec).toBe(0)
+  })
+})
+
+describe('getServiceStepsDurationSec', () => {
+  it('adds completed step durations to the elapsed ongoing step duration', () => {
+    const durationSec = getServiceStepsDurationSec(
+      [
+        { status: 'SUCCESS', duration_sec: 2 },
+        { status: 'SUCCESS', duration_sec: 15 },
+        { status: 'ONGOING', duration_sec: 0, started_at: '2026-08-28T13:29:30Z' },
+      ],
+      nowMs
+    )
+
+    expect(durationSec).toBe(47)
+  })
+
+  it('returns zero for an empty step list', () => {
+    expect(getServiceStepsDurationSec([], nowMs)).toBe(0)
+  })
+})
+
+describe('getServiceStepsComputingDurationSec', () => {
+  it('excludes completed queueing steps from the live computing duration', () => {
+    const durationSec = getServiceStepsComputingDurationSec(
+      [
+        { step_name: 'BUILD_QUEUEING', status: 'SUCCESS', duration_sec: 12 },
+        { step_name: 'BUILD', status: 'SUCCESS', duration_sec: 4 },
+        { step_name: 'DEPLOYMENT_QUEUEING', status: 'SUCCESS', duration_sec: 8 },
+        {
+          step_name: 'DEPLOYMENT',
+          status: 'ONGOING',
+          duration_sec: 0,
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ],
+      nowMs
+    )
+
+    expect(durationSec).toBe(34)
+  })
+})
+
+describe('hasLiveServiceStepComputingDuration', () => {
+  it('returns false when only a queueing step is live', () => {
+    expect(
+      hasLiveServiceStepComputingDuration([
+        {
+          step_name: 'DEPLOYMENT_QUEUEING',
+          status: 'ONGOING',
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ])
+    ).toBe(false)
+  })
+
+  it('returns true when a computing step is live', () => {
+    expect(
+      hasLiveServiceStepComputingDuration([
+        {
+          step_name: 'DEPLOYMENT',
+          status: 'ONGOING',
+          started_at: '2026-08-28T13:29:30Z',
+        },
+      ])
+    ).toBe(true)
+  })
+})

--- a/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
+++ b/libs/domains/service-logs/feature/src/lib/service-step-metrics.ts
@@ -1,0 +1,62 @@
+import { type ServiceStepMetric } from 'qovery-typescript-axios'
+
+const NON_COMPUTING_STEP_NAMES = new Set<ServiceStepMetric['step_name']>(['BUILD_QUEUEING', 'DEPLOYMENT_QUEUEING'])
+
+/**
+ * Returns whether a step contributes to the header's computing timer and q-core's `total_computing_duration_sec`.
+ * Unlike stage and wall-clock durations, computing time excludes build and deployment queueing.
+ */
+export function isServiceStepIncludedInComputingDuration(step: ServiceStepMetric) {
+  return step.step_name !== undefined && !NON_COMPUTING_STEP_NAMES.has(step.step_name)
+}
+
+/**
+ * Returns whether an individual step should advance from its backend `started_at` timestamp.
+ * Completed steps may retain this timestamp, so the `ONGOING` status is essential to keep their final duration frozen.
+ */
+export function isServiceStepDurationLive(step: ServiceStepMetric) {
+  if (step.status !== 'ONGOING' || !step.started_at) return false
+
+  return Number.isFinite(Date.parse(step.started_at))
+}
+
+/**
+ * Returns an individual step's live elapsed time while ongoing, or its backend-recorded duration otherwise.
+ * This also provides a stable fallback when `started_at` is missing or malformed.
+ */
+export function getServiceStepDurationSec(step: ServiceStepMetric, nowMs: number) {
+  if (!isServiceStepDurationLive(step)) return step.duration_sec || 0
+
+  const startedAtMs = Date.parse(step.started_at ?? '')
+  return Math.max(0, Math.floor((nowMs - startedAtMs) / 1_000))
+}
+
+/**
+ * Calculates a Build, Deploy, or Executing stage timer by adding every step assigned to that stage.
+ * Queueing is intentionally included because these timers represent the complete elapsed time of each stage.
+ */
+export function getServiceStepsDurationSec(steps: ServiceStepMetric[], nowMs: number) {
+  return steps.reduce((totalDurationSec, step) => totalDurationSec + getServiceStepDurationSec(step, nowMs), 0)
+}
+
+/**
+ * Calculates the live header timer by adding completed and ongoing computing steps while excluding queueing.
+ * This keeps it comparable with q-core's completed computing total rather than the deployment history's wall-clock total.
+ */
+export function getServiceStepsComputingDurationSec(steps: ServiceStepMetric[], nowMs: number) {
+  return steps.reduce(
+    (totalDurationSec, step) =>
+      isServiceStepIncludedInComputingDuration(step)
+        ? totalDurationSec + getServiceStepDurationSec(step, nowMs)
+        : totalDurationSec,
+    0
+  )
+}
+
+/**
+ * Returns whether the header needs a one-second client-side update for an ongoing computing step.
+ * Queue-only and completed deployments remain stable because they do not change the displayed computing duration.
+ */
+export function hasLiveServiceStepComputingDuration(steps: ServiceStepMetric[]) {
+  return steps.some((step) => isServiceStepIncludedInComputingDuration(step) && isServiceStepDurationLive(step))
+}


### PR DESCRIPTION
## Summary

**Issue**: 
This PR brings back the timer-related changes introduced by [this PR](https://github.com/Qovery/console/pull/2903), and reverted by [this one](https://github.com/Qovery/console/pull/2926).

## Screenshots / Recordings

| Before | After |
|--------|--------|
| <img width="543" height="345" alt="SCR-20260902-osge" src="https://github.com/user-attachments/assets/192ce5e1-fc5b-45b8-a924-06bdad300c23" /> | <img width="1616" height="1774" alt="SCR-20260902-osop" src="https://github.com/user-attachments/assets/7abe102e-275b-4734-b767-fd00f9866e96" /> | 

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores accurate deployment timers in service logs by computing live duration from each step's backend start time instead of wall-clock time, and safely handles missing service status.

- Deployment header now uses computing duration, excluding build and deployment queueing, to match q-core's totals.
- Ongoing steps tick client-side from their `started_at` timestamp, falling back to recorded durations when timing data is missing.
- Service log pages no longer fail when service status is null.
- Adds shared `service-step-metrics` helpers with regression coverage for queueing, fallbacks, and timer updates.

<sup>Written for commit 8795d87e3eb6d8f353e4b76bed1b4ec5468bd333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

