### PR TITLE
feat(automation): add environment automation area

### DIFF
--- a/apps/console/src/routeTree.gen.ts
+++ b/apps/console/src/routeTree.gen.ts
@@ -96,9 +96,11 @@ import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploym
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesRouteRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/route'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsRouteRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/route'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route'
+import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/route'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesIndexRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/index'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsIndexRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/index'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewIndexRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/index'
+import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/index'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesExternalSecretsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesBuiltInRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/built-in'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsPreviewEnvironmentsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments'
@@ -107,14 +109,19 @@ import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnviron
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsDangerZoneRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/danger-zone'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceNewRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/new'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewPipelineRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/pipeline'
+import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs'
+import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/route'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateIndexRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/index'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdIndexRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/index'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdIndexRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/index'
+import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/index'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdServiceLogsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdOverviewRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdManifestRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/manifest'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdCloudShellRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdPreCheckLogsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs'
+import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments'
+import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateTerraformRouteRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/terraform/route'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateLifecycleJobRouteRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/lifecycle-job/route'
 import { Route as AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateHelmRouteRouteImport } from './routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/helm/route'
@@ -872,6 +879,14 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
       getParentRoute: () => AuthenticatedOrganizationOrganizationIdRouteRoute,
     } as any,
   )
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteImport.update(
+    {
+      id: '/project/$projectId/environment/$environmentId/automations',
+      path: '/project/$projectId/environment/$environmentId/automations',
+      getParentRoute: () => AuthenticatedOrganizationOrganizationIdRouteRoute,
+    } as any,
+  )
 const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesIndexRoute =
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesIndexRouteImport.update(
     {
@@ -897,6 +912,15 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
       path: '/',
       getParentRoute: () =>
         AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRoute,
+    } as any,
+  )
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRoute =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRouteImport.update(
+    {
+      id: '/',
+      path: '/',
+      getParentRoute: () =>
+        AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute,
     } as any,
   )
 const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesExternalSecretsRoute =
@@ -970,6 +994,24 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
         AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRoute,
     } as any,
   )
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRoute =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRouteImport.update(
+    {
+      id: '/runs',
+      path: '/runs',
+      getParentRoute: () =>
+        AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute,
+    } as any,
+  )
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteImport.update(
+    {
+      id: '/settings',
+      path: '/settings',
+      getParentRoute: () =>
+        AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute,
+    } as any,
+  )
 const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateIndexRoute =
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateIndexRouteImport.update(
     {
@@ -992,6 +1034,15 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
       id: '/project/$projectId/environment/$environmentId/deployment/$deploymentId/',
       path: '/project/$projectId/environment/$environmentId/deployment/$deploymentId/',
       getParentRoute: () => AuthenticatedOrganizationOrganizationIdRouteRoute,
+    } as any,
+  )
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRoute =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRouteImport.update(
+    {
+      id: '/',
+      path: '/',
+      getParentRoute: () =>
+        AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute,
     } as any,
   )
 const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdServiceLogsRoute =
@@ -1032,6 +1083,24 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironm
       id: '/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs',
       path: '/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs',
       getParentRoute: () => AuthenticatedOrganizationOrganizationIdRouteRoute,
+    } as any,
+  )
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRoute =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRouteImport.update(
+    {
+      id: '/preview-environments',
+      path: '/preview-environments',
+      getParentRoute: () =>
+        AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute,
+    } as any,
+  )
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRoute =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRouteImport.update(
+    {
+      id: '/deployment-rules',
+      path: '/deployment-rules',
+      getParentRoute: () =>
+        AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute,
     } as any,
   )
 const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateTerraformRouteRoute =
@@ -1912,12 +1981,15 @@ export interface FileRoutesByFullPath {
   '/organization/$organizationId/cluster/create/$slug/': typeof AuthenticatedOrganizationOrganizationIdClusterCreateSlugIndexRoute
   '/organization/$organizationId/project/$projectId/deployment-rules': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesIndexRoute
   '/organization/$organizationId/project/$projectId/settings/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdSettingsIndexRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteWithChildren
   '/organization/$organizationId/project/$projectId/environment/$environmentId/overview': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRouteWithChildren
   '/organization/$organizationId/project/$projectId/environment/$environmentId/settings': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsRouteRouteWithChildren
   '/organization/$organizationId/project/$projectId/environment/$environmentId/variables': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesRouteRouteWithChildren
   '/organization/$organizationId/project/$projectId/deployment-rules/edit/$deploymentRuleId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesEditDeploymentRuleIdRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/deployments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdIndexRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteWithChildren
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/overview/pipeline': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewPipelineRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/new': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceNewRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/danger-zone': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsDangerZoneRoute
@@ -1926,6 +1998,7 @@ export interface FileRoutesByFullPath {
   '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsPreviewEnvironmentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/built-in': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesBuiltInRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesExternalSecretsRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/overview/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesIndexRoute
@@ -1939,11 +2012,14 @@ export interface FileRoutesByFullPath {
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/helm': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateHelmRouteRouteWithChildren
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/lifecycle-job': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateLifecycleJobRouteRouteWithChildren
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/terraform': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateTerraformRouteRouteWithChildren
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdPreCheckLogsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdCloudShellRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/manifest': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdManifestRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdOverviewRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdServiceLogsRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateIndexRoute
@@ -2105,6 +2181,7 @@ export interface FileRoutesByTo {
   '/organization/$organizationId/project/$projectId/deployment-rules/edit/$deploymentRuleId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesEditDeploymentRuleIdRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/deployments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdIndexRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/overview/pipeline': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewPipelineRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/new': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceNewRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/danger-zone': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsDangerZoneRoute
@@ -2113,14 +2190,18 @@ export interface FileRoutesByTo {
   '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsPreviewEnvironmentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/built-in': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesBuiltInRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesExternalSecretsRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/overview': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/settings': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/variables': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesIndexRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdPreCheckLogsRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdCloudShellRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/manifest': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdManifestRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdOverviewRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdServiceLogsRoute
+  '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdIndexRoute
   '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateIndexRoute
@@ -2286,12 +2367,15 @@ export interface FileRoutesById {
   '/_authenticated/organization/$organizationId/cluster/create/$slug/': typeof AuthenticatedOrganizationOrganizationIdClusterCreateSlugIndexRoute
   '/_authenticated/organization/$organizationId/project/$projectId/deployment-rules/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesIndexRoute
   '/_authenticated/organization/$organizationId/project/$projectId/settings/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdSettingsIndexRoute
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteWithChildren
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRouteWithChildren
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsRouteRouteWithChildren
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesRouteRouteWithChildren
   '/_authenticated/organization/$organizationId/project/$projectId/deployment-rules/edit/$deploymentRuleId': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesEditDeploymentRuleIdRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentsRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdIndexRoute
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteWithChildren
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/pipeline': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewPipelineRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/new': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceNewRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/danger-zone': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsDangerZoneRoute
@@ -2300,6 +2384,7 @@ export interface FileRoutesById {
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsPreviewEnvironmentsRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/built-in': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesBuiltInRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesExternalSecretsRoute
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewIndexRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsIndexRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesIndexRoute
@@ -2313,11 +2398,14 @@ export interface FileRoutesById {
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/helm': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateHelmRouteRouteWithChildren
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/lifecycle-job': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateLifecycleJobRouteRouteWithChildren
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/terraform': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateTerraformRouteRouteWithChildren
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRoute
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdPreCheckLogsRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdCloudShellRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/manifest': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdManifestRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdOverviewRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdServiceLogsRoute
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdIndexRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceServiceIdIndexRoute
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/': typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdServiceCreateIndexRoute
@@ -2485,12 +2573,15 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/cluster/create/$slug/'
     | '/organization/$organizationId/project/$projectId/deployment-rules'
     | '/organization/$organizationId/project/$projectId/settings/'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/overview'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/settings'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/variables'
     | '/organization/$organizationId/project/$projectId/deployment-rules/edit/$deploymentRuleId'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/deployments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/overview/pipeline'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/new'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/danger-zone'
@@ -2499,6 +2590,7 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/built-in'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/overview/'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/'
@@ -2512,11 +2604,14 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/helm'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/lifecycle-job'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/terraform'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/manifest'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create'
@@ -2678,6 +2773,7 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/project/$projectId/deployment-rules/edit/$deploymentRuleId'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/deployments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/overview/pipeline'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/new'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/danger-zone'
@@ -2686,14 +2782,18 @@ export interface FileRouteTypes {
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/built-in'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/overview'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/settings'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/variables'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/manifest'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs'
+    | '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId'
     | '/organization/$organizationId/project/$projectId/environment/$environmentId/service/create'
@@ -2858,12 +2958,15 @@ export interface FileRouteTypes {
     | '/_authenticated/organization/$organizationId/cluster/create/$slug/'
     | '/_authenticated/organization/$organizationId/project/$projectId/deployment-rules/'
     | '/_authenticated/organization/$organizationId/project/$projectId/settings/'
+    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables'
     | '/_authenticated/organization/$organizationId/project/$projectId/deployment-rules/edit/$deploymentRuleId'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployments'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/'
+    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings'
+    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/pipeline'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/new'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/danger-zone'
@@ -2872,6 +2975,7 @@ export interface FileRouteTypes {
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/built-in'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets'
+    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/'
@@ -2885,11 +2989,14 @@ export interface FileRouteTypes {
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/helm'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/lifecycle-job'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/terraform'
+    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules'
+    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/cloud-shell'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/manifest'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/overview'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs'
+    | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/'
     | '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/'
@@ -3593,6 +3700,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRouteImport
       parentRoute: typeof AuthenticatedOrganizationOrganizationIdRouteRoute
     }
+    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations': {
+      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations'
+      path: '/project/$projectId/environment/$environmentId/automations'
+      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdRouteRoute
+    }
     '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/': {
       id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/'
       path: '/'
@@ -3613,6 +3727,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/overview/'
       preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewIndexRouteImport
       parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRoute
+    }
+    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/': {
+      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/'
+      path: '/'
+      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute
     }
     '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets': {
       id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables/external-secrets'
@@ -3670,6 +3791,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewPipelineRouteImport
       parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRoute
     }
+    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs': {
+      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs'
+      path: '/runs'
+      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute
+    }
+    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings': {
+      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings'
+      path: '/settings'
+      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute
+    }
     '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/': {
       id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/'
       path: '/project/$projectId/environment/$environmentId/service/create'
@@ -3690,6 +3825,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId'
       preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdIndexRouteImport
       parentRoute: typeof AuthenticatedOrganizationOrganizationIdRouteRoute
+    }
+    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/': {
+      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/'
+      path: '/'
+      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute
     }
     '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs': {
       id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/service-logs'
@@ -3725,6 +3867,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/deployment/$deploymentId/pre-check-logs'
       preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdDeploymentDeploymentIdPreCheckLogsRouteImport
       parentRoute: typeof AuthenticatedOrganizationOrganizationIdRouteRoute
+    }
+    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments': {
+      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments'
+      path: '/preview-environments'
+      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute
+    }
+    '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules': {
+      id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules'
+      path: '/deployment-rules'
+      fullPath: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules'
+      preLoaderRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRouteImport
+      parentRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute
     }
     '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/terraform': {
       id: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/terraform'
@@ -4560,6 +4716,48 @@ const AuthenticatedOrganizationOrganizationIdProjectProjectIdSettingsRouteRouteW
     AuthenticatedOrganizationOrganizationIdProjectProjectIdSettingsRouteRouteChildren,
   )
 
+interface AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteChildren {
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRoute
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRoute
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRoute
+}
+
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteChildren: AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteChildren =
+  {
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRoute:
+      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsDeploymentRulesRoute,
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRoute:
+      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsPreviewEnvironmentsRoute,
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRoute:
+      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsIndexRoute,
+  }
+
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteWithChildren =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute._addFileChildren(
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteChildren,
+  )
+
+interface AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteChildren {
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteWithChildren
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRoute
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRoute
+}
+
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteChildren: AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteChildren =
+  {
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRoute:
+      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsSettingsRouteRouteWithChildren,
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRoute:
+      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRunsRoute,
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRoute:
+      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsIndexRoute,
+  }
+
+const AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteWithChildren =
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute._addFileChildren(
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteChildren,
+  )
+
 interface AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRouteChildren {
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewPipelineRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewPipelineRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewIndexRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewIndexRoute
@@ -5031,6 +5229,7 @@ interface AuthenticatedOrganizationOrganizationIdRouteRouteChildren {
   AuthenticatedOrganizationOrganizationIdProjectProjectIdIndexRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdIndexRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesCreateRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesCreateRoute
   AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesIndexRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesIndexRoute
+  AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteWithChildren
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRouteWithChildren
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsRouteRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsRouteRouteWithChildren
   AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesRouteRoute: typeof AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdVariablesRouteRouteWithChildren
@@ -5104,6 +5303,8 @@ const AuthenticatedOrganizationOrganizationIdRouteRouteChildren: AuthenticatedOr
       AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesCreateRoute,
     AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesIndexRoute:
       AuthenticatedOrganizationOrganizationIdProjectProjectIdDeploymentRulesIndexRoute,
+    AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRoute:
+      AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdAutomationsRouteRouteWithChildren,
     AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRoute:
       AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdOverviewRouteRouteWithChildren,
     AuthenticatedOrganizationOrganizationIdProjectProjectIdEnvironmentEnvironmentIdSettingsRouteRoute:

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/index.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/index.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute, useParams } from '@tanstack/react-router'
+import { useEnvironment } from '@qovery/domains/environments/feature'
+import { isAgenticWorkflow } from '@qovery/domains/services/data-access'
+import { AgenticWorkflowServiceList, AgenticWorkflowUseCases, useServices } from '@qovery/domains/services/feature'
+import { SettingsHeading } from '@qovery/shared/console-shared'
+import { Section } from '@qovery/shared/ui'
+
+export const Route = createFileRoute(
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/'
+)({ component: RouteComponent })
+
+function RouteComponent() {
+  const { organizationId = '', projectId = '', environmentId = '' } = useParams({ strict: false })
+  const { data: environment } = useEnvironment({ environmentId, suspense: true })
+  const { data: services = [] } = useServices({ environmentId, suspense: true })
+
+  if (!environment) return null
+
+  const hasAgentTasks = services.some(isAgenticWorkflow)
+  const useCasesProps = {
+    organizationId,
+    projectId,
+    environmentId,
+    cloudProvider: environment.cloud_provider?.provider,
+  }
+
+  return (
+    <Section className="px-8 pb-8 pt-6">
+      <SettingsHeading title="Automations" description="Create and monitor AI-powered environment automations.">
+        {hasAgentTasks ? (
+          <div className="flex shrink-0 items-center pb-6">
+            <AgenticWorkflowUseCases {...useCasesProps} display="menu" />
+          </div>
+        ) : null}
+      </SettingsHeading>
+      <div
+        className={
+          hasAgentTasks ? 'flex w-full flex-col gap-8' : 'flex max-w-content-with-navigation-left flex-col gap-8'
+        }
+      >
+        <AgenticWorkflowServiceList environment={environment} />
+        {!hasAgentTasks ? <AgenticWorkflowUseCases {...useCasesProps} /> : null}
+      </div>
+    </Section>
+  )
+}

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/route.tsx
@@ -1,0 +1,47 @@
+import { Outlet, createFileRoute, useParams } from '@tanstack/react-router'
+import { Sidebar } from '@qovery/shared/ui'
+
+export const Route = createFileRoute(
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations'
+)({ component: RouteComponent })
+
+function RouteComponent() {
+  const { organizationId, projectId, environmentId } = useParams({ strict: false })
+  const basePath = `/organization/${organizationId}/project/${projectId}/environment/${environmentId}/automations`
+  const agentTaskLinks = [
+    { title: 'General', to: basePath },
+    { title: 'Runs', to: `${basePath}/runs` },
+  ]
+  const environmentLinks = [
+    { title: 'Deployment rules', to: `${basePath}/settings/deployment-rules` },
+    { title: 'Preview environments', to: `${basePath}/settings/preview-environments` },
+  ]
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <aside className="relative min-h-[calc(100vh-2.75rem-4rem)] w-52 shrink-0 self-stretch border-r border-neutral">
+        <div className="sticky top-16">
+          <Sidebar.Root className="mt-6">
+            <Sidebar.Group title="Agent tasks" icon="robot" defaultOpen>
+              {agentTaskLinks.map((link) => (
+                <Sidebar.SubItem key={link.to} to={link.to}>
+                  {link.title}
+                </Sidebar.SubItem>
+              ))}
+            </Sidebar.Group>
+            <Sidebar.Group title="Environment" icon="layer-group" defaultOpen>
+              {environmentLinks.map((link) => (
+                <Sidebar.SubItem key={link.to} to={link.to}>
+                  {link.title}
+                </Sidebar.SubItem>
+              ))}
+            </Sidebar.Group>
+          </Sidebar.Root>
+        </div>
+      </aside>
+      <div className="min-w-0 flex-1">
+        <Outlet />
+      </div>
+    </div>
+  )
+}

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SettingsHeading } from '@qovery/shared/console-shared'
+import { EmptyState, Section } from '@qovery/shared/ui'
+
+export const Route = createFileRoute(
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/runs'
+)({ component: RouteComponent })
+
+function RouteComponent() {
+  return (
+    <Section className="px-8 pb-8 pt-6">
+      <SettingsHeading title="Runs" description="Monitor your agent task executions." />
+      <div className="max-w-content-with-navigation-left">
+        <EmptyState
+          title="No automation runs yet"
+          description="Runs will appear here when an environment automation executes."
+        />
+      </div>
+    </Section>
+  )
+}

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SettingsDeploymentRules } from '@qovery/domains/environments/feature'
+
+export const Route = createFileRoute(
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/deployment-rules'
+)({ component: SettingsDeploymentRules })

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/index.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/index.tsx
@@ -1,10 +1,8 @@
 import { Navigate, createFileRoute, useParams } from '@tanstack/react-router'
 
 export const Route = createFileRoute(
-  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/deployment-rules'
-)({
-  component: RouteComponent,
-})
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/'
+)({ component: RouteComponent })
 
 function RouteComponent() {
   const { organizationId = '', projectId = '', environmentId = '' } = useParams({ strict: false })

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { PageSettingsPreviewEnvironmentsFeature } from '@qovery/domains/environments/feature'
+
+export const Route = createFileRoute(
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments'
+)({ component: PageSettingsPreviewEnvironmentsFeature })

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/route.tsx
@@ -1,0 +1,9 @@
+import { Outlet, createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings'
+)({ component: RouteComponent })
+
+function RouteComponent() {
+  return <Outlet />
+}

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
@@ -2,7 +2,6 @@ import { type IconName } from '@fortawesome/fontawesome-common-types'
 import { Outlet, createFileRoute, useMatchRoute } from '@tanstack/react-router'
 import { Link as RouterLink } from '@tanstack/react-router'
 import posthog from 'posthog-js'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { useEffect, useMemo } from 'react'
 import {
   ClusterAvatar,
@@ -23,7 +22,7 @@ import {
 } from '@qovery/domains/environments/feature'
 import { useEnvironmentsOverview } from '@qovery/domains/projects/feature'
 import { isArgoCd, isEditableService } from '@qovery/domains/services/data-access'
-import { AgenticWorkflowServiceList, ArgoCdServiceList, useServices } from '@qovery/domains/services/feature'
+import { ArgoCdServiceList, useServices } from '@qovery/domains/services/feature'
 import { Heading, Icon, Link, Navbar, Section, Tooltip } from '@qovery/shared/ui'
 
 export const Route = createFileRoute(
@@ -45,7 +44,6 @@ function RouteComponent() {
   const { data: deploymentStatus } = useDeploymentStatus({ environmentId })
   const { data: cluster } = useCluster({ organizationId, clusterId: environment?.cluster_id, suspense: true })
   const { data: services = [] } = useServices({ environmentId, suspense: true })
-  const isAgenticWorkflowEnabled = Boolean(useFeatureFlagEnabled('argentic-workflow'))
 
   useClusterRunningStatusSocket({
     organizationId,
@@ -197,9 +195,6 @@ function RouteComponent() {
                 )}
               </div>
               {shouldDisplayArgoCdServicesBelowQovery && <ArgoCdServiceList environment={environment} />}
-              {isServicesListTab && isAgenticWorkflowEnabled && (
-                <AgenticWorkflowServiceList environment={environment} />
-              )}
             </div>
           </Section>
         </div>

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview/route.tsx
@@ -21,9 +21,9 @@ import {
   useEnvironment,
 } from '@qovery/domains/environments/feature'
 import { useEnvironmentsOverview } from '@qovery/domains/projects/feature'
-import { isArgoCd, isEditableService } from '@qovery/domains/services/data-access'
+import { isAgenticWorkflow, isArgoCd, isEditableService } from '@qovery/domains/services/data-access'
 import { ArgoCdServiceList, useServices } from '@qovery/domains/services/feature'
-import { Heading, Icon, Link, Navbar, Section, Tooltip } from '@qovery/shared/ui'
+import { Badge, Heading, Icon, Link, Navbar, Section, Tooltip } from '@qovery/shared/ui'
 
 export const Route = createFileRoute(
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/overview'
@@ -68,6 +68,7 @@ function RouteComponent() {
   const isServicesListTab = activeTabId === 'services'
   const qoveryServicesCount = useMemo(() => services.filter(isEditableService).length, [services])
   const argoCdServicesCount = useMemo(() => services.filter(isArgoCd).length, [services])
+  const agentTasksCount = useMemo(() => services.filter(isAgenticWorkflow).length, [services])
   const hasQoveryServices = qoveryServicesCount > 0
   const hasArgoCdServices = argoCdServicesCount > 0
   const shouldDisplayQoveryServicesSubtitle = isServicesListTab && hasArgoCdServices
@@ -127,6 +128,11 @@ function RouteComponent() {
                 </RouterLink>
                 {cluster && <ClusterRunningStatusIndicator cluster={cluster} type="dot" />}
               </div>
+              {agentTasksCount > 0 && (
+                <Badge size="sm" variant="surface" color="neutral" className="ml-1 whitespace-nowrap">
+                  {agentTasksCount} agent {agentTasksCount === 1 ? 'task' : 'tasks'}
+                </Badge>
+              )}
             </div>
 
             <div className="flex shrink-0 gap-2">

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/create/agentic-workflow/route.tsx
@@ -20,7 +20,7 @@ function RouteComponent() {
   useEffect(() => {
     if (!isAgenticWorkflowEnabled) {
       navigate({
-        to: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/new',
+        to: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations',
         params: { organizationId, projectId, environmentId },
       })
     }
@@ -34,7 +34,7 @@ function RouteComponent() {
       variablesSeed={selectedTemplate?.variables}
       onExit={() =>
         navigate({
-          to: '/organization/$organizationId/project/$projectId/environment/$environmentId/service/new',
+          to: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations',
           params: { organizationId, projectId, environmentId },
         })
       }

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments.tsx
@@ -1,5 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { PageSettingsPreviewEnvironmentsFeature } from '@qovery/domains/environments/feature'
+import { Navigate, createFileRoute, useParams } from '@tanstack/react-router'
 
 export const Route = createFileRoute(
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/preview-environments'
@@ -8,5 +7,12 @@ export const Route = createFileRoute(
 })
 
 function RouteComponent() {
-  return <PageSettingsPreviewEnvironmentsFeature />
+  const { organizationId = '', projectId = '', environmentId = '' } = useParams({ strict: false })
+  return (
+    <Navigate
+      to="/organization/$organizationId/project/$projectId/environment/$environmentId/automations/settings/preview-environments"
+      params={{ organizationId, projectId, environmentId }}
+      replace
+    />
+  )
 }

--- a/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings/route.tsx
@@ -17,25 +17,13 @@ function RouteComponent() {
     icon: 'gear' as const,
   }
 
-  const deploymentRulesLink = {
-    title: 'Deployment rules',
-    to: `${pathSettings}/deployment-rules`,
-    icon: 'browsers' as const,
-  }
-
-  const previewEnvironmentsLink = {
-    title: 'Preview environments',
-    to: `${pathSettings}/preview-environments`,
-    icon: 'eye' as const,
-  }
-
   const dangerZoneLink = {
     title: 'Danger zone',
     to: `${pathSettings}/danger-zone`,
     icon: 'skull' as const,
   }
 
-  const LINKS_SETTINGS = [generalLink, deploymentRulesLink, previewEnvironmentsLink, dangerZoneLink]
+  const LINKS_SETTINGS = [generalLink, dangerZoneLink]
 
   return (
     <div className="flex min-h-0 flex-1">

--- a/apps/console/src/routes/_authenticated/organization/route.tsx
+++ b/apps/console/src/routes/_authenticated/organization/route.tsx
@@ -152,6 +152,12 @@ const ENVIRONMENT_TABS: NavigationTab[] = [
     routeId: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/variables',
   },
   {
+    id: 'automations',
+    label: 'Automations',
+    iconName: 'stopwatch',
+    routeId: '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations',
+  },
+  {
     id: 'settings',
     label: 'Settings',
     iconName: 'gear-complex',
@@ -372,9 +378,11 @@ function useNavigationContext(): NavigationContext | null {
         const tabs =
           context.type === 'service'
             ? getServiceTabs(service, currentCluster, isAgenticWorkflowEnabled)
-            : context.type === 'organization'
-              ? context.tabs.filter((tab) => hasAlerting || tab.id !== 'alerts')
-              : context.tabs
+            : context.type === 'environment'
+              ? context.tabs.filter((tab) => isAgenticWorkflowEnabled || tab.id !== 'automations')
+              : context.type === 'organization'
+                ? context.tabs.filter((tab) => hasAlerting || tab.id !== 'alerts')
+                : context.tabs
 
         return {
           type: context.type,
@@ -474,6 +482,7 @@ const fullWidthRouteIds: FileRouteTypes['id'][] = [
   '/_authenticated/organization/$organizationId/cluster/$clusterId/settings',
   '/_authenticated/organization/$organizationId/project/$projectId/settings',
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/settings',
+  '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/automations',
   '/_authenticated/organization/$organizationId/settings',
   '/_authenticated/organization/$organizationId/audit-logs',
   '/_authenticated/organization/$organizationId/project/$projectId/environment/$environmentId/service/$serviceId/monitoring',

--- a/libs/domains/services/feature/src/index.ts
+++ b/libs/domains/services/feature/src/index.ts
@@ -124,6 +124,7 @@ export * from './lib/service-creation-flow/agentic-workflow/agentic-workflow-con
 export * from './lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/mcp/mcp-sheet'
 export * from './lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/git-repository-card'
 export * from './lib/service-creation-flow/agentic-workflow/agentic-workflow-request'
+export * from './lib/agentic-workflow-use-cases/agentic-workflow-use-cases'
 export * from './lib/application-container-healthchecks/application-container-healthchecks-form/application-container-healthchecks-form'
 export * from './lib/application-container-healthchecks/healthchecks-utils'
 export * from './lib/application-container-healthchecks/step-healthchecks/step-healthchecks'

--- a/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-service-list/agentic-workflow-service-list.tsx
@@ -83,10 +83,8 @@ export function AgenticWorkflowServiceList({ environment }: AgenticWorkflowServi
   return (
     <Section className="flex flex-col gap-3.5">
       <div className="flex flex-col gap-1">
-        <Heading level={3} className="font-medium text-neutral-subtle">
-          Agent tasks
-        </Heading>
-        <p className="text-sm text-neutral-subtle">One-time tasks delegated to AI agents.</p>
+        <Heading level={2}>Agent tasks</Heading>
+        <p className="text-sm leading-5 text-neutral-subtle">One-time tasks delegated to AI agents.</p>
       </div>
 
       <div className="flex flex-col overflow-hidden rounded-lg border border-neutral">

--- a/libs/domains/services/feature/src/lib/agentic-workflow-use-cases/agentic-workflow-use-cases.spec.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-use-cases/agentic-workflow-use-cases.spec.tsx
@@ -1,0 +1,91 @@
+import posthog from 'posthog-js'
+import { type ReactNode } from 'react'
+import { renderWithProviders, screen } from '@qovery/shared/util-tests'
+import { AgenticWorkflowUseCases } from './agentic-workflow-use-cases'
+
+const mockShowPylonForm = jest.fn()
+
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+
+jest.mock('@qovery/shared/util-hooks', () => ({
+  useSupportChat: () => ({ showPylonForm: mockShowPylonForm }),
+}))
+
+jest.mock('@qovery/shared/ui', () => {
+  const actual = jest.requireActual('@qovery/shared/ui')
+
+  return {
+    ...actual,
+    Link: ({
+      children,
+      search,
+      to,
+      ...props
+    }: {
+      children: ReactNode
+      search?: Record<string, string>
+      to: string
+    }) => {
+      const query = search ? `?${new URLSearchParams(search).toString()}` : ''
+      return (
+        <a href={`${to}${query}`} {...props}>
+          {children}
+        </a>
+      )
+    },
+  }
+})
+
+describe('AgenticWorkflowUseCases', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should expose agent task templates from the automation area', async () => {
+    const { userEvent } = renderWithProviders(
+      <AgenticWorkflowUseCases organizationId="org-1" projectId="project-1" environmentId="env-1" />
+    )
+
+    expect(screen.getByText('Incident Analyser')).toBeInTheDocument()
+    const [incidentAnalyser] = screen.getAllByRole('link', { name: /Use template/i })
+    expect(incidentAnalyser).toHaveAttribute(
+      'href',
+      '/organization/org-1/project/project-1/environment/env-1/service/create/agentic-workflow?template=incident-analyser'
+    )
+    expect(screen.getByText('Start from scratch')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Configure manually/i })).toBeInTheDocument()
+
+    await userEvent.click(incidentAnalyser)
+    expect(posthog.capture).toHaveBeenCalledWith('select-agent-use-case', { agentUseCase: 'incident-analyser' })
+  })
+
+  it('should open support from the custom agent action', async () => {
+    const { userEvent } = renderWithProviders(
+      <AgenticWorkflowUseCases organizationId="org-1" projectId="project-1" environmentId="env-1" />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /Contact us/i }))
+
+    expect(mockShowPylonForm).toHaveBeenCalledWith('request-ai-builder-portal')
+  })
+
+  it('should expose the use cases from a create menu', async () => {
+    const { userEvent } = renderWithProviders(
+      <AgenticWorkflowUseCases organizationId="org-1" projectId="project-1" environmentId="env-1" display="menu" />
+    )
+
+    expect(screen.getByRole('button', { name: /Need a specific agent/i })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /Create agent task/i }))
+
+    expect(screen.getByRole('menuitem', { name: /Incident Analyser/i })).toHaveAttribute(
+      'href',
+      '/organization/org-1/project/project-1/environment/env-1/service/create/agentic-workflow?template=incident-analyser'
+    )
+    expect(screen.getByRole('menuitem', { name: /Manual/i })).toHaveAttribute(
+      'href',
+      '/organization/org-1/project/project-1/environment/env-1/service/create/agentic-workflow'
+    )
+    expect(screen.queryByRole('menuitem', { name: /Start from scratch/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /Need a specific agent/i })).not.toBeInTheDocument()
+  })
+})

--- a/libs/domains/services/feature/src/lib/agentic-workflow-use-cases/agentic-workflow-use-cases.tsx
+++ b/libs/domains/services/feature/src/lib/agentic-workflow-use-cases/agentic-workflow-use-cases.tsx
@@ -1,0 +1,164 @@
+import posthog from 'posthog-js'
+import { type CloudProviderEnum } from 'qovery-typescript-axios'
+import { cloneElement } from 'react'
+import { Button, DropdownMenu, Heading, Icon, Link, Section } from '@qovery/shared/ui'
+import { useSupportChat } from '@qovery/shared/util-hooks'
+import { AGENTIC_WORKFLOW_TEMPLATES } from '../service-creation-flow/agentic-workflow/agentic-workflow-templates'
+import { type ServiceBlock } from '../service-new/service-card/service-card'
+import { getServicesPath } from '../service-new/service-new-utils/service-new-utils'
+
+export interface AgenticWorkflowUseCasesProps {
+  cloudProvider?: CloudProviderEnum | string
+  display?: 'cards' | 'menu'
+  environmentId: string
+  organizationId: string
+  projectId: string
+}
+
+function AgenticWorkflowUseCaseCard({ useCase, actionLabel }: { useCase: ServiceBlock; actionLabel: string }) {
+  return (
+    <section className="flex h-full flex-col gap-4 rounded-lg border border-neutral bg-surface-neutral p-4 [box-shadow:0px_0px_4px_0px_rgba(0,0,0,0.01),0px_2px_3px_0px_rgba(0,0,0,0.02)]">
+      <div className="flex flex-1 flex-col gap-3">
+        <span className="flex h-9 w-9 items-center justify-center rounded-md bg-surface-neutral-component text-neutral">
+          <span className="flex h-4 w-4 items-center justify-center leading-none">
+            {cloneElement(useCase.icon, { width: 16, height: 16, className: 'block h-4 w-4' })}
+          </span>
+        </span>
+        <div className="flex flex-col gap-1">
+          <Heading level={3}>{useCase.title}</Heading>
+          <p className="text-sm leading-5 text-neutral-subtle">{useCase.description}</p>
+        </div>
+      </div>
+      <div className="mt-auto flex items-center gap-1">
+        {useCase.link ? (
+          <Link
+            as="button"
+            variant="outline"
+            color="neutral"
+            size="sm"
+            // @ts-expect-error-next-line TODO new-nav: Route strings need to use typed routes
+            to={useCase.link}
+            search={useCase.search}
+            onClick={useCase.onClick}
+          >
+            {actionLabel}
+          </Link>
+        ) : useCase.onClick ? (
+          <Button type="button" variant="outline" color="neutral" size="sm" onClick={useCase.onClick}>
+            {actionLabel}
+          </Button>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+export function AgenticWorkflowUseCases({
+  cloudProvider,
+  display = 'cards',
+  environmentId,
+  organizationId,
+  projectId,
+}: AgenticWorkflowUseCasesProps) {
+  const { showPylonForm } = useSupportChat()
+  const createPath = getServicesPath(organizationId, projectId, environmentId, '/service/create/agentic-workflow')
+  const useCases: ServiceBlock[] = [
+    ...AGENTIC_WORKFLOW_TEMPLATES.map((template) => ({
+      title: template.title,
+      description: template.description,
+      icon: <Icon iconName={template.iconName} iconStyle="regular" />,
+      link: createPath,
+      search: { template: template.id },
+      onClick: () => posthog.capture('select-agent-use-case', { agentUseCase: template.id }),
+      cloud_provider: cloudProvider,
+    })),
+    {
+      title: 'Start from scratch',
+      description: 'Start with a blank agent task and configure everything yourself.',
+      icon: <Icon iconName="circle-plus" iconStyle="regular" />,
+      link: createPath,
+      onClick: () => posthog.capture('select-agent-use-case', { agentUseCase: 'from-scratch' }),
+      cloud_provider: cloudProvider,
+    },
+    {
+      title: 'Need a specific agent? Contact us',
+      description: 'Tell us which agent use case you need and we will help you set it up.',
+      icon: <Icon iconName="circle-question" iconStyle="regular" />,
+      onClick: () => showPylonForm('request-ai-builder-portal'),
+    },
+  ]
+
+  if (display === 'menu') {
+    const creationUseCases = useCases.slice(0, -1).map((useCase) =>
+      useCase.title === 'Start from scratch'
+        ? {
+            ...useCase,
+            title: 'Manual',
+            description: 'Configure an agent task without using a template.',
+          }
+        : useCase
+    )
+    const customUseCase = useCases.at(-1)
+
+    return (
+      <div className="flex shrink-0 items-center gap-2">
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <Button size="md">
+              <Icon iconName="circle-plus" iconStyle="regular" />
+              Create agent task
+              <Icon iconName="chevron-down" />
+            </Button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content align="end" className="w-80">
+            {creationUseCases.map((useCase) =>
+              useCase.link ? (
+                <DropdownMenu.Item key={useCase.title} asChild color="neutral" className="h-auto items-start py-2.5">
+                  {/* @ts-expect-error-next-line TODO new-nav: Route strings need to use typed routes */}
+                  <Link to={useCase.link} search={useCase.search} onClick={useCase.onClick}>
+                    {cloneElement(useCase.icon, { className: 'mr-3 mt-0.5 min-w-5 text-base text-neutral-subtle' })}
+                    <span className="flex min-w-0 flex-col gap-0.5">
+                      <span className="text-sm font-medium text-neutral">{useCase.title}</span>
+                      <span className="text-xs font-normal leading-4 text-neutral-subtle">{useCase.description}</span>
+                    </span>
+                  </Link>
+                </DropdownMenu.Item>
+              ) : null
+            )}
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+        {customUseCase ? (
+          <Button size="md" color="neutral" variant="outline" onClick={customUseCase.onClick}>
+            Need a specific agent?
+          </Button>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <Section className="gap-4">
+      <div className="flex flex-col gap-1">
+        <Heading level={2}>Create an agent task</Heading>
+        <p className="text-sm leading-5 text-neutral-subtle">
+          Start from a ready-made agent configuration and adjust it to your needs.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {useCases.map((useCase) => (
+          <AgenticWorkflowUseCaseCard
+            key={useCase.title}
+            useCase={useCase}
+            actionLabel={
+              useCase.title === 'Start from scratch'
+                ? 'Configure manually'
+                : useCase.link
+                  ? 'Use template'
+                  : 'Contact us'
+            }
+          />
+        ))}
+      </div>
+    </Section>
+  )
+}

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/agentic-workflow-configuration.tsx
@@ -437,7 +437,7 @@ export function AgenticWorkflowConfiguration() {
 
       posthog.capture('create-service', { selectedServiceType: 'agentic-workflow' })
       navigate({
-        to: '/organization/$organizationId/project/$projectId/environment/$environmentId/overview',
+        to: '/organization/$organizationId/project/$projectId/environment/$environmentId/automations',
         params: { organizationId, projectId, environmentId },
       })
     } catch {

--- a/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.spec.tsx
@@ -1,5 +1,4 @@
 import { within } from '@testing-library/react'
-import posthog from 'posthog-js'
 import type { BlueprintItem } from 'qovery-typescript-axios'
 import type { ReactNode } from 'react'
 import { renderWithProviders, screen, waitFor } from '@qovery/shared/util-tests'
@@ -18,10 +17,6 @@ const mockGetLinkHref = (to?: string, params?: Record<string, string>) =>
 jest.mock('@tanstack/react-router', () => ({
   ...jest.requireActual('@tanstack/react-router'),
   useParams: () => ({ organizationId: 'org-1', projectId: 'project-1', environmentId: 'env-1' }),
-}))
-
-jest.mock('posthog-js', () => ({
-  capture: jest.fn(),
 }))
 
 jest.mock('posthog-js/react', () => ({
@@ -104,7 +99,6 @@ describe('ServiceNew', () => {
   beforeEach(() => {
     mockUseFeatureFlagEnabled.mockReturnValue(false)
     mockShowPylonForm.mockClear()
-    ;(posthog.capture as jest.Mock).mockClear()
     mockUseBlueprintCatalog.mockReturnValue({ data: undefined })
     mockUseBlueprintCatalogServiceReadme.mockReturnValue({
       data: blueprintReadmeResponse,
@@ -142,68 +136,16 @@ describe('ServiceNew', () => {
     expect(screen.queryByText('Agent task')).not.toBeInTheDocument()
   })
 
-  it('should render the from-scratch agent task entry in Agent use cases when the flag is enabled', () => {
+  it('should not render agent task entries when the feature flag is enabled', () => {
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'argentic-workflow')
 
-    renderWithProviders(
-      <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
-    )
-
-    // The blank agent task entry lives in Agent use cases, not Base services.
-    const baseServices = screen.getByRole('heading', { name: 'Base services' }).closest('section')
-    expect(within(baseServices as HTMLElement).queryByText(/Agent task/i)).not.toBeInTheDocument()
-
-    expect(screen.getByRole('link', { name: /Start from scratch/i })).toHaveAttribute(
-      'href',
-      '/organization/org-1/project/project-1/environment/env-1/service/create/agentic-workflow'
-    )
-  })
-
-  it('should render the Agent use cases section behind the agentic workflow flag', () => {
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'argentic-workflow')
-
-    renderWithProviders(
-      <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
-    )
-
-    expect(screen.getByRole('heading', { name: 'Agent use cases' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Incident Analyser/i })).toHaveAttribute(
-      'href',
-      '/organization/org-1/project/project-1/environment/env-1/service/create/agentic-workflow?template=incident-analyser'
-    )
-  })
-
-  it('should capture a PostHog event when an agent use case is selected', async () => {
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'argentic-workflow')
-
-    const { userEvent } = renderWithProviders(
-      <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
-    )
-
-    await userEvent.click(screen.getByRole('link', { name: /Incident Analyser/i }))
-
-    expect(posthog.capture).toHaveBeenCalledWith('select-agent-use-case', { agentUseCase: 'incident-analyser' })
-  })
-
-  it('should open the Pylon contact form from the Agent use cases CTA card', async () => {
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) => flag === 'argentic-workflow')
-
-    const { userEvent } = renderWithProviders(
-      <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
-    )
-
-    await userEvent.click(screen.getByRole('button', { name: /Need a specific agent/i }))
-
-    expect(mockShowPylonForm).toHaveBeenCalledWith('request-ai-builder-portal')
-  })
-
-  it('should hide the Agent use cases section when the agentic workflow flag is disabled', () => {
     renderWithProviders(
       <ServiceNew organizationId="org-1" projectId="project-1" environmentId="env-1" availableTemplates={[]} />
     )
 
     expect(screen.queryByRole('heading', { name: 'Agent use cases' })).not.toBeInTheDocument()
     expect(screen.queryByText('Incident Analyser')).not.toBeInTheDocument()
+    expect(screen.queryByText('Start from scratch')).not.toBeInTheDocument()
   })
 
   it('should show base service descriptions in info tooltips', async () => {

--- a/libs/domains/services/feature/src/lib/service-new/service-new.tsx
+++ b/libs/domains/services/feature/src/lib/service-new/service-new.tsx
@@ -1,5 +1,4 @@
 import { useParams } from '@tanstack/react-router'
-import posthog from 'posthog-js'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import {
   type BlueprintItem,
@@ -13,7 +12,6 @@ import { BlueprintDetailsPanel } from '../blueprint-details-panel/blueprint-deta
 import { BlueprintQueryBoundary } from '../blueprint-query-boundary/blueprint-query-boundary'
 import { isBlueprintCompatibleWithCluster } from '../blueprint-utils/blueprint-utils'
 import { useBlueprintCatalog } from '../hooks/use-blueprint-catalog/use-blueprint-catalog'
-import { AGENTIC_WORKFLOW_TEMPLATES } from '../service-creation-flow/agentic-workflow/agentic-workflow-templates'
 import { BlueprintCard } from './blueprint-card/blueprint-card'
 import { BlueprintMissingModal } from './blueprint-missing-modal/blueprint-missing-modal'
 import { BaseServiceCard, Card, CardService, SectionByTag, type ServiceBlock } from './service-card/service-card'
@@ -188,7 +186,6 @@ export function ServiceNew({
 }: ServiceNewProps) {
   const isTerraformFeatureFlag = Boolean(useFeatureFlagEnabled('terraform'))
   const isServiceCatalogEnabled = Boolean(useFeatureFlagEnabled('service-catalog'))
-  const isAgenticWorkflowEnabled = Boolean(useFeatureFlagEnabled('argentic-workflow'))
   const { showPylonForm } = useSupportChat()
 
   const serviceEmpty: ServiceBlock[] = useMemo(
@@ -263,49 +260,6 @@ export function ServiceNew({
     [cloudProvider, environmentId, isTerraformFeatureFlag, organizationId, projectId, showPylonForm]
   )
 
-  const agentUseCases: ServiceBlock[] = useMemo(
-    () => [
-      ...AGENTIC_WORKFLOW_TEMPLATES.map((template) => ({
-        title: template.title,
-        description: template.description,
-        // BaseServiceCard overrides the icon className with a 20x20 box, so center
-        // the glyph via inline style (not overridden) and size/color the inner Icon.
-        icon: (
-          <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Icon iconName={template.iconName} iconStyle="regular" className="text-base text-[color:var(--brand-9)]" />
-          </span>
-        ),
-        link: getServicesPath(organizationId, projectId, environmentId, '/service/create/agentic-workflow'),
-        search: { template: template.id },
-        onClick: () => posthog.capture('select-agent-use-case', { agentUseCase: template.id }),
-        cloud_provider: cloudProvider,
-      })),
-      {
-        title: 'Start from scratch',
-        description: 'Start with a blank agent task and configure everything yourself.',
-        icon: (
-          <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Icon iconName="circle-plus" iconStyle="regular" className="text-base text-[color:var(--brand-9)]" />
-          </span>
-        ),
-        link: getServicesPath(organizationId, projectId, environmentId, '/service/create/agentic-workflow'),
-        onClick: () => posthog.capture('select-agent-use-case', { agentUseCase: 'from-scratch' }),
-        cloud_provider: cloudProvider,
-      },
-      {
-        title: 'Need a specific agent? Contact us',
-        description: 'Tell us which agent use case you need and we will help you set it up.',
-        icon: (
-          <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Icon iconName="paper-plane" iconStyle="regular" className="text-base text-[color:var(--brand-9)]" />
-          </span>
-        ),
-        onClick: () => showPylonForm('request-ai-builder-portal'),
-      },
-    ],
-    [cloudProvider, environmentId, organizationId, projectId, showPylonForm]
-  )
-
   const [blueprintSearchInput, setBlueprintSearchInput] = useState('')
   const [selectedBlueprint, setSelectedBlueprint] = useState<BlueprintItem | null>(null)
   const [isBlueprintDetailsOpen, setIsBlueprintDetailsOpen] = useState(false)
@@ -332,21 +286,6 @@ export function ServiceNew({
           </div>
         </Section>
 
-        {isAgenticWorkflowEnabled && agentUseCases.length > 0 && (
-          <Section className="gap-4">
-            <div className="flex flex-col gap-1">
-              <Heading>Agent use cases</Heading>
-              <p className="text-sm leading-5 text-neutral-subtle">
-                Start from a ready-made agent configuration and adjust it to your needs.
-              </p>
-            </div>
-            <div className="grid grid-cols-3 gap-3">
-              {agentUseCases.map((useCase) => (
-                <BaseServiceCard key={useCase.title} {...useCase} />
-              ))}
-            </div>
-          </Section>
-        )}
         {isServiceCatalogEnabled && (
           <BlueprintQueryBoundary
             errorFallback={BlueprintSectionErrorFallback}


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

Add an environment-level Automations area to make Agent Tasks easier to discover and manage. Move Agent Task creation and listing out of Create Service and expose Runs, Deployment rules, and Preview environments in the same navigation area while preserving redirects from the previous Settings routes.

## Screenshots / Recordings

Not applicable.

## Testing

- [x] Changes tested locally in the relevant Console pages
- [x] Targeted Jest suites (21 tests)
- [x] Formatting and pre-commit checks
- [x] ESLint on affected source files (one existing hook dependency warning)

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English
- [x] I involved a designer to validate UI changes if I am not a designer
- [x] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [x] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an environment-level Automations area so Agent Tasks are easier to discover and manage. Agent Task creation and listing move out of Create Service and the Overview page, and the new area also hosts Runs, Deployment rules, and Preview environments.

- The Automations sidebar groups Agent tasks (General, Runs) and Environment (Deployment rules, Preview environments).
- Agent task templates render from a shared `AgenticWorkflowUseCases` component in card and menu layouts, keeping PostHog events intact.
- The previous `/settings/deployment-rules` and `/settings/preview-environments` routes redirect to `automations/settings/*`; the Settings sidebar no longer shows those links.
- The Automations tab only appears when the `argentic-workflow` flag is enabled.
- Agent workflow creation now returns to the Automations area instead of Overview.
- The environment header shows the agent task count, and the Overview page no longer lists agent tasks.

<sup>Written for commit 684c45b861cd77ba9e4e9891569d79f9b4e5b7e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

