### PR TITLE
fix(qov-2191): plan blueprint Terraform variable updates

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/variables/terraform.tsx
@@ -33,6 +33,7 @@ const TerraformVariablesForm = ({ service }: { service: Terraform }) => {
     organizationId,
     projectId,
     environmentId,
+    planTerraformChanges: Boolean(service.blueprint_id),
   })
   const onSubmit = handleSubmit(() => {
     const payload = buildEditServicePayload({

--- a/libs/domains/services/feature/src/lib/hooks/use-edit-service/use-edit-service.spec.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-edit-service/use-edit-service.spec.ts
@@ -1,0 +1,89 @@
+import { TerraformDeployRequestActionEnum } from 'qovery-typescript-axios'
+import { renderHook } from '@qovery/shared/util-tests'
+import { useEditService } from './use-edit-service'
+
+const mockDeployService = jest.fn()
+const mockInvalidateQueries = jest.fn()
+let mockMutationOptions: unknown
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: (_mutation: unknown, options: unknown) => {
+    mockMutationOptions = options
+    return {}
+  },
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}))
+
+jest.mock('../use-deploy-service/use-deploy-service', () => ({
+  useDeployService: () => ({ mutate: mockDeployService }),
+}))
+
+type SuccessNotification = {
+  callback: () => void
+  description: string
+  labelAction: string
+  title: string
+}
+
+type EditServiceMutationOptions = {
+  meta: {
+    notifyOnSuccess: (_data: unknown, variables: unknown) => SuccessNotification
+  }
+}
+
+function getSuccessNotification({ planTerraformChanges = false }: { planTerraformChanges?: boolean } = {}) {
+  renderHook(() =>
+    useEditService({
+      organizationId: 'organization-id',
+      projectId: 'project-id',
+      environmentId: 'environment-id',
+      planTerraformChanges,
+    })
+  )
+
+  const options = mockMutationOptions as EditServiceMutationOptions
+  return options.meta.notifyOnSuccess(undefined, {
+    serviceId: 'service-id',
+    payload: { serviceType: 'TERRAFORM' },
+  })
+}
+
+describe('useEditService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('offers a Terraform plan and starts only a plan when requested', () => {
+    const notification = getSuccessNotification({ planTerraformChanges: true })
+
+    expect(notification).toMatchObject({
+      title: 'Service updated',
+      description: 'Run a plan to preview these changes before applying them',
+      labelAction: 'Plan',
+    })
+
+    notification.callback()
+
+    expect(mockDeployService).toHaveBeenCalledWith({
+      serviceId: 'service-id',
+      serviceType: 'TERRAFORM',
+      request: { action: TerraformDeployRequestActionEnum.PLAN },
+    })
+  })
+
+  it('keeps the default deployment action for other Terraform updates', () => {
+    const notification = getSuccessNotification()
+
+    expect(notification).toMatchObject({
+      description: 'You must update to apply the settings',
+      labelAction: 'Update',
+    })
+
+    notification.callback()
+
+    expect(mockDeployService).toHaveBeenCalledWith({
+      serviceId: 'service-id',
+      serviceType: 'TERRAFORM',
+    })
+  })
+})

--- a/libs/domains/services/feature/src/lib/hooks/use-edit-service/use-edit-service.ts
+++ b/libs/domains/services/feature/src/lib/hooks/use-edit-service/use-edit-service.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { TerraformDeployRequestActionEnum } from 'qovery-typescript-axios'
 import { mutations } from '@qovery/domains/services/data-access'
 import { queries } from '@qovery/state/util-queries'
 import { useDeployService } from '../use-deploy-service/use-deploy-service'
@@ -7,11 +8,13 @@ export function useEditService({
   organizationId,
   projectId,
   environmentId,
+  planTerraformChanges = false,
   silently = false,
 }: {
   organizationId: string
   projectId: string
   environmentId: string
+  planTerraformChanges?: boolean
   silently?: boolean
 }) {
   const queryClient = useQueryClient()
@@ -38,13 +41,25 @@ export function useEditService({
                   description: 'Your agent task settings were saved',
                 }
               }
+              const shouldPlanTerraformChanges = planTerraformChanges && payload.serviceType === 'TERRAFORM'
+
               return {
                 title: 'Service updated',
-                description: 'You must update to apply the settings',
+                description: shouldPlanTerraformChanges
+                  ? 'Run a plan to preview these changes before applying them'
+                  : 'You must update to apply the settings',
                 callback() {
-                  deployService({ serviceId, serviceType: payload.serviceType })
+                  if (shouldPlanTerraformChanges) {
+                    deployService({
+                      serviceId,
+                      serviceType: payload.serviceType,
+                      request: { action: TerraformDeployRequestActionEnum.PLAN },
+                    })
+                  } else {
+                    deployService({ serviceId, serviceType: payload.serviceType })
+                  }
                 },
-                labelAction: 'Update',
+                labelAction: shouldPlanTerraformChanges ? 'Plan' : 'Update',
               }
             },
             notifyOnError: true,


### PR DESCRIPTION
## Summary

**Issue**: QOV-2191

- Make Terraform variable updates on blueprint-backed services generate a plan instead of applying immediately.
- Preserve the existing immediate-save behavior for non-blueprint Terraform services.
- Refactor blueprint service creation and agent task flows around the new summary step and creation mutation.
- Remove the agent task execution-mode setting and simplify related settings sections.
- Update websocket, service-edit, blueprint-flow, and agent task tests to cover the revised behavior.

## Screenshots / Recordings

Not applicable.

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [ ] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [ ] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terraform variable updates on blueprint-backed services now generate a plan instead of applying immediately. Non-blueprint Terraform services keep the immediate update behavior.

- `useEditService` accepts `planTerraformChanges`, which triggers a Terraform plan and updates the success notification copy.
- The Terraform variables form passes the flag when the service has a `blueprint_id`.
- Adds tests for both the planned and default deployment actions.

<sup>Written for commit 612f039e8d68de892abbf0dc737da0ebf183aff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

