### PR TITLE
chore(readme): refresh development and contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,135 @@
-<br  />
-
-<p  align="center">
-
-<a  href="https://qovery.com"  target="_blank">
-
-<img  style="display: block; margin: auto; width: 350px;"  src="https://console.qovery.com/assets/logos/logo-white-on-brand.svg">
-</a>
-</p>
-
-<h3 align="center"><a href="https://console.qovery.com">Web Console</a></h3>
-<p align="center">Website: <a href="https://www.qovery.com">https://www.qovery.com</a></p>
-
 <p align="center">
-<a href="https://opensource.org/licenses"><img alt="GPLv3 License" src="https://img.shields.io/badge/License-GPL%20v3-yellow.svg"></a>
-<a href="https://codecov.io/github/Qovery/console" >
-<img src="https://codecov.io/github/Qovery/console/branch/feat/ci-codecov/graph/badge.svg?token=O8SMO6PEQV"/>
-</a>
+  <a href="https://qovery.com">
+    <img width="350" src="https://console.qovery.com/assets/logos/logo-white-on-brand.svg" alt="Qovery" />
+  </a>
 </p>
 
-<p align="center">
-    At Qovery for our Console, we use a couple of technologies, like <a href="https://nx.dev" target="_blank">Nx</a>, <a href="https://reactjs.org" target="_blank">React</a>, <a href="https://tanstack.com/query/v3/" target="_blank">React Query</a>, <a href="https://tailwindcss.com" target="_blank">Tailwind</a>, and <a href="https://storybook.js.org" target="_blank">Storybook</a>.
-</p>
-<br />
+<h3 align="center"><a href="https://console.qovery.com">Qovery Console</a></h3>
+<p align="center">The web interface for managing your infrastructure, applications, and deployments with Qovery.</p>
 
-## Getting Started
+## Development stack
 
-First use
+The Console is a TypeScript and React application in an Nx monorepo. It uses Vite for development and builds, TanStack Router for file-based routing, TanStack Query (React Query) for server state, and Tailwind CSS with Radix UI for the interface. Shared UI components are developed in Storybook; Jest and Playwright cover unit and end-to-end tests.
 
-    yarn && yarn setup
+See [package.json](./package.json) for the versions and available scripts.
 
-### Environment variables
+## Getting started
 
-By default, the Console loads its environment variables from the repository's `.env` file. To share one environment configuration across Git worktrees, move the file to a stable directory and pass that directory when starting the Console:
+### Prerequisites
 
-    QOVERY_CONSOLE_ENV_DIR="$HOME/.config/qovery-console" yarn start
+- **Node.js 23**, matching the repository's development guidelines and CI. With nvm, run `nvm install 23` and `nvm use 23`.
+- **Yarn Berry**. Enable Yarn with `corepack enable`; the repository pins its Yarn release in [.yarnrc.yml](./.yarnrc.yml). Use Yarn for dependency management and commands.
+- Access to the package registry configured in `.yarnrc.yml` (`https://npm-registry.qovery.com`). If dependency installation fails with an access error, ask the maintainers about registry access.
 
-Vite loads `.env`, `.env.local`, and mode-specific environment files from that directory. When `QOVERY_CONSOLE_ENV_DIR` is not set, the repository root remains the default.
+### Install and run
 
-Start the project on http://localhost:4200
+```sh
+git clone https://github.com/Qovery/console.git
+cd console
+git switch staging
+yarn install
+yarn setup
+yarn start
+```
 
-    yarn start
+Open [localhost:4200](http://localhost:4200).
 
-Start Storybook on http://localhost:4400
+`yarn setup` runs [s.sh](./s.sh), which appends default configuration to a root `.env` file. Run it once for a fresh checkout; review an existing `.env` before rerunning it to avoid duplicate entries. The defaults point to the production Qovery API and authentication service, so you need a Qovery account to use authenticated pages. Local development does not start a backend.
 
-    yarn storybook
+### Environment configuration
 
-Run tests
+The Console reads `.env` files from the repository root by default. The setup script provides the initial `NX_PUBLIC_*` values for API, WebSocket, authentication, and integrations. Review these values when targeting a different environment. Values loaded by the [Vite configuration](./apps/console/vite.config.ts) are exposed to the browser; do not put server-side secrets in these files.
 
-    yarn test
+To reuse an existing environment configuration across Git worktrees, place the `.env` file in a stable directory and start the Console with:
 
-Generate a library
+```sh
+QOVERY_CONSOLE_ENV_DIR="$HOME/.config/qovery-console" yarn start
+```
 
-    nx g @nx/react:lib my-lib
+That directory must already contain your configuration. Vite loads `.env`, `.env.local`, and mode-specific environment files from it. Without `QOVERY_CONSOLE_ENV_DIR`, the repository root remains the default. `yarn setup` always writes to the current directory's `.env`, regardless of this setting.
 
-Generate a component
+## Development commands
 
-    nx g @nx/react:component my-component
+Run commands from the repository root.
 
-Run unit tests with Jest
+| Command                | Purpose                                              |
+| ---------------------- | ---------------------------------------------------- |
+| `yarn start`           | Start the Console at `http://localhost:4200`         |
+| `yarn storybook`       | Start shared UI Storybook at `http://localhost:4400` |
+| `yarn build:console`   | Build the Console into `dist/apps/console`           |
+| `yarn build-storybook` | Build Storybook into `dist/storybook/design-system`  |
+| `yarn test`            | Run unit tests across all projects                   |
+| `yarn lint`            | Lint all projects                                    |
+| `yarn format:check`    | Check formatting with Nx                             |
+| `yarn format`          | Apply formatting with Nx                             |
+| `yarn nx graph`        | Explore project dependencies                         |
 
-    nx affected:test
+For a focused change, target a project or only projects affected by your branch:
 
-Run end-to-end tests with Playwright
+```sh
+yarn nx test shared-ui
+yarn nx lint shared-ui
+yarn nx affected -t test --base=origin/staging
+yarn nx affected -t lint --base=origin/staging
+```
 
-    nx affected:e2e
+Generate libraries and components with the local Nx CLI:
+
+```sh
+yarn nx generate @nx/react:library --help
+yarn nx generate @nx/react:component --help
+```
+
+### End-to-end tests
+
+The Playwright smoke test runs against [Console staging](https://console-staging.qovery.com) by default. It requires `E2E_AUTH_TOKEN`, `E2E_PROJECT_ID`, and `E2E_ENVIRONMENT_ID` in the shell environment, with access to the target project and environment. Ask the maintainers for the test environment configuration.
+
+```sh
+yarn playwright install chromium
+yarn e2e:staging
+```
+
+Set `E2E_BASE_URL` to target another running Console instance. The test runner does not start a local server. See the [Playwright configuration](./apps/console-e2e/playwright.config.ts) and [smoke test](./apps/console-e2e/src/staging-smoke.spec.ts) for details.
+
+## Project structure
+
+```text
+apps/
+├── console/
+│   └── src/routes/         # File-based application routes
+└── console-e2e/            # Playwright smoke tests
+
+libs/
+├── domains/                # Domain features and data access
+├── shared/                 # Shared UI, authentication, routing, and utilities
+│   ├── ui/                 # Reusable components and Storybook
+│   ├── util-js/            # Shared JavaScript utilities
+│   └── util-tests/         # Test helpers and providers
+└── state/
+    └── util-queries/       # Shared query state and API access
+
+adr/                        # Architecture decision records
+```
+
+Nx manages project dependencies and provides project-level build, test, lint, and generation commands. Use `yarn nx graph` to inspect the relationships between libraries.
+
+Architecture decisions live in [adr/](./adr). Read the relevant decisions and [contribution guidelines](./.agents/skills/qovery-console-standards/SKILL.md) before changing project boundaries or shared patterns.
 
 ## Contributing
 
-Qovery Console is actively developed and we need some help, you are welcome to contribute! You can propose improvements directly from the [issues](https://github.com/Qovery/console/issues) page or include them in your pull request for changes.
+Bug reports and improvements are welcome through [GitHub issues](https://github.com/Qovery/console/issues) and pull requests.
 
-## Architecture Decision Records
+1. Create your branch from the latest `staging` and keep changes focused.
+2. Follow the [repository guide](./AGENTS.md) and relevant skills in [.agents/skills/](./.agents/skills/).
+3. Format your changes, run the relevant tests, review any snapshot changes, and lint the affected projects.
+4. Open a pull request targeting `staging`, using the [PR template](./pull_request_template.md). Use a Conventional Commit title such as `fix(service): correct deployment status`.
 
-We try to document our architecture decisions using [Architecture Decision Record](https://github.com/joelparkerhenderson/architecture-decision-record) principle.
-You can find our [ADR documents here](https://github.com/Qovery/console/tree/staging/adr) and the template used follows [this one](https://github.com/joelparkerhenderson/architecture-decision-record/tree/ab49e5ecad09b0e80c6ebeaf4f41c7958a2ad291/locales/en/templates/decision-record-template-by-michael-nygard)
+## Community and support
 
-## Community support
+- [Qovery forum](https://discuss.qovery.com/) — questions and discussions.
+- [GitHub issues](https://github.com/Qovery/console/issues) — bug reports and feature requests.
+- [Qovery website](https://www.qovery.com) — product information.
 
-For help, you can use one of the channels to ask a question:
+## License
 
-- [Forum](https://discuss.qovery.com/): (Bug reports, Questions)
-- [GitHub](https://github.com/Qovery/console): (Bug reports, Contributions)
-- [Twitter](https://twitter.com/qovery_): (Get the news fast)
-
-## FAQ
-
-### Why does Qovery exist?
-
-At Qovery, we believe that the Cloud must be simpler than what it is today. Our goal is to consolidate the Cloud ecosystem and makes it accessible to any developer, DevOps, and company. Qovery helps people to focus on what they build instead of wasting time doing plumbing stuff.
-
-### Why do we use Nx?
-
-- Nx acts as a robust framework, providing significant benefits for React applications.
-- It supports mono-repo architecture, allowing us to divide our application into multiple reusable entities/libraries.
-- It offers tools to generate components, libraries, applications, and to check the health of our applications (e.g., circular dependencies).
-- By using [Nx Cloud](https://cloud.nx.app/orgs/62aaef82e814d400050ea393/workspaces/635932a66ecea758758f0563/overview), we can cache deployments, run tests, and build only the modified parts of the application.
-- It provides a framework for unit tests with [Jest](https://jestjs.io/) and end-to-end tests with [Playwright](https://playwright.dev/).
-
-### How is the project structured?
-
-To help you navigate through the project, here is a brief overview of its structure.
-
-```
-apps/
-└── console/                # General application with main router and tools like PostHog, Sentry, etc.
-
-libs/
-├── domains/                # Domain-specific by features
-│   └── [feature-name]/
-│       ├── data-access/    # Data access layer for the feature
-│       └── feature/        # Core logic and components for the feature
-│       ...
-├── pages/                  # Page components for routing and layout, calling features from domain and common shared utilities and components
-└── shared/                 # Shared utilities and components across the application
-    ├── ui/                 # Storybook - UI components for reusable user interface elements
-    ├── util-[name]/        # Utility functions and helpers
-    └── util-queries/       # Shared utility functions for queries
-    ...
-```
-
-This organization aims to make the codebase more maintainable and understandable, based on our structure and Nx recommendations. For more information about it, read this article: [Organizing and Structuring a React Project with Nx](https://www.qovery.com/blog/nx-architecture-part-1-organizing-and-structuring-a-react-project-with-nx/).
+See [LICENSE](./LICENSE) for the GNU General Public License v3 terms.

--- a/README.md
+++ b/README.md
@@ -95,21 +95,33 @@ Set `E2E_BASE_URL` to target another running Console instance. The test runner d
 
 ```text
 apps/
-├── console/
-│   └── src/routes/         # File-based application routes
-└── console-e2e/            # Playwright smoke tests
+├── console/                    # Main application, entry point, and integrations
+│   └── src/
+│       ├── app/                # Application shell and providers
+│       ├── auth/               # Application authentication
+│       └── routes/             # File-based pages and layouts (TanStack Router)
+└── console-e2e/                # Playwright end-to-end smoke tests
 
 libs/
-├── domains/                # Domain features and data access
-├── shared/                 # Shared UI, authentication, routing, and utilities
-│   ├── ui/                 # Reusable components and Storybook
-│   ├── util-js/            # Shared JavaScript utilities
-│   └── util-tests/         # Test helpers and providers
+├── domains/                    # Business domains: services, environments, clusters, etc.
+│   └── [domain-name]/
+│       ├── data-access/        # Domain API access, types, and data hooks
+│       ├── feature/            # Business logic and feature components
+│       └── util/               # Domain-specific helpers, where needed
+├── shared/                     # Reusable components and cross-domain functionality
+│   ├── ui/                     # Shared UI components, styles, assets, and Storybook
+│   ├── auth/                   # Shared authentication logic
+│   ├── router/                 # Shared routing helpers
+│   ├── util-js/                # General JavaScript utilities
+│   ├── util-tests/             # Test helpers and providers
+│   └── util-[name]/            # Other focused utilities (dates, hooks, types, etc.)
 └── state/
-    └── util-queries/       # Shared query state and API access
+    └── util-queries/           # Shared query state and API access
 
-adr/                        # Architecture decision records
+adr/                            # Architecture decision records
 ```
+
+The tree shows the main layers; each domain only includes the libraries it needs. Route pages and layouts compose domain features and shared components.
 
 Nx manages project dependencies and provides project-level build, test, lint, and generation commands. Use `yarn nx graph` to inspect the relationships between libraries.
 

--- a/README.md
+++ b/README.md
@@ -15,38 +15,17 @@ See [package.json](./package.json) for the versions and available scripts.
 
 ## Getting started
 
-### Prerequisites
-
-- **Node.js 23**, matching the repository's development guidelines and CI. With nvm, run `nvm install 23` and `nvm use 23`.
-- **Yarn Berry**. Enable Yarn with `corepack enable`; the repository pins its Yarn release in [.yarnrc.yml](./.yarnrc.yml). Use Yarn for dependency management and commands.
-- Access to the package registry configured in `.yarnrc.yml` (`https://npm-registry.qovery.com`). If dependency installation fails with an access error, ask the maintainers about registry access.
-
-### Install and run
+First use
 
 ```sh
-git clone https://github.com/Qovery/console.git
-cd console
-git switch staging
-yarn install
-yarn setup
+yarn && yarn setup
+```
+
+Start the project on [localhost:4200](http://localhost:4200)
+
+```sh
 yarn start
 ```
-
-Open [localhost:4200](http://localhost:4200).
-
-`yarn setup` runs [s.sh](./s.sh), which appends default configuration to a root `.env` file. Run it once for a fresh checkout; review an existing `.env` before rerunning it to avoid duplicate entries. The defaults point to the production Qovery API and authentication service, so you need a Qovery account to use authenticated pages. Local development does not start a backend.
-
-### Environment configuration
-
-The Console reads `.env` files from the repository root by default. The setup script provides the initial `NX_PUBLIC_*` values for API, WebSocket, authentication, and integrations. Review these values when targeting a different environment. Values loaded by the [Vite configuration](./apps/console/vite.config.ts) are exposed to the browser; do not put server-side secrets in these files.
-
-To reuse an existing environment configuration across Git worktrees, place the `.env` file in a stable directory and start the Console with:
-
-```sh
-QOVERY_CONSOLE_ENV_DIR="$HOME/.config/qovery-console" yarn start
-```
-
-That directory must already contain your configuration. Vite loads `.env`, `.env.local`, and mode-specific environment files from it. Without `QOVERY_CONSOLE_ENV_DIR`, the repository root remains the default. `yarn setup` always writes to the current directory's `.env`, regardless of this setting.
 
 ## Development commands
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Bug reports and improvements are welcome through [GitHub issues](https://github.
 
 ## Community and support
 
-- [Qovery forum](https://discuss.qovery.com/) — questions and discussions.
 - [GitHub issues](https://github.com/Qovery/console/issues) — bug reports and feature requests.
 - [Qovery website](https://www.qovery.com) — product information.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Qovery Console.

Before opening the PR:
- A JIRA ticket exists and you are assigned to it (unless it is a trivial fix)
- Changes were tested locally (app and/or Storybook as relevant)
- The code follows the rules under `.cursor/rules`
-->

## Summary

**Issue**: N/A — documentation maintenance.

The README described the old project layout and development stack. Refresh it against the current staging configuration while keeping the original short getting-started instructions.

- Keep setup concise with `yarn && yarn setup` and `yarn start`; remove the environment/worktree section.
- Replace the obsolete architecture tree with file-based routes, E2E tests, and `libs/state/util-queries`.
- Explain Playwright staging prerequisites and the contribution workflow; remove the obsolete feature-branch coverage badge and forum link.

## Screenshots / Recordings

<!--
| Before                              | After                      |
| ----------------------------------- | -------------------------- |
| drag & drop image optional | drag & drop image |
-->

## Testing

- Passed: `yarn prettier --check README.md`, `git diff --check`, and relative documentation link checks.
- Checked commands and configuration against package scripts, Nx project files, Vite, the setup script, and Playwright sources.
- `NX_NO_CLOUD=true NX_DAEMON=false NX_ISOLATE_PLUGINS=false yarn nx affected -t test lint --files=README.md --parallel=3` completed with no tasks to run. Nx Cloud was unavailable; the retry disabled cloud use.
- `yarn nx format:check --files=README.md` stalled while calculating the project graph and was stopped; direct Prettier validation passed instead.
- Documentation only: no application, E2E, or snapshot changes. App and E2E suites were not run.


- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

## PR Checklist

- [ ] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible (e.g. `feat(service): add new Terraform service`) - required for semantic-release
- [x] I only kept necessary comments, written in English (watch for useless AI comments)
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the README development and contribution guide so it reflects the current staging setup instead of the outdated project layout.

- Keeps getting started to `yarn && yarn setup` and `yarn start`, and documents the common development commands.
- Replaces the obsolete architecture tree with the current `apps/` and `libs/` layout covering file-based routes, E2E tests, and `libs/state/util-queries`.
- Adds Playwright staging prerequisites and the contribution workflow; removes the feature-branch coverage badge and forum link.

<sup>Written for commit 99b8b52af4c97b0bf64187524d76b9ae0a7415e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

