### PR TITLE
fix(agent-task): require a creation trigger

### DIFF
--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.spec.tsx
@@ -177,7 +177,13 @@ describe('AgenticWorkflowConfiguration', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Add automation' }))
     expect(screen.getByRole('heading', { name: 'Configure automation' })).toBeInTheDocument()
     expect(screen.getByText('Triggers')).toBeInTheDocument()
-    expect(screen.getByText('Enable agent task')).toBeInTheDocument()
+    expect(screen.queryByRole('switch', { name: 'Enable agent task' })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
+    await userEvent.click(screen.getByRole('menuitem', { name: 'From a webhook' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Apply changes' }))
+
+    expect(screen.getByRole('button', { name: 'Webhook' })).toBeInTheDocument()
   })
 
   it('should manage MCP from a side panel', async () => {
@@ -207,6 +213,12 @@ describe('AgenticWorkflowConfiguration', () => {
 
     expect(createButton).toBeEnabled()
     expect(createAndDeployButton).toBeEnabled()
+
+    await userEvent.click(createButton)
+
+    expect(screen.getByRole('heading', { name: 'Configure automation' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Apply changes' })).toBeDisabled()
+    expect(mockCreateService).not.toHaveBeenCalled()
   })
 
   it('should create without deploying when Create is clicked', async () => {
@@ -217,12 +229,16 @@ describe('AgenticWorkflowConfiguration', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Anthropic' }))
     await userEvent.type(screen.getByLabelText('API key'), 'sk-ant-test')
     await userEvent.click(screen.getByRole('button', { name: 'Save provider' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add automation' }))
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
+    await userEvent.click(screen.getByRole('menuitem', { name: 'From a webhook' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Apply changes' }))
     await userEvent.click(screen.getByRole('button', { name: 'Create' }))
 
     await waitFor(() => expect(mockCreateService).toHaveBeenCalledTimes(1))
     expect(mockCreateService).toHaveBeenCalledWith(
       expect.objectContaining({
-        payload: expect.objectContaining({ execution_mode: AgenticWorkflowExecutionMode.IN_PLACE }),
+        payload: expect.objectContaining({ enabled: true, execution_mode: AgenticWorkflowExecutionMode.IN_PLACE }),
       })
     )
     expect(mockDeployEnvironment).not.toHaveBeenCalled()
@@ -236,6 +252,10 @@ describe('AgenticWorkflowConfiguration', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Anthropic' }))
     await userEvent.type(screen.getByLabelText('API key'), 'sk-ant-test')
     await userEvent.click(screen.getByRole('button', { name: 'Save provider' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Add automation' }))
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
+    await userEvent.click(screen.getByRole('menuitem', { name: 'From a webhook' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Apply changes' }))
     await userEvent.click(screen.getByRole('button', { name: 'Create and deploy' }))
 
     await waitFor(() => expect(mockDeployEnvironment).toHaveBeenCalledWith({ environmentId: 'environment-1' }))

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.spec.tsx
@@ -216,8 +216,8 @@ describe('AgenticWorkflowConfiguration', () => {
 
     await userEvent.click(createButton)
 
-    expect(screen.getByRole('heading', { name: 'Configure automation' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Apply changes' })).toBeDisabled()
+    expect(screen.getByText('Add at least one trigger.')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Configure automation' })).not.toBeInTheDocument()
     expect(mockCreateService).not.toHaveBeenCalled()
   })
 

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.spec.tsx
@@ -216,8 +216,8 @@ describe('AgenticWorkflowConfiguration', () => {
 
     await userEvent.click(createButton)
 
-    expect(screen.getByText('Add at least one trigger.')).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { name: 'Configure automation' })).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Configure automation' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Apply changes' })).toBeDisabled()
     expect(mockCreateService).not.toHaveBeenCalled()
   })
 

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
@@ -305,6 +305,7 @@ export function AgenticWorkflowConfiguration() {
     advanced: false,
   }
   const automation = values.automations[0] ?? createDefaultAutomation()
+  const automationValid = automation.triggers.length > 0
   const availableMcpServers = [...mcpServers, ...createdMcpServers].filter(
     (mcpServer, index, servers) => servers.findIndex(({ id }) => id === mcpServer.id) === index
   )
@@ -386,6 +387,11 @@ export function AgenticWorkflowConfiguration() {
     if (!gitRepositoriesValid) {
       const invalidIndex = values.gitRepositories.findIndex((repository) => !isGitRepositoryComplete(repository))
       openGitContext(invalidIndex >= 0 ? invalidIndex : undefined)
+      return false
+    }
+
+    if (!automationValid) {
+      setActiveSheet('automation')
       return false
     }
 
@@ -879,13 +885,9 @@ export function AgenticWorkflowConfiguration() {
       {activeSheet === 'automation' ? (
         <AutomationSheet
           automation={automation}
-          enabled={values.workflowEnabled}
           onClose={() => setActiveSheet(null)}
-          onSave={(nextAutomation, enabled) => {
+          onSave={(nextAutomation) => {
             form.setValue('automations', [nextAutomation], { shouldDirty: true })
-            if (enabled !== undefined) {
-              form.setValue('workflowEnabled', enabled, { shouldDirty: true })
-            }
           }}
         />
       ) : null}

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
@@ -142,15 +142,12 @@ function ConfigurationModalContent({
   )
 }
 
-function ConfigurationRow({ children, error, label }: { children: ReactNode; error?: string; label: string }) {
+function ConfigurationRow({ children, label }: { children: ReactNode; label: string }) {
   return (
     <div className="grid min-h-11 grid-cols-1 items-center gap-1 sm:grid-cols-[112px_minmax(0,1fr)] sm:gap-4">
       <span className="text-sm font-medium text-neutral-subtle">{label}</span>
-      <div className="min-w-0">
-        <div className="group flex min-h-9 min-w-0 flex-wrap items-center gap-2 rounded px-1 hover:bg-surface-neutral-subtle">
-          {children}
-        </div>
-        {error ? <p className="mt-1 px-1 text-xs font-medium text-negative">{error}</p> : null}
+      <div className="group flex min-h-9 min-w-0 flex-wrap items-center gap-2 rounded px-1 hover:bg-surface-neutral-subtle">
+        {children}
       </div>
     </div>
   )
@@ -309,7 +306,6 @@ export function AgenticWorkflowConfiguration() {
   }
   const automation = values.automations[0] ?? createDefaultAutomation()
   const automationValid = automation.triggers.length > 0
-  const showAutomationError = showValidationErrors && !automationValid
   const availableMcpServers = [...mcpServers, ...createdMcpServers].filter(
     (mcpServer, index, servers) => servers.findIndex(({ id }) => id === mcpServer.id) === index
   )
@@ -395,6 +391,7 @@ export function AgenticWorkflowConfiguration() {
     }
 
     if (!automationValid) {
+      setActiveSheet('automation')
       return false
     }
 
@@ -777,10 +774,7 @@ export function AgenticWorkflowConfiguration() {
                   Add MCP
                 </Button>
               </ConfigurationRow>
-              <ConfigurationRow
-                label="Automations"
-                error={showAutomationError ? 'Add at least one trigger.' : undefined}
-              >
+              <ConfigurationRow label="Automations">
                 <Button
                   type="button"
                   size="sm"

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
@@ -142,12 +142,15 @@ function ConfigurationModalContent({
   )
 }
 
-function ConfigurationRow({ children, label }: { children: ReactNode; label: string }) {
+function ConfigurationRow({ children, error, label }: { children: ReactNode; error?: string; label: string }) {
   return (
     <div className="grid min-h-11 grid-cols-1 items-center gap-1 sm:grid-cols-[112px_minmax(0,1fr)] sm:gap-4">
       <span className="text-sm font-medium text-neutral-subtle">{label}</span>
-      <div className="group flex min-h-9 min-w-0 flex-wrap items-center gap-2 rounded px-1 hover:bg-surface-neutral-subtle">
-        {children}
+      <div className="min-w-0">
+        <div className="group flex min-h-9 min-w-0 flex-wrap items-center gap-2 rounded px-1 hover:bg-surface-neutral-subtle">
+          {children}
+        </div>
+        {error ? <p className="mt-1 px-1 text-xs font-medium text-negative">{error}</p> : null}
       </div>
     </div>
   )
@@ -306,6 +309,7 @@ export function AgenticWorkflowConfiguration() {
   }
   const automation = values.automations[0] ?? createDefaultAutomation()
   const automationValid = automation.triggers.length > 0
+  const showAutomationError = showValidationErrors && !automationValid
   const availableMcpServers = [...mcpServers, ...createdMcpServers].filter(
     (mcpServer, index, servers) => servers.findIndex(({ id }) => id === mcpServer.id) === index
   )
@@ -391,7 +395,6 @@ export function AgenticWorkflowConfiguration() {
     }
 
     if (!automationValid) {
-      setActiveSheet('automation')
       return false
     }
 
@@ -774,7 +777,10 @@ export function AgenticWorkflowConfiguration() {
                   Add MCP
                 </Button>
               </ConfigurationRow>
-              <ConfigurationRow label="Automations">
+              <ConfigurationRow
+                label="Automations"
+                error={showAutomationError ? 'Add at least one trigger.' : undefined}
+              >
                 <Button
                   type="button"
                   size="sm"

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/automations/automation-sheet.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/automations/automation-sheet.spec.tsx
@@ -38,22 +38,6 @@ describe('AutomationSheet', () => {
 
     expect(screen.getByText('Schedule')).toBeInTheDocument()
     expect(screen.getByText('https://hooks.example.com')).toBeInTheDocument()
-  })
-
-  it('saves the agent task enabled state with the automation', async () => {
-    const onSave = jest.fn()
-    const automation: AgenticWorkflowAutomation = {
-      id: 'automation-1',
-      triggers: [{ id: 'trigger-1', type: 'webhook' }],
-      outputs: [],
-    }
-    const { userEvent } = renderWithProviders(
-      <AutomationSheet enabled automation={automation} onClose={jest.fn()} onSave={onSave} />
-    )
-
-    await userEvent.click(screen.getByRole('switch', { name: 'Enable agent task' }))
-    await userEvent.click(screen.getByRole('button', { name: 'Apply changes' }))
-
-    expect(onSave).toHaveBeenCalledWith(automation, false)
+    expect(screen.queryByRole('switch', { name: 'Enable agent task' })).not.toBeInTheDocument()
   })
 })

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/automations/automation-sheet.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/automations/automation-sheet.tsx
@@ -1,16 +1,6 @@
 import { type ReactNode, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import {
-  Button,
-  DropdownMenu,
-  Heading,
-  Icon,
-  InputText,
-  InputTextArea,
-  InputToggle,
-  Section,
-  useModal,
-} from '@qovery/shared/ui'
+import { Button, DropdownMenu, Heading, Icon, InputText, InputTextArea, Section, useModal } from '@qovery/shared/ui'
 import { formatCronExpression } from '@qovery/shared/util-js'
 import { TimezoneSetting } from '../../../../timezone-setting/timezone-setting'
 import {
@@ -266,21 +256,18 @@ function WebhookOutputModal({
 export function AutomationSheet({
   allowEmptyOutputUrl = false,
   automation,
-  enabled,
   lockWebhookTrigger = false,
   onClose,
   onSave,
 }: {
   allowEmptyOutputUrl?: boolean
   automation: AgenticWorkflowAutomation
-  enabled?: boolean
   lockWebhookTrigger?: boolean
   onClose: () => void
-  onSave: (automation: AgenticWorkflowAutomation, enabled?: boolean) => void
+  onSave: (automation: AgenticWorkflowAutomation) => void
 }) {
   const { closeModal, openModal } = useModal()
   const [draft, setDraft] = useState<AgenticWorkflowAutomation>(automation)
-  const [enabledDraft, setEnabledDraft] = useState(enabled)
   const scheduleTrigger = draft.triggers.find((trigger) => trigger.type === 'schedule')
   const webhookTrigger = draft.triggers.find((trigger) => trigger.type === 'webhook')
 
@@ -375,18 +362,8 @@ export function AutomationSheet({
             </DropdownMenu.Root>
           }
         >
-          {enabledDraft !== undefined || draft.triggers.length ? (
+          {draft.triggers.length ? (
             <div className="flex flex-col gap-3">
-              {enabledDraft !== undefined ? (
-                <InputToggle
-                  small
-                  align="top"
-                  value={enabledDraft}
-                  title="Enable agent task"
-                  description="When disabled, triggers cannot start runs, so external webhook integrations can remain configured."
-                  onChange={setEnabledDraft}
-                />
-              ) : null}
               {draft.triggers.map((trigger) =>
                 trigger.type === 'webhook' ? (
                   <AutomationItemCard
@@ -453,7 +430,7 @@ export function AutomationSheet({
           size="md"
           disabled={draft.triggers.length === 0}
           onClick={() => {
-            enabledDraft === undefined ? onSave(draft) : onSave(draft, enabledDraft)
+            onSave(draft)
             onClose()
           }}
         >

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-context.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-context.spec.tsx
@@ -15,7 +15,6 @@ function FormDefaults() {
       <span data-testid="memory">{values.memory}</span>
       <span data-testid="storage">{values.storage}</span>
       <span data-testid="whitelist-hosts">{values.whitelistHosts}</span>
-      <span data-testid="workflow-enabled">{String(values.workflowEnabled)}</span>
       <span data-testid="execution-mode">{values.executionMode}</span>
       <span data-testid="variables">{variables.map((variable) => variable.variable).join(',')}</span>
     </>
@@ -34,7 +33,6 @@ describe('AgenticWorkflowCreationFlow', () => {
     expect(screen.getByTestId('memory')).toHaveTextContent('2048')
     expect(screen.getByTestId('storage')).toHaveTextContent('10')
     expect(screen.getByTestId('whitelist-hosts')).toHaveTextContent('*')
-    expect(screen.getByTestId('workflow-enabled')).toHaveTextContent('true')
     expect(screen.getByTestId('execution-mode')).toHaveTextContent(AgenticWorkflowExecutionMode.IN_PLACE)
   })
 
@@ -56,6 +54,5 @@ describe('AgenticWorkflowCreationFlow', () => {
     expect(screen.getByTestId('variables')).toHaveTextContent('INCIDENT_IO_API_KEY')
     // …while untouched fields keep their defaults.
     expect(screen.getByTestId('cpu')).toHaveTextContent('2000')
-    expect(screen.getByTestId('workflow-enabled')).toHaveTextContent('true')
   })
 })

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-context.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-context.tsx
@@ -88,10 +88,8 @@ export interface AgenticWorkflowFormData {
   cpu: string
   memory: string
   storage: string
-  workflowEnabled: boolean
   executionMode: AgenticWorkflowExecutionMode
   aiModel: AgenticWorkflowModelType
-  webhookEnabled: boolean
   mcpServerIds: string[]
   mcpJson: string
   gitRepositories: AgenticWorkflowGitRepository[]
@@ -128,10 +126,8 @@ export function getAgenticWorkflowDefaults(): AgenticWorkflowFormData {
     cpu: '2000',
     memory: '2048',
     storage: '10',
-    workflowEnabled: true,
     executionMode: AgenticWorkflowExecutionMode.IN_PLACE,
     aiModel: AgenticWorkflowModelType.CLAUDE,
-    webhookEnabled: true,
     mcpServerIds: [],
     mcpJson: '',
     gitRepositories: [],

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-request.spec.ts
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-request.spec.ts
@@ -8,10 +8,8 @@ const values: AgenticWorkflowFormData = {
   cpu: '2000',
   memory: '2048',
   storage: '10',
-  workflowEnabled: true,
   executionMode: AgenticWorkflowExecutionMode.IN_PLACE,
   aiModel: AgenticWorkflowModelType.CLAUDE,
-  webhookEnabled: true,
   mcpServerIds: ['mcp-1', 'mcp-2'],
   mcpJson: '',
   gitRepositories: [],
@@ -24,6 +22,10 @@ const values: AgenticWorkflowFormData = {
 }
 
 describe('formatAgenticWorkflowRequest', () => {
+  it('enables newly created agent tasks', () => {
+    expect(formatAgenticWorkflowRequest(values).enabled).toBe(true)
+  })
+
   it('sends the selected organization MCP server IDs', () => {
     expect(formatAgenticWorkflowRequest(values).mcp_server_ids).toEqual(['mcp-1', 'mcp-2'])
   })

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-request.ts
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-request.ts
@@ -19,7 +19,7 @@ export function formatAgenticWorkflowRequest(values: AgenticWorkflowFormData): A
     name: values.name,
     description: values.description,
     docker_fragment: values.dockerFragment,
-    enabled: values.workflowEnabled,
+    enabled: true,
     execution_mode: values.executionMode,
     schedule: scheduleTrigger
       ? {


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Make automation mandatory in the Agent Task creation flow. Remove the "Enable agent task" toggle, require at least one Webhook or Schedule trigger before creation, and always create the Agent Task enabled once a trigger is configured.

## Screenshots / Recordings

Not applicable.

## Testing

- [x] Changes tested locally in the relevant Console's pages and Storybooks
- [x] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [x] `yarn format`
- [x] `yarn lint`

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires at least one webhook or schedule trigger before an agent task can be created, and always creates the task enabled.

- Removes the "Enable agent task" toggle and the `workflowEnabled`/`webhookEnabled` form fields.
- Blocks creation without a trigger by opening the automation sheet so one can be added.
- Sends `enabled: true` in the create request.

<sup>Written for commit 4e100f232e584914d18fccf69ec6592516aeb29f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

