### PR TITLE
feat(request-integration): let users request missing blueprints and secret manager integration

### DIFF
--- a/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/cluster/$clusterId/settings/addons.tsx
@@ -10,6 +10,7 @@ import {
   SecretManagerAssociatedExternalSecretsModal,
   SecretManagerIntegrationModal,
   SecretManagerList,
+  SecretManagerMissingModal,
   getSecretManagerOption,
   useCluster,
   useEditCluster,
@@ -112,6 +113,18 @@ function RouteComponent() {
     })
   }
 
+  const openSecretManagerMissingModal = () =>
+    openModal({
+      content: (
+        <SecretManagerMissingModal
+          organizationId={organizationId}
+          clusterId={clusterId}
+          source="settings"
+          onClose={closeModal}
+        />
+      ),
+    })
+
   const handleDeleteSecretManager = (integration: SecretManagerAccess) => {
     openModalConfirmation({
       title: 'Delete secret manager',
@@ -202,44 +215,56 @@ function RouteComponent() {
                     </p>
                   </div>
                   <div className="flex flex-col items-start gap-3">
-                    <DropdownMenu.Root
-                      onOpenChange={(open) => {
-                        if (open) {
-                          posthog.capture('cluster-secret-manager-add-clicked', {
-                            cluster_id: clusterId,
-                            organization_id: organizationId,
-                            source: 'settings',
-                          })
-                        }
-                      }}
-                    >
-                      <DropdownMenu.Trigger asChild>
-                        <Button color="neutral" variant="solid" size="md" className="gap-2" type="button">
-                          <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
-                          Add secret manager
-                          <Icon iconName="chevron-down" className="text-[10px]" />
-                        </Button>
-                      </DropdownMenu.Trigger>
-                      <DropdownMenu.Content align="start">
-                        {secretManagerDropdownOptions.map((option) => (
-                          <DropdownMenu.Item
-                            key={option.value}
-                            color="neutral"
-                            icon={<Icon name={option.icon} width={16} height={16} />}
-                            onSelect={() => {
-                              posthog.capture('cluster-secret-manager-type-selected', {
-                                cluster_id: clusterId,
-                                organization_id: organizationId,
-                                secret_manager_type: option.value,
-                              })
-                              openSecretManagerModal(option)
-                            }}
-                          >
-                            {option.label}
-                          </DropdownMenu.Item>
-                        ))}
-                      </DropdownMenu.Content>
-                    </DropdownMenu.Root>
+                    <div className="flex items-center gap-2">
+                      <DropdownMenu.Root
+                        onOpenChange={(open) => {
+                          if (open) {
+                            posthog.capture('cluster-secret-manager-add-clicked', {
+                              cluster_id: clusterId,
+                              organization_id: organizationId,
+                              source: 'settings',
+                            })
+                          }
+                        }}
+                      >
+                        <DropdownMenu.Trigger asChild>
+                          <Button color="neutral" variant="solid" size="md" className="gap-2" type="button">
+                            <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
+                            Add secret manager
+                            <Icon iconName="chevron-down" className="text-[10px]" />
+                          </Button>
+                        </DropdownMenu.Trigger>
+                        <DropdownMenu.Content align="start">
+                          {secretManagerDropdownOptions.map((option) => (
+                            <DropdownMenu.Item
+                              key={option.value}
+                              color="neutral"
+                              icon={<Icon name={option.icon} width={16} height={16} />}
+                              onSelect={() => {
+                                posthog.capture('cluster-secret-manager-type-selected', {
+                                  cluster_id: clusterId,
+                                  organization_id: organizationId,
+                                  secret_manager_type: option.value,
+                                })
+                                openSecretManagerModal(option)
+                              }}
+                            >
+                              {option.label}
+                            </DropdownMenu.Item>
+                          ))}
+                        </DropdownMenu.Content>
+                      </DropdownMenu.Root>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        color="neutral"
+                        size="md"
+                        className="h-8"
+                        onClick={openSecretManagerMissingModal}
+                      >
+                        Request integration
+                      </Button>
+                    </div>
                     <SecretManagerList
                       secretManagers={secretManagers}
                       onEdit={(manager) =>

--- a/libs/domains/clusters/feature/src/lib/cluster-addons/index.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-addons/index.ts
@@ -4,4 +4,6 @@ export {
   type SecretManagerListProps,
   SECRET_MANAGER_OPTIONS,
   getSecretManagerOption,
+  SecretManagerMissingModal,
+  type SecretManagerMissingModalProps,
 } from './secret-manager'

--- a/libs/domains/clusters/feature/src/lib/cluster-addons/secret-manager/index.ts
+++ b/libs/domains/clusters/feature/src/lib/cluster-addons/secret-manager/index.ts
@@ -1,2 +1,3 @@
 export { SecretManagerList, type SecretManagerListProps } from './secret-manager-list'
 export { SECRET_MANAGER_OPTIONS, getSecretManagerOption } from './secret-manager-options'
+export { SecretManagerMissingModal, type SecretManagerMissingModalProps } from './secret-manager-missing-modal'

--- a/libs/domains/clusters/feature/src/lib/cluster-addons/secret-manager/secret-manager-missing-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-addons/secret-manager/secret-manager-missing-modal.tsx
@@ -47,7 +47,7 @@ export function SecretManagerMissingModal({
         <Controller
           name="message"
           control={methods.control}
-          rules={{ required: 'Please describe the secret manager you need.' }}
+          rules={{ validate: (value) => Boolean(value.trim()) || 'Please describe the secret manager you need.' }}
           render={({ field, fieldState: { error } }) => (
             <InputTextArea
               className="w-full"

--- a/libs/domains/clusters/feature/src/lib/cluster-addons/secret-manager/secret-manager-missing-modal.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-addons/secret-manager/secret-manager-missing-modal.tsx
@@ -1,0 +1,68 @@
+import posthog from 'posthog-js'
+import { Controller, FormProvider, useForm } from 'react-hook-form'
+import { InputTextArea, ModalCrud, toast } from '@qovery/shared/ui'
+
+export interface SecretManagerMissingModalProps {
+  organizationId: string
+  clusterId?: string
+  source: 'creation-flow' | 'settings'
+  onClose: () => void
+}
+
+type SecretManagerMissingFormValues = {
+  message: string
+}
+
+export function SecretManagerMissingModal({
+  organizationId,
+  clusterId,
+  source,
+  onClose,
+}: SecretManagerMissingModalProps) {
+  const methods = useForm<SecretManagerMissingFormValues>({
+    defaultValues: { message: '' },
+    mode: 'onChange',
+  })
+
+  const handleSubmit = methods.handleSubmit((data) => {
+    posthog.capture('cluster-secret-manager-missing-feedback', {
+      message: data.message.trim(),
+      organization_id: organizationId,
+      cluster_id: clusterId,
+      source,
+    })
+    toast('success', 'Thanks for the feedback!', "We'll let you know when it's available.")
+    onClose()
+  })
+
+  return (
+    <FormProvider {...methods}>
+      <ModalCrud
+        title="Request a secret manager integration"
+        description="Tell us which secret manager you'd like Qovery to support next."
+        onSubmit={handleSubmit}
+        onClose={onClose}
+        submitLabel="Send request"
+      >
+        <Controller
+          name="message"
+          control={methods.control}
+          rules={{ required: 'Please describe the secret manager you need.' }}
+          render={({ field, fieldState: { error } }) => (
+            <InputTextArea
+              className="w-full"
+              label="Which secret manager is missing?"
+              name={field.name}
+              value={field.value}
+              onChange={field.onChange}
+              error={error?.message}
+              hint="e.g. HashiCorp Vault, Azure Key Vault, Doppler..."
+            />
+          )}
+        />
+      </ModalCrud>
+    </FormProvider>
+  )
+}
+
+export default SecretManagerMissingModal

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -19,6 +19,7 @@ import {
   AddonToggleCard,
   SECRET_MANAGER_OPTIONS,
   SecretManagerList,
+  SecretManagerMissingModal,
   getSecretManagerOption,
 } from '../../cluster-addons'
 import {
@@ -71,6 +72,13 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
       secretManagers,
     }))
   }
+
+  const openSecretManagerMissingModal = () =>
+    openModal({
+      content: (
+        <SecretManagerMissingModal organizationId={organizationId} source="creation-flow" onClose={closeModal} />
+      ),
+    })
 
   const openSecretManagerModal = (option: SecretManagerOption, integration?: SecretManagerAccess) => {
     openModal({
@@ -142,42 +150,54 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                 </p>
               </div>
               <div className="flex flex-col items-start gap-3">
-                <DropdownMenu.Root
-                  onOpenChange={(open) => {
-                    if (open) {
-                      posthog.capture('cluster-secret-manager-add-clicked', {
-                        organization_id: organizationId,
-                        source: 'creation-flow',
-                      })
-                    }
-                  }}
-                >
-                  <DropdownMenu.Trigger asChild>
-                    <Button color="neutral" variant="solid" size="md" className="gap-2" type="button">
-                      <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
-                      Add secret manager
-                      <Icon iconName="chevron-down" className="text-[10px]" />
-                    </Button>
-                  </DropdownMenu.Trigger>
-                  <DropdownMenu.Content align="start">
-                    {secretManagerDropdownOptions.map((option) => (
-                      <DropdownMenu.Item
-                        key={option.value}
-                        color="neutral"
-                        icon={<Icon name={option.icon} width={16} height={16} />}
-                        onSelect={() => {
-                          posthog.capture('cluster-secret-manager-type-selected', {
-                            organization_id: organizationId,
-                            secret_manager_type: option.value,
-                          })
-                          openSecretManagerModal(option)
-                        }}
-                      >
-                        {option.label}
-                      </DropdownMenu.Item>
-                    ))}
-                  </DropdownMenu.Content>
-                </DropdownMenu.Root>
+                <div className="flex items-center gap-2">
+                  <DropdownMenu.Root
+                    onOpenChange={(open) => {
+                      if (open) {
+                        posthog.capture('cluster-secret-manager-add-clicked', {
+                          organization_id: organizationId,
+                          source: 'creation-flow',
+                        })
+                      }
+                    }}
+                  >
+                    <DropdownMenu.Trigger asChild>
+                      <Button color="neutral" variant="solid" size="md" className="gap-2" type="button">
+                        <Icon iconName="circle-plus" iconStyle="regular" className="text-xs" />
+                        Add secret manager
+                        <Icon iconName="chevron-down" className="text-[10px]" />
+                      </Button>
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Content align="start">
+                      {secretManagerDropdownOptions.map((option) => (
+                        <DropdownMenu.Item
+                          key={option.value}
+                          color="neutral"
+                          icon={<Icon name={option.icon} width={16} height={16} />}
+                          onSelect={() => {
+                            posthog.capture('cluster-secret-manager-type-selected', {
+                              organization_id: organizationId,
+                              secret_manager_type: option.value,
+                            })
+                            openSecretManagerModal(option)
+                          }}
+                        >
+                          {option.label}
+                        </DropdownMenu.Item>
+                      ))}
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Root>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    color="neutral"
+                    size="md"
+                    className="h-8"
+                    onClick={openSecretManagerMissingModal}
+                  >
+                    Request integration
+                  </Button>
+                </div>
                 <SecretManagerList
                   secretManagers={addonsData.secretManagers}
                   onEdit={(manager) => openSecretManagerModal(getSecretManagerOption(manager.endpoint.mode), manager)}

--- a/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
+++ b/libs/domains/clusters/feature/src/lib/cluster-creation-flow/step-addons/step-addons.tsx
@@ -150,7 +150,7 @@ function StepAddonsForm({ onSubmit, organizationId, backTo }: StepAddonsFormProp
                 </p>
               </div>
               <div className="flex flex-col items-start gap-3">
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <DropdownMenu.Root
                     onOpenChange={(open) => {
                       if (open) {

--- a/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.spec.tsx
@@ -1,0 +1,49 @@
+import posthog from 'posthog-js'
+import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { BlueprintMissingModal } from './blueprint-missing-modal'
+
+jest.mock('posthog-js', () => ({
+  capture: jest.fn(),
+}))
+
+describe('BlueprintMissingModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should disable submit until a message is entered when opened empty', () => {
+    renderWithProviders(<BlueprintMissingModal organizationId="org-1" onClose={jest.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Send request' })).toBeDisabled()
+  })
+
+  it('should enable submit immediately when opened with a prefilled search input', async () => {
+    renderWithProviders(<BlueprintMissingModal organizationId="org-1" searchInput="redis" onClose={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Send request' })).toBeEnabled()
+    })
+  })
+
+  it('should submit feedback with the trimmed message, organization and cloud provider', async () => {
+    const onClose = jest.fn()
+    const { userEvent } = renderWithProviders(
+      <BlueprintMissingModal organizationId="org-1" cloudProvider="AWS" searchInput="  redis  " onClose={onClose} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Send request' })).toBeEnabled()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Send request' }))
+
+    await waitFor(() => {
+      expect(posthog.capture).toHaveBeenCalledWith('blueprint-missing-feedback', {
+        message: 'redis',
+        organization_id: 'org-1',
+        cloud_provider: 'AWS',
+      })
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.tsx
@@ -46,7 +46,7 @@ export function BlueprintMissingModal({
         <Controller
           name="message"
           control={methods.control}
-          rules={{ required: 'Please describe the blueprint you need.' }}
+          rules={{ validate: (v: string) => v.trim().length > 0 || 'Please describe the blueprint you need.' }}
           render={({ field, fieldState: { error } }) => (
             <InputTextArea
               className="w-full"

--- a/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.tsx
@@ -1,4 +1,5 @@
 import posthog from 'posthog-js'
+import { useEffect } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { InputTextArea, ModalCrud, toast } from '@qovery/shared/ui'
 
@@ -23,6 +24,11 @@ export function BlueprintMissingModal({
     defaultValues: { message: searchInput ?? '' },
     mode: 'onChange',
   })
+
+  useEffect(() => {
+    methods.trigger()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleSubmit = methods.handleSubmit((data) => {
     posthog.capture('blueprint-missing-feedback', {

--- a/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.tsx
@@ -26,9 +26,11 @@ export function BlueprintMissingModal({
   })
 
   useEffect(() => {
-    methods.trigger()
+    if (searchInput) {
+      methods.trigger()
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [searchInput])
 
   const handleSubmit = methods.handleSubmit((data) => {
     posthog.capture('blueprint-missing-feedback', {

--- a/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/blueprint-missing-modal/blueprint-missing-modal.tsx
@@ -1,0 +1,67 @@
+import posthog from 'posthog-js'
+import { Controller, FormProvider, useForm } from 'react-hook-form'
+import { InputTextArea, ModalCrud, toast } from '@qovery/shared/ui'
+
+export interface BlueprintMissingModalProps {
+  organizationId: string
+  cloudProvider?: string
+  searchInput?: string
+  onClose: () => void
+}
+
+type BlueprintMissingFormValues = {
+  message: string
+}
+
+export function BlueprintMissingModal({
+  organizationId,
+  cloudProvider,
+  searchInput,
+  onClose,
+}: BlueprintMissingModalProps) {
+  const methods = useForm<BlueprintMissingFormValues>({
+    defaultValues: { message: searchInput ?? '' },
+    mode: 'onChange',
+  })
+
+  const handleSubmit = methods.handleSubmit((data) => {
+    posthog.capture('blueprint-missing-feedback', {
+      message: data.message.trim(),
+      organization_id: organizationId,
+      cloud_provider: cloudProvider,
+    })
+    toast('success', 'Thanks for the feedback!', "We'll let you know when it's available.")
+    onClose()
+  })
+
+  return (
+    <FormProvider {...methods}>
+      <ModalCrud
+        title="Request a blueprint"
+        description="Tell us which service, database, or infrastructure blueprint you'd like Qovery to add next."
+        onSubmit={handleSubmit}
+        onClose={onClose}
+        submitLabel="Send request"
+      >
+        <Controller
+          name="message"
+          control={methods.control}
+          rules={{ required: 'Please describe the blueprint you need.' }}
+          render={({ field, fieldState: { error } }) => (
+            <InputTextArea
+              className="w-full"
+              label="Which blueprint is missing?"
+              name={field.name}
+              value={field.value}
+              onChange={field.onChange}
+              error={error?.message}
+              hint="e.g. MongoDB Atlas, Kafka, Elasticsearch..."
+            />
+          )}
+        />
+      </ModalCrud>
+    </FormProvider>
+  )
+}
+
+export default BlueprintMissingModal

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -6,13 +6,14 @@ import {
   type LifecycleTemplateListResponseResultsInner,
 } from 'qovery-typescript-axios'
 import { type ReactNode, useMemo, useState } from 'react'
-import { Button, Heading, Icon, InputSearch, Section, Skeleton } from '@qovery/shared/ui'
+import { Button, Heading, Icon, InputSearch, Section, Skeleton, useModal } from '@qovery/shared/ui'
 import { useSupportChat } from '@qovery/shared/util-hooks'
 import { BlueprintDetailsPanel } from '../blueprint-details-panel/blueprint-details-panel'
 import { BlueprintQueryBoundary } from '../blueprint-query-boundary/blueprint-query-boundary'
 import { isBlueprintCompatibleWithCluster } from '../blueprint-utils/blueprint-utils'
 import { useBlueprintCatalog } from '../hooks/use-blueprint-catalog/use-blueprint-catalog'
 import { BlueprintCard } from './blueprint-card/blueprint-card'
+import { BlueprintMissingModal } from './blueprint-missing-modal/blueprint-missing-modal'
 import { BaseServiceCard, Card, CardService, SectionByTag, type ServiceBlock } from './service-card/service-card'
 import { buildCreateFlowPathForType, getCreateFlowPath, getServicesPath } from './service-new-utils/service-new-utils'
 import { serviceTemplates } from './service-templates'
@@ -106,6 +107,7 @@ function BlueprintSection({
     organizationId,
     suspense: true,
   })
+  const { openModal, closeModal } = useModal()
   const blueprints = blueprintCatalog?.blueprints ?? []
   const filterBlueprint = ({ name, description, categories }: BlueprintItem) =>
     `${name} ${description} ${categories?.join(' ')}`.toLowerCase().includes(blueprintSearchInput.toLowerCase())
@@ -114,18 +116,42 @@ function BlueprintSection({
   )
   const filteredBlueprints = compatibleBlueprints.filter(filterBlueprint)
 
+  const openBlueprintMissingModal = () =>
+    openModal({
+      content: (
+        <BlueprintMissingModal
+          organizationId={organizationId}
+          cloudProvider={cloudProvider}
+          searchInput={blueprintSearchInput}
+          onClose={closeModal}
+        />
+      ),
+    })
+
   if (compatibleBlueprints.length === 0) return null
 
   return (
     <Section className="gap-4">
       <BlueprintSectionHeader
         action={
-          <InputSearch
-            placeholder="Search blueprints..."
-            className="w-60"
-            customSize="h-9 text-sm"
-            onChange={onBlueprintSearchInputChange}
-          />
+          <div className="flex items-center gap-2">
+            <InputSearch
+              placeholder="Search blueprints..."
+              className="w-60"
+              customSize="h-9 text-sm"
+              onChange={onBlueprintSearchInputChange}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              color="neutral"
+              size="md"
+              className="h-9"
+              onClick={openBlueprintMissingModal}
+            >
+              Request blueprint
+            </Button>
+          </div>
         }
       />
       {filteredBlueprints.length > 0 ? (
@@ -139,9 +165,14 @@ function BlueprintSection({
           ))}
         </div>
       ) : (
-        <div className="flex min-h-[186px] flex-col items-center justify-center rounded border border-neutral bg-surface-neutral px-3 py-6 text-center">
-          <Icon iconName="wave-pulse" className="text-neutral-subtle" />
-          <p className="mt-1 text-xs font-medium text-neutral-subtle">No blueprints found</p>
+        <div className="flex min-h-[186px] flex-col items-center justify-center gap-3 rounded border border-neutral bg-surface-neutral px-3 py-6 text-center">
+          <div className="flex flex-col items-center gap-1">
+            <Icon iconName="wave-pulse" className="text-neutral-subtle" />
+            <p className="mt-1 text-xs font-medium text-neutral-subtle">No blueprints found</p>
+          </div>
+          <Button type="button" variant="outline" color="neutral" size="sm" onClick={openBlueprintMissingModal}>
+            Request blueprint
+          </Button>
         </div>
       )}
     </Section>

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -128,8 +128,6 @@ function BlueprintSection({
       ),
     })
 
-  if (compatibleBlueprints.length === 0) return null
-
   return (
     <Section className="gap-4">
       <BlueprintSectionHeader


### PR DESCRIPTION
## Summary

**Issue**: [QOV-2230](https://qovery.atlassian.net/browse/QOV-2230)

Frontend
- "New service" page (service-new.tsx):
  - "Request blueprint" button in the Blueprints section header (next to the search input).
  - Additional "Request blueprint" button in the empty state ("No blueprints found").
  - New BlueprintMissingModal component (textarea: "Which blueprint is missing?").
- Cluster creation flow, Add-ons step (step-addons.tsx) and Cluster Settings > Add-ons (addons.tsx):
  - "Request integration" button next to "Add secret manager".
  - New shared SecretManagerMissingModal component.
- UI fix: button height aligned with neighboring elements (search input / dropdown trigger).

Tracking (PostHog)
- Event blueprint-missing-feedback — payload: message, organization_id, cloud_provider.
- Event cluster-secret-manager-missing-feedback — payload: message, organization_id, cluster_id, source (creation-flow | settings).
- Standard insights created (Trends, breakdown by message, internal accounts filtered out):
  - Blueprint requests
  - Secret manager integration requests

## Screenshots / Recordings

<img width="724" height="649" alt="image" src="https://github.com/user-attachments/assets/4292650c-c0bb-4c44-a03b-2c109c4fc4af" />
<img width="1429" height="799" alt="image" src="https://github.com/user-attachments/assets/5d1e8f0b-f486-407c-8af2-0b0796d3dd8d" />
<img width="1280" height="776" alt="image" src="https://github.com/user-attachments/assets/7017a6e8-9485-4821-a1e9-672905b9f399" />
<img width="1320" height="306" alt="image" src="https://github.com/user-attachments/assets/4ef131a3-3672-4b69-a3cd-7bef69876c81" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code


[QOV-2230]: https://qovery.atlassian.net/browse/QOV-2230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets users request missing blueprints and secret manager integrations (QOV-2230) instead of leaving them stuck when what they need isn't listed. Adds "Request blueprint" buttons on the New Service page and "Request integration" buttons on the cluster creation Add-ons step and Cluster Settings > Add-ons, each opening a feedback modal. Also aligns button heights with the surrounding search inputs and dropdown triggers.

The blueprint modal pre-fills the message with the current search term and enables Send request right away when that term is already filled; the "No blueprints found" empty state shows a request button even when no blueprints are compatible with the cluster.

**Tracking**
- Records `blueprint-missing-feedback` with message, organization_id, and cloud_provider.
- Records `cluster-secret-manager-missing-feedback` with message, organization_id, cluster_id, and source (`creation-flow` or `settings`).

<sup>Written for commit 89f91317b76cf94c0c167b6e10d3727128da2fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

