### PR TITLE
feat: display blueprint names and group blueprints by catalog category

### DIFF
--- a/libs/domains/services/feature/src/lib/blueprint-details-panel/blueprint-details-panel.spec.tsx
+++ b/libs/domains/services/feature/src/lib/blueprint-details-panel/blueprint-details-panel.spec.tsx
@@ -45,10 +45,12 @@ jest.mock('../hooks/use-blueprint-catalog-service-readme/use-blueprint-catalog-s
 
 const blueprint: BlueprintItem = {
   name: 'AWS S3 Bucket',
+  displayName: 'AWS S3 Bucket',
   kind: 'ServiceBlueprint',
   description: 'Object storage with server-side encryption.',
   icon: 'app://qovery-console/s3',
   categories: ['storage'],
+  primaryCategory: 'Storage',
   provider: 'aws',
   serviceFamily: 's3',
   majorVersions: [{ serviceVersion: '1', latestTag: 'aws/s3/1/1.0.0' }],

--- a/libs/domains/services/feature/src/lib/blueprint-details-panel/blueprint-details-panel.tsx
+++ b/libs/domains/services/feature/src/lib/blueprint-details-panel/blueprint-details-panel.tsx
@@ -7,7 +7,7 @@ import { formatCloudProvider } from '@qovery/domains/clusters/data-access'
 import { Badge, Button, ExternalLink, Heading, Icon, Link, Sheet } from '@qovery/shared/ui'
 import { twMerge } from '@qovery/shared/util-js'
 import { BlueprintQueryBoundary } from '../blueprint-query-boundary/blueprint-query-boundary'
-import { formatBlueprintName } from '../blueprint-utils/blueprint-utils'
+import { getBlueprintDisplayName } from '../blueprint-utils/blueprint-utils'
 import { useBlueprintCatalogServiceReadme } from '../hooks/use-blueprint-catalog-service-readme/use-blueprint-catalog-service-readme'
 import { ServiceAvatar } from '../service-avatar/service-avatar'
 
@@ -161,7 +161,7 @@ function BlueprintDetailsPanelContent({
   const canDeploy = footerMode === 'deploy' && Boolean(blueprint.serviceFamily)
 
   const provider = formatCloudProvider(blueprint.provider)
-  const blueprintName = formatBlueprintName(blueprint.name)
+  const blueprintName = getBlueprintDisplayName(blueprint)
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
@@ -1,5 +1,10 @@
 import type { BlueprintItem } from 'qovery-typescript-axios'
-import { formatBlueprintName, getBlueprintDisplayName, isBlueprintCompatibleWithCluster } from './blueprint-utils'
+import {
+  formatBlueprintName,
+  getBlueprintDisplayName,
+  getBlueprintPrimaryCategory,
+  isBlueprintCompatibleWithCluster,
+} from './blueprint-utils'
 
 describe('formatBlueprintName', () => {
   it.each([
@@ -24,6 +29,20 @@ describe('getBlueprintDisplayName', () => {
 
   it('formats the catalog name when the display name is missing', () => {
     expect(getBlueprintDisplayName(blueprint)).toBe('AWS RDS MySQL')
+  })
+})
+
+describe('getBlueprintPrimaryCategory', () => {
+  const blueprint = {
+    name: 'aws-s3',
+  } as BlueprintItem
+
+  it('returns the catalog category', () => {
+    expect(getBlueprintPrimaryCategory({ ...blueprint, primaryCategory: 'Storage' } as BlueprintItem)).toBe('Storage')
+  })
+
+  it('falls back for catalog entries without a category', () => {
+    expect(getBlueprintPrimaryCategory(blueprint)).toBe('Other')
   })
 })
 

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
@@ -1,4 +1,5 @@
-import { formatBlueprintName, isBlueprintCompatibleWithCluster } from './blueprint-utils'
+import type { BlueprintItem } from 'qovery-typescript-axios'
+import { formatBlueprintName, getBlueprintDisplayName, isBlueprintCompatibleWithCluster } from './blueprint-utils'
 
 describe('formatBlueprintName', () => {
   it.each([
@@ -7,6 +8,22 @@ describe('formatBlueprintName', () => {
     ['AWS S3 Bucket', 'AWS S3 Bucket'],
   ])('formats %s as %s', (name, expectedName) => {
     expect(formatBlueprintName(name)).toBe(expectedName)
+  })
+})
+
+describe('getBlueprintDisplayName', () => {
+  const blueprint = {
+    name: 'aws-rds-mysql',
+  } as BlueprintItem
+
+  it('prefers the catalog display name', () => {
+    expect(getBlueprintDisplayName({ ...blueprint, displayName: 'Amazon RDS for MySQL' } as BlueprintItem)).toBe(
+      'Amazon RDS for MySQL'
+    )
+  })
+
+  it('formats the catalog name when the display name is missing', () => {
+    expect(getBlueprintDisplayName(blueprint)).toBe('AWS RDS MySQL')
   })
 })
 

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.spec.ts
@@ -1,5 +1,6 @@
 import type { BlueprintItem } from 'qovery-typescript-axios'
 import {
+  OTHER_BLUEPRINT_CATEGORY,
   formatBlueprintName,
   getBlueprintDisplayName,
   getBlueprintPrimaryCategory,
@@ -42,7 +43,7 @@ describe('getBlueprintPrimaryCategory', () => {
   })
 
   it('falls back for catalog entries without a category', () => {
-    expect(getBlueprintPrimaryCategory(blueprint)).toBe('Other')
+    expect(getBlueprintPrimaryCategory(blueprint)).toBe(OTHER_BLUEPRINT_CATEGORY)
   })
 })
 

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
@@ -34,6 +34,12 @@ export function getBlueprintDisplayName(blueprint: BlueprintItem): string {
   return displayName || formatBlueprintName(blueprint.name)
 }
 
+export function getBlueprintPrimaryCategory(blueprint: BlueprintItem): string {
+  const { primaryCategory } = blueprint as BlueprintItem & { primaryCategory?: string }
+
+  return primaryCategory || 'Other'
+}
+
 export function isBlueprintCompatibleWithCluster(blueprintProvider: string, clusterCloudProvider?: string): boolean {
   if (!clusterCloudProvider) return true
 

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
@@ -1,3 +1,5 @@
+import { type BlueprintItem } from 'qovery-typescript-axios'
+
 const BLUEPRINT_NAME_PARTS: Record<string, string> = {
   aws: 'AWS',
   gcp: 'GCP',
@@ -20,6 +22,16 @@ export function formatBlueprintName(name: string): string {
       return BLUEPRINT_NAME_PARTS[normalizedPart] ?? `${part.charAt(0).toUpperCase()}${part.slice(1)}`
     })
     .join(' ')
+}
+
+/**
+ * The catalog's stable name is an identifier. Prefer its optional display name
+ * when available, while preserving the label generated for older catalog entries.
+ */
+export function getBlueprintDisplayName(blueprint: BlueprintItem): string {
+  const { displayName } = blueprint as BlueprintItem & { displayName?: string }
+
+  return displayName || formatBlueprintName(blueprint.name)
 }
 
 export function isBlueprintCompatibleWithCluster(blueprintProvider: string, clusterCloudProvider?: string): boolean {

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
@@ -12,6 +12,8 @@ const BLUEPRINT_NAME_PARTS: Record<string, string> = {
 
 const CLUSTER_AGNOSTIC_BLUEPRINT_PROVIDERS = new Set(['EXTERNAL', 'HELM'])
 
+export const OTHER_BLUEPRINT_CATEGORY = 'Other'
+
 export function formatBlueprintName(name: string): string {
   return name
     .split(/[-_]/)
@@ -33,7 +35,7 @@ export function getBlueprintDisplayName(blueprint: BlueprintItem): string {
 }
 
 export function getBlueprintPrimaryCategory(blueprint: BlueprintItem): string {
-  return blueprint.primaryCategory || 'Other'
+  return blueprint.primaryCategory || OTHER_BLUEPRINT_CATEGORY
 }
 
 export function isBlueprintCompatibleWithCluster(blueprintProvider: string, clusterCloudProvider?: string): boolean {

--- a/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
+++ b/libs/domains/services/feature/src/lib/blueprint-utils/blueprint-utils.ts
@@ -25,19 +25,15 @@ export function formatBlueprintName(name: string): string {
 }
 
 /**
- * The catalog's stable name is an identifier. Prefer its optional display name
- * when available, while preserving the label generated for older catalog entries.
+ * The catalog's stable name is an identifier. Prefer its customer-facing display name,
+ * while preserving the label generated for stale cached catalog entries.
  */
 export function getBlueprintDisplayName(blueprint: BlueprintItem): string {
-  const { displayName } = blueprint as BlueprintItem & { displayName?: string }
-
-  return displayName || formatBlueprintName(blueprint.name)
+  return blueprint.displayName || formatBlueprintName(blueprint.name)
 }
 
 export function getBlueprintPrimaryCategory(blueprint: BlueprintItem): string {
-  const { primaryCategory } = blueprint as BlueprintItem & { primaryCategory?: string }
-
-  return primaryCategory || 'Other'
+  return blueprint.primaryCategory || 'Other'
 }
 
 export function isBlueprintCompatibleWithCluster(blueprintProvider: string, clusterCloudProvider?: string): boolean {

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-configuration-view/blueprint-configuration-view.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-configuration-view/blueprint-configuration-view.tsx
@@ -11,7 +11,7 @@ import {
   isFieldValid,
 } from '../../../blueprint-field-utils/blueprint-field-utils'
 import { BlueprintManifestVariableInput } from '../../../blueprint-manifest-variable-input/blueprint-manifest-variable-input'
-import { formatBlueprintName } from '../../../blueprint-utils/blueprint-utils'
+import { getBlueprintDisplayName } from '../../../blueprint-utils/blueprint-utils'
 import { usePrefetchBlueprintCatalogServiceManifest } from '../../../hooks/use-blueprint-catalog-service-manifest/use-blueprint-catalog-service-manifest'
 import { useBlueprintCreateContext } from '../blueprint-create-context/blueprint-create-context'
 import { sortBlueprintMajorVersions } from '../blueprint-creation-utils/blueprint-creation-utils'
@@ -53,12 +53,12 @@ export function BlueprintConfigurationView({ currentSection }: BlueprintConfigur
     <FunnelFlowBody customContentWidth="max-w-[684px]">
       <header className="mb-5">
         <h1 className="text-2xl font-medium leading-8 text-neutral">
-          {formatBlueprintName(blueprint.name)} configuration
+          {getBlueprintDisplayName(blueprint)} configuration
         </h1>
         <p className="mt-2 text-sm leading-5 text-neutral-subtle">
           Provisioned from{' '}
           <button type="button" className="font-normal underline hover:text-neutral" onClick={onViewDetails}>
-            {formatBlueprintName(blueprint.name)}
+            {getBlueprintDisplayName(blueprint)}
           </button>{' '}
           blueprint
         </p>

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.spec.tsx
@@ -84,10 +84,12 @@ jest.mock('posthog-js', () => ({
 
 const blueprint: BlueprintItem = {
   name: 'AWS RDS PostgreSQL',
+  displayName: 'AWS RDS PostgreSQL',
   kind: 'ServiceBlueprint',
   description: 'Managed PostgreSQL database.',
   icon: 'https://cdn.qovery.com/icons/postgresql.svg',
   categories: ['database'],
+  primaryCategory: 'Databases & Caches',
   provider: 'AWS',
   serviceFamily: 'postgres',
   majorVersions: [{ serviceVersion: '17', latestTag: 'aws/postgres/17/1.0.0' }],

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-creation-flow.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { FunnelFlow } from '@qovery/shared/ui'
 import { BlueprintDetailsPanel } from '../../blueprint-details-panel/blueprint-details-panel'
-import { formatBlueprintName } from '../../blueprint-utils/blueprint-utils'
+import { getBlueprintDisplayName } from '../../blueprint-utils/blueprint-utils'
 import {
   BlueprintCreateContext,
   type BlueprintCreateFormData,
@@ -43,7 +43,7 @@ export function BlueprintCreationFlow({ blueprint, children, onExit }: Blueprint
   const defaultVersionTag = defaultBlueprintVersion?.latestTag ?? ''
   const form = useForm<BlueprintCreateFormData>({
     defaultValues: {
-      serviceName: formatBlueprintName(blueprint.name),
+      serviceName: getBlueprintDisplayName(blueprint),
       versionTag: defaultVersionTag,
       fields: {},
     },

--- a/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/blueprint/blueprint-step-summary/blueprint-step-summary.tsx
@@ -10,7 +10,7 @@ import {
   getSummaryFieldValue,
   isFieldValid,
 } from '../../../blueprint-field-utils/blueprint-field-utils'
-import { formatBlueprintName } from '../../../blueprint-utils/blueprint-utils'
+import { getBlueprintDisplayName } from '../../../blueprint-utils/blueprint-utils'
 import { useBlueprintCreationLogs } from '../../../hooks/use-blueprint-creation-logs/use-blueprint-creation-logs'
 import { useBlueprintServiceCreatedSocket } from '../../../hooks/use-blueprint-service-created-socket/use-blueprint-service-created-socket'
 import { useBlueprint } from '../../../hooks/use-blueprint/use-blueprint'
@@ -372,7 +372,7 @@ export function BlueprintStepSummary() {
               </div>
               <ul className="list-none space-y-2 text-sm text-neutral-subtle">
                 <SummaryValue label="Name" value={serviceName} />
-                <SummaryValue label="Blueprint" value={formatBlueprintName(blueprint.name)} />
+                <SummaryValue label="Blueprint" value={getBlueprintDisplayName(blueprint)} />
                 <SummaryValue label="Version" value={serviceVersion} />
               </ul>
             </Section>

--- a/libs/domains/services/feature/src/lib/service-new/blueprint-card/blueprint-card.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/blueprint-card/blueprint-card.tsx
@@ -1,7 +1,7 @@
 import { useParams } from '@tanstack/react-router'
 import { type BlueprintItem } from 'qovery-typescript-axios'
 import { Button, Heading, Link } from '@qovery/shared/ui'
-import { formatBlueprintName } from '../../blueprint-utils/blueprint-utils'
+import { getBlueprintDisplayName } from '../../blueprint-utils/blueprint-utils'
 import { ServiceAvatar } from '../../service-avatar/service-avatar'
 
 export function BlueprintCard({
@@ -24,7 +24,7 @@ export function BlueprintCard({
           size="custom"
         />
         <div className="flex flex-col gap-1">
-          <Heading level={3}>{formatBlueprintName(blueprint.name)}</Heading>
+          <Heading level={3}>{getBlueprintDisplayName(blueprint)}</Heading>
           <p className="text-sm leading-5 text-neutral-subtle">{blueprint.description}</p>
         </div>
       </div>

--- a/libs/domains/services/feature/src/lib/service-new/blueprint-card/blueprint-card.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/blueprint-card/blueprint-card.tsx
@@ -24,8 +24,10 @@ export function BlueprintCard({
           size="custom"
         />
         <div className="flex flex-col gap-1">
-          <Heading level={3}>{getBlueprintDisplayName(blueprint)}</Heading>
-          <p className="text-sm leading-5 text-neutral-subtle">{blueprint.description}</p>
+          <Heading level={4} className="text-sm">
+            {getBlueprintDisplayName(blueprint)}
+          </Heading>
+          <p className="text-xs leading-5 text-neutral-subtle">{blueprint.description}</p>
         </div>
       </div>
       <div className="mt-auto flex items-center gap-1">

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -272,6 +272,26 @@ describe('ServiceNew', () => {
     expect(blueprintsSectionScreen.getByText('Redis')).toBeInTheDocument()
   })
 
+  it('should group blueprint cards by the primary categories returned by the catalog', () => {
+    mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'service-catalog')
+    mockUseBlueprintCatalog.mockReturnValue({
+      data: {
+        blueprints: [
+          { ...blueprints[0], primaryCategory: 'Storage' },
+          { ...blueprints[1], primaryCategory: 'Custom Platform' },
+        ],
+      },
+    })
+
+    renderWithProviders(
+      <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Custom Platform' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Storage' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Other' })).not.toBeInTheDocument()
+  })
+
   it('should show an empty state when the blueprint search has no results', async () => {
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'service-catalog')
     mockUseBlueprintCatalog.mockReturnValue({ data: { blueprints } })

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -303,6 +303,20 @@ describe('ServiceNew', () => {
     expect(screen.getByText('AWS RDS MySQL')).toBeInTheDocument()
   })
 
+  it('should prefer a blueprint display name from the catalog', () => {
+    mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'service-catalog')
+    mockUseBlueprintCatalog.mockReturnValue({
+      data: { blueprints: [{ ...blueprints[0], name: 'aws-rds-mysql', displayName: 'Amazon RDS for MySQL' }] },
+    })
+
+    renderWithProviders(
+      <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
+    )
+
+    expect(screen.getByText('Amazon RDS for MySQL')).toBeInTheDocument()
+    expect(screen.queryByText('AWS RDS MySQL')).not.toBeInTheDocument()
+  })
+
   it('should only display blueprints compatible with the environment cluster', () => {
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'service-catalog')
     mockUseBlueprintCatalog.mockReturnValue({

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -287,8 +287,8 @@ describe('ServiceNew', () => {
       <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
     )
 
-    expect(screen.getByRole('heading', { name: 'Custom Platform' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Storage' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Custom Platform', level: 3 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Storage', level: 3 })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Other' })).not.toBeInTheDocument()
   })
 

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -281,7 +281,7 @@ describe('ServiceNew', () => {
     mockUseBlueprintCatalog.mockReturnValue({
       data: {
         blueprints: [
-          { ...blueprints[0], primaryCategory: 'Storage' },
+          { ...blueprints[0], primaryCategory: '' },
           { ...blueprints[1], primaryCategory: 'Custom Platform' },
         ],
       },
@@ -292,8 +292,13 @@ describe('ServiceNew', () => {
     )
 
     expect(screen.getByRole('heading', { name: 'Custom Platform', level: 3 })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Storage', level: 3 })).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { name: 'Other' })).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Other', level: 3 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'AWS S3 Bucket', level: 4 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Redis', level: 4 })).toBeInTheDocument()
+    expect(screen.getAllByRole('heading', { level: 3 }).map(({ textContent }) => textContent)).toEqual([
+      'Custom Platform',
+      'Other',
+    ])
   })
 
   it('should show an empty state when the blueprint search has no results', async () => {

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -3,6 +3,7 @@ import posthog from 'posthog-js'
 import type { BlueprintItem } from 'qovery-typescript-axios'
 import type { ReactNode } from 'react'
 import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
+import { OTHER_BLUEPRINT_CATEGORY } from '../blueprint-utils/blueprint-utils'
 import { ServiceNew } from './service-new'
 
 const mockUseFeatureFlagEnabled = jest.fn(() => false)
@@ -292,12 +293,12 @@ describe('ServiceNew', () => {
     )
 
     expect(screen.getByRole('heading', { name: 'Custom Platform', level: 3 })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Other', level: 3 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: OTHER_BLUEPRINT_CATEGORY, level: 3 })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'AWS S3 Bucket', level: 4 })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Redis', level: 4 })).toBeInTheDocument()
     expect(screen.getAllByRole('heading', { level: 3 }).map(({ textContent }) => textContent)).toEqual([
       'Custom Platform',
-      'Other',
+      OTHER_BLUEPRINT_CATEGORY,
     ])
   })
 

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -80,20 +80,24 @@ jest.mock('../hooks/use-blueprint-catalog/use-blueprint-catalog', () => ({
 const blueprints: BlueprintItem[] = [
   {
     name: 'AWS S3 Bucket',
+    displayName: 'AWS S3 Bucket',
     kind: 'ServiceBlueprint',
     description: 'Object storage with server-side encryption, versioning, and configurable lifecycle policies.',
     icon: 'app://qovery-console/s3',
     categories: ['storage'],
+    primaryCategory: 'Storage',
     provider: 'aws',
     serviceFamily: 's3',
     majorVersions: [{ serviceVersion: '1', latestTag: 'aws/s3/1/1.0.0' }],
   },
   {
     name: 'Redis',
+    displayName: 'Redis',
     kind: 'ServiceBlueprint',
     description: 'In-memory key-value store deployed via the Bitnami Helm chart with configurable replicas.',
     icon: 'https://cdn.qovery.com/icons/redis.svg',
     categories: ['cache'],
+    primaryCategory: 'Databases & Caches',
     provider: 'aws',
     serviceFamily: 'redis',
     majorVersions: [{ serviceVersion: '7', latestTag: 'aws/redis/7/1.0.0' }],
@@ -313,7 +317,7 @@ describe('ServiceNew', () => {
   it('should format slug blueprint names', () => {
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'service-catalog')
     mockUseBlueprintCatalog.mockReturnValue({
-      data: { blueprints: [{ ...blueprints[0], name: 'aws-rds-mysql' }] },
+      data: { blueprints: [{ ...blueprints[0], name: 'aws-rds-mysql', displayName: '' }] },
     })
 
     renderWithProviders(
@@ -342,9 +346,14 @@ describe('ServiceNew', () => {
     mockUseBlueprintCatalog.mockReturnValue({
       data: {
         blueprints: [
-          { ...blueprints[0], name: 'AWS S3', provider: 'AWS' },
-          { ...blueprints[0], name: 'Scaleway Object Storage', provider: 'SCW' },
-          { ...blueprints[1], name: 'Helm Redis', provider: 'HELM' },
+          { ...blueprints[0], name: 'AWS S3', displayName: 'AWS S3', provider: 'AWS' },
+          {
+            ...blueprints[0],
+            name: 'Scaleway Object Storage',
+            displayName: 'Scaleway Object Storage',
+            provider: 'SCW',
+          },
+          { ...blueprints[1], name: 'Helm Redis', displayName: 'Helm Redis', provider: 'HELM' },
         ],
       },
     })

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -11,7 +11,11 @@ import { Button, Heading, Icon, InputSearch, Section, Skeleton, useModal } from 
 import { useSupportChat } from '@qovery/shared/util-hooks'
 import { BlueprintDetailsPanel } from '../blueprint-details-panel/blueprint-details-panel'
 import { BlueprintQueryBoundary } from '../blueprint-query-boundary/blueprint-query-boundary'
-import { getBlueprintDisplayName, isBlueprintCompatibleWithCluster } from '../blueprint-utils/blueprint-utils'
+import {
+  getBlueprintDisplayName,
+  getBlueprintPrimaryCategory,
+  isBlueprintCompatibleWithCluster,
+} from '../blueprint-utils/blueprint-utils'
 import { useBlueprintCatalog } from '../hooks/use-blueprint-catalog/use-blueprint-catalog'
 import { AGENTIC_WORKFLOW_TEMPLATES } from '../service-creation-flow/agentic-workflow/agentic-workflow-templates'
 import { BlueprintCard } from './blueprint-card/blueprint-card'
@@ -119,6 +123,16 @@ function BlueprintSection({
     isBlueprintCompatibleWithCluster(blueprint.provider, cloudProvider)
   )
   const filteredBlueprints = compatibleBlueprints.filter(filterBlueprint)
+  const categorizedBlueprints = Array.from(
+    filteredBlueprints.reduce((categories, blueprint) => {
+      const category = getBlueprintPrimaryCategory(blueprint)
+      const blueprints = categories.get(category) ?? []
+      blueprints.push(blueprint)
+      categories.set(category, blueprints)
+
+      return categories
+    }, new Map<string, BlueprintItem[]>())
+  )
 
   const openBlueprintMissingModal = () =>
     openModal({
@@ -157,13 +171,22 @@ function BlueprintSection({
         }
       />
       {filteredBlueprints.length > 0 ? (
-        <div className="grid grid-cols-3 gap-3">
-          {filteredBlueprints.map((blueprint) => (
-            <BlueprintCard
-              key={`${blueprint.provider}-${blueprint.serviceFamily}`}
-              blueprint={blueprint}
-              onViewDetails={onViewDetails}
-            />
+        <div className="flex flex-col gap-8">
+          {categorizedBlueprints.map(([category, blueprints], index) => (
+            <section key={category} className="flex flex-col gap-3" aria-labelledby={`blueprint-category-${index}`}>
+              <Heading id={`blueprint-category-${index}`} level={2}>
+                {category}
+              </Heading>
+              <div className="grid grid-cols-3 gap-3">
+                {blueprints.map((blueprint) => (
+                  <BlueprintCard
+                    key={`${blueprint.provider}-${blueprint.serviceFamily}`}
+                    blueprint={blueprint}
+                    onViewDetails={onViewDetails}
+                  />
+                ))}
+              </div>
+            </section>
           ))}
         </div>
       ) : (

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -11,7 +11,7 @@ import { Button, Heading, Icon, InputSearch, Section, Skeleton, useModal } from 
 import { useSupportChat } from '@qovery/shared/util-hooks'
 import { BlueprintDetailsPanel } from '../blueprint-details-panel/blueprint-details-panel'
 import { BlueprintQueryBoundary } from '../blueprint-query-boundary/blueprint-query-boundary'
-import { isBlueprintCompatibleWithCluster } from '../blueprint-utils/blueprint-utils'
+import { getBlueprintDisplayName, isBlueprintCompatibleWithCluster } from '../blueprint-utils/blueprint-utils'
 import { useBlueprintCatalog } from '../hooks/use-blueprint-catalog/use-blueprint-catalog'
 import { AGENTIC_WORKFLOW_TEMPLATES } from '../service-creation-flow/agentic-workflow/agentic-workflow-templates'
 import { BlueprintCard } from './blueprint-card/blueprint-card'
@@ -111,8 +111,10 @@ function BlueprintSection({
   })
   const { openModal, closeModal } = useModal()
   const blueprints = blueprintCatalog?.blueprints ?? []
-  const filterBlueprint = ({ name, description, categories }: BlueprintItem) =>
-    `${name} ${description} ${categories?.join(' ')}`.toLowerCase().includes(blueprintSearchInput.toLowerCase())
+  const filterBlueprint = (blueprint: BlueprintItem) =>
+    `${blueprint.name} ${getBlueprintDisplayName(blueprint)} ${blueprint.description} ${blueprint.categories?.join(' ')}`
+      .toLowerCase()
+      .includes(blueprintSearchInput.toLowerCase())
   const compatibleBlueprints = blueprints.filter((blueprint) =>
     isBlueprintCompatibleWithCluster(blueprint.provider, cloudProvider)
   )

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -12,6 +12,7 @@ import { useSupportChat } from '@qovery/shared/util-hooks'
 import { BlueprintDetailsPanel } from '../blueprint-details-panel/blueprint-details-panel'
 import { BlueprintQueryBoundary } from '../blueprint-query-boundary/blueprint-query-boundary'
 import {
+  OTHER_BLUEPRINT_CATEGORY,
   getBlueprintDisplayName,
   getBlueprintPrimaryCategory,
   isBlueprintCompatibleWithCluster,
@@ -126,15 +127,15 @@ function BlueprintSection({
   const categorizedBlueprints = Array.from(
     filteredBlueprints.reduce((categories, blueprint) => {
       const category = getBlueprintPrimaryCategory(blueprint)
-      const blueprints = categories.get(category) ?? []
-      blueprints.push(blueprint)
-      categories.set(category, blueprints)
+      const categoryBlueprints = categories.get(category) ?? []
+      categoryBlueprints.push(blueprint)
+      categories.set(category, categoryBlueprints)
 
       return categories
     }, new Map<string, BlueprintItem[]>())
   ).sort(([leftCategory], [rightCategory]) => {
-    if (leftCategory === 'Other') return 1
-    if (rightCategory === 'Other') return -1
+    if (leftCategory === OTHER_BLUEPRINT_CATEGORY) return 1
+    if (rightCategory === OTHER_BLUEPRINT_CATEGORY) return -1
 
     return 0
   })

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -173,8 +173,8 @@ function BlueprintSection({
       {filteredBlueprints.length > 0 ? (
         <div className="flex flex-col gap-8">
           {categorizedBlueprints.map(([category, blueprints], index) => (
-            <section key={category} className="flex flex-col gap-3" aria-labelledby={`blueprint-category-${index}`}>
-              <Heading id={`blueprint-category-${index}`} level={2}>
+            <section key={category} className="flex flex-col gap-2" aria-labelledby={`blueprint-category-${index}`}>
+              <Heading id={`blueprint-category-${index}`} level={3}>
                 {category}
               </Heading>
               <div className="grid grid-cols-3 gap-3">

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -132,7 +132,12 @@ function BlueprintSection({
 
       return categories
     }, new Map<string, BlueprintItem[]>())
-  )
+  ).sort(([leftCategory], [rightCategory]) => {
+    if (leftCategory === 'Other') return 1
+    if (rightCategory === 'Other') return -1
+
+    return 0
+  })
 
   const openBlueprintMissingModal = () =>
     openModal({

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "mermaid": "11.6.0",
     "monaco-editor": "0.53.0",
     "posthog-js": "1.345.1",
-    "qovery-typescript-axios": "1.1.966",
+    "qovery-typescript-axios": "1.1.967",
     "react": "18.3.1",
     "react-country-flag": "3.0.2",
     "react-datepicker": "4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6438,7 +6438,7 @@ __metadata:
     prettier: 3.2.5
     prettier-plugin-tailwindcss: 0.5.14
     pretty-quick: 4.0.0
-    qovery-typescript-axios: 1.1.966
+    qovery-typescript-axios: 1.1.967
     qovery-ws-typescript-axios: 0.1.646
     react: 18.3.1
     react-country-flag: 3.0.2
@@ -25965,12 +25965,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qovery-typescript-axios@npm:1.1.966":
-  version: 1.1.966
-  resolution: "qovery-typescript-axios@npm:1.1.966"
+"qovery-typescript-axios@npm:1.1.967":
+  version: 1.1.967
+  resolution: "qovery-typescript-axios@npm:1.1.967"
   dependencies:
     axios: 1.18.1
-  checksum: b8b95fb277c8d16ad938e871d780519a65c4194652ec5c3d60b86504e7bd9564e54468884c9bdb287e94c3e9a4b8403d4cfa47379aea4654ace49ab813269d0b
+  checksum: 67726ebf3ac7e88f85072e2f70a4a7ec77d3bc0b79ba9cba563815ecf2305ab64c13a0e6a68832a41ff054de5394f9ec542ae9c34e26da6aaa1735836858a4b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Summary

**Issue**: [QOV-2232](https://qovery.atlassian.net/browse/QOV-2232)

Updates the Blueprint creation experience to use the new Service Catalog metadata.

- Displays `displayName` when provided by the catalog, with the existing name formatter as a fallback.
- Groups blueprint cards by their catalog-provided `primaryCategory`.
- Derives categories dynamically from returned blueprints, so the Console does not maintain a duplicate category registry.
- Falls back to an **Other** section for catalogs that do not yet provide a category.

<!-- Brief description of what this PR does -->
<!-- step-by-step instructions for reviewers -->
<!-- bullet list of changes -->
<!-- reasons / problems solved -->
<!-- highlight the key implementation details -->

## Screenshots / Recordings

<img width="1616" height="1774" alt="SCR-20260907-psjs" src="https://github.com/user-attachments/assets/64c62962-695e-4939-bd91-1b489686824f" />


## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [x] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements QOV-2232: the Blueprint UI now shows the catalog's `displayName` when available and groups cards by `primaryCategory`, falling back to the formatted name and an "Other" section for entries without either.

- Shows `displayName` in cards, details panel, configuration view, step summary, and the default service name.
- Includes `displayName` in catalog search matching.
- Derives category sections from the catalog response, so the Console keeps no duplicate category registry, and sorts the "Other" section last.
- Bumps `qovery-typescript-axios` to `1.1.967` for the new `displayName` and `primaryCategory` fields.

<sup>Written for commit c807ab6601aad983ce984664b1884e1bfe5186f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







[QOV-2232]: https://qovery.atlassian.net/browse/QOV-2232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ