### PR TITLE
fix(agent-task): restore repo & branch when editing Git context

### DIFF
--- a/apps/console/public/changelog/latest.json
+++ b/apps/console/public/changelog/latest.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "Qovery Blueprints, Builders Portal improvements",
-    "summary": "Hey Team, AI agents are provisioning infrastructure now, not just writing code, spinning up a database or a full environment in seconds, faster than any ticket queue or manual review was built for. That leaves platform teams with the same old choice, hand-build every request or hand out raw access ...",
-    "url": "https://www.qovery.com/changelog/2026-07-29",
-    "firstPublishedAt": "2026-07-29T00:00:00.000Z"
+    "name": "API Policy Tokens, More Agent CLI Commands, Expanded Blueprint Catalog",
+    "summary": "Hey Team, This release ships API Policy Tokens, which let you define exactly what a token can do, action by action, instead of handing it a bundle of permissions and trusting it to only use the ones it needs. We are also extending the CLI with more agent-facing commands and adding a wave of new bl ...",
+    "url": "https://www.qovery.com/changelog/2026-08-26",
+    "firstPublishedAt": "2026-08-26T00:00:00.000Z"
   }
 ]

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-connections-settings/agentic-workflow-connections-settings.spec.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-connections-settings/agentic-workflow-connections-settings.spec.tsx
@@ -40,7 +40,7 @@ describe('AgenticWorkflowConnectionsSettings', () => {
           dockerFragment: 'RUN apt-get update',
         }}
       >
-        {(form) => <AgenticWorkflowConnectionsSettings form={form} />}
+        {(form) => <AgenticWorkflowConnectionsSettings form={form} gitTokensLoading={false} />}
       </AgenticWorkflowSettingsFormHarness>
     )
 

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-connections-settings/agentic-workflow-connections-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-connections-settings/agentic-workflow-connections-settings.tsx
@@ -16,8 +16,10 @@ import { AgenticWorkflowSettingsCard } from '../agentic-workflow-settings-card'
 
 export function AgenticWorkflowConnectionsSettings({
   form,
+  gitTokensLoading,
 }: {
   form: UseFormReturn<AgenticWorkflowSettingsFormValues>
+  gitTokensLoading: boolean
 }) {
   const { organizationId = '' } = useParams({ strict: false })
   const { data: mcpServers = [], isLoading } = useMcpServers({ organizationId })
@@ -76,6 +78,7 @@ export function AgenticWorkflowConnectionsSettings({
                 key={`${repository.repository}-${index}`}
                 provider={repository.provider}
                 repository={repository.gitRepository?.name ?? repository.repository}
+                disabled={gitTokensLoading && Boolean(repository.gitTokenId) && !repository.provider}
                 onClick={() => openGitContext(index)}
               />
             ))}

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.spec.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.spec.tsx
@@ -145,7 +145,7 @@ describe('AgenticWorkflowSettings views', () => {
     jest.useFakeTimers()
     editService.mockReset()
     useServiceSpy.mockReturnValue({ data: service })
-    useGitTokensSpy.mockReturnValue({ data: [{ id: 'token-1', type: 'GITHUB' }] })
+    useGitTokensSpy.mockReturnValue({ data: [{ id: 'token-1', type: 'GITHUB' }], isLoading: false })
     useMcpServersSpy.mockReturnValue({
       data: [{ id: 'mcp-1', name: 'Documentation', url: 'https://docs.example.com' }],
       isLoading: false,
@@ -236,6 +236,26 @@ describe('AgenticWorkflowSettings views', () => {
     expect(screen.getByRole('heading', { name: 'Connections' })).toBeInTheDocument()
     expect(screen.getByText('qovery/console')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Remove Documentation' })).toBeInTheDocument()
+  })
+
+  it('prevents editing a private self-hosted repository until its provider is resolved', () => {
+    useServiceSpy.mockReturnValue({
+      data: {
+        ...service,
+        project_repositories: [
+          {
+            url: 'https://gitlab.company.com/qovery/backend.git',
+            branch: 'main',
+            git_token_id: 'token-1',
+          },
+        ],
+      },
+    })
+    useGitTokensSpy.mockReturnValue({ data: undefined, isLoading: true })
+
+    renderWithProviders(<AgenticWorkflowSettings page="connections" />)
+
+    expect(screen.getByRole('button', { name: 'Manage context' })).toBeDisabled()
   })
 
   it('preserves malformed legacy MCP JSON without blocking Connections changes', async () => {

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.spec.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.spec.tsx
@@ -7,6 +7,7 @@ import {
   agenticWorkflowJsonValidation,
   formatAgenticWorkflowRepositories,
   getGitRepositoryName,
+  getGitRepositoryProvider,
 } from './agentic-workflow-settings'
 
 const useGitTokensSpy = jest.spyOn(organizationsDomain, 'useGitTokens') as jest.Mock
@@ -98,6 +99,21 @@ describe('Agentic Workflow settings validation', () => {
     ['qovery/console', 'qovery/console'],
   ])('normalizes the repository value displayed by Git settings', (url, expected) => {
     expect(getGitRepositoryName(url)).toBe(expected)
+  })
+
+  it('uses the Git token provider for a self-hosted repository', () => {
+    expect(
+      getGitRepositoryProvider('https://gitlab.company.com/qovery/backend.git', 'token-1', [
+        {
+          id: 'token-1',
+          name: 'Company GitLab',
+          type: 'GITLAB',
+          created_at: '2026-09-10T00:00:00Z',
+          associated_services_count: 1,
+          git_api_url: 'https://gitlab.company.com/api/v4',
+        },
+      ])
+    ).toBe('GITLAB')
   })
 
   it('uses the full repository URL in the edit payload', () => {

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
@@ -13,6 +13,7 @@ import {
 } from '@qovery/domains/services/feature'
 import { SettingsHeading } from '@qovery/shared/console-shared'
 import { Button, Section } from '@qovery/shared/ui'
+import { guessGitProvider } from '@qovery/shared/util-git'
 import { useDocumentTitle } from '@qovery/shared/util-hooks'
 import { AgenticWorkflowAdvancedSettings } from './agentic-workflow-advanced-settings/agentic-workflow-advanced-settings'
 import { AgenticWorkflowAiConfigurationSettings } from './agentic-workflow-ai-configuration-settings/agentic-workflow-ai-configuration-settings'
@@ -121,6 +122,7 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
           repositories: workflow.project_repositories.map(({ url, branch, git_token_id }) => {
             const name = getGitRepositoryName(url)
             return {
+              provider: guessGitProvider(url),
               repository: name,
               branch,
               gitTokenId: git_token_id,

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
@@ -1,6 +1,11 @@
 import { useParams } from '@tanstack/react-router'
-import { AgenticWorkflowExecutionMode, type AgenticWorkflowRequest } from 'qovery-typescript-axios'
+import {
+  AgenticWorkflowExecutionMode,
+  type AgenticWorkflowRequest,
+  type GitTokenResponse,
+} from 'qovery-typescript-axios'
 import { useForm } from 'react-hook-form'
+import { useGitTokens } from '@qovery/domains/organizations/feature'
 import { isAgenticWorkflow } from '@qovery/domains/services/data-access'
 import {
   type AgenticWorkflowAutomation,
@@ -84,6 +89,14 @@ export function getGitRepositoryName(url: string) {
   }
 }
 
+export function getGitRepositoryProvider(
+  url: string,
+  gitTokenId: string | null | undefined,
+  gitTokens: GitTokenResponse[]
+) {
+  return gitTokens.find(({ id }) => id === gitTokenId)?.type ?? guessGitProvider(url)
+}
+
 export function formatAgenticWorkflowRepositories(repositories: AgenticWorkflowGitRepository[]) {
   return repositories.map(({ repository, gitRepository, branch, gitTokenId }) => ({
     url: gitRepository?.url ?? repository,
@@ -108,6 +121,10 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
   const content = PAGE_CONTENT[page]
   useDocumentTitle(`${content.title} - Service settings`)
   const workflow = service && isAgenticWorkflow(service) ? service : undefined
+  const { data: gitTokens = [] } = useGitTokens({
+    organizationId,
+    enabled: page === 'connections' && workflow?.project_repositories.some(({ git_token_id }) => git_token_id != null),
+  })
   const form = useForm<AgenticWorkflowSettingsFormValues>({
     mode: 'onChange',
     values: workflow
@@ -122,7 +139,7 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
           repositories: workflow.project_repositories.map(({ url, branch, git_token_id }) => {
             const name = getGitRepositoryName(url)
             return {
-              provider: guessGitProvider(url),
+              provider: getGitRepositoryProvider(url, git_token_id, gitTokens),
               repository: name,
               branch,
               gitTokenId: git_token_id,

--- a/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
+++ b/libs/domains/service-settings/feature/src/lib/agentic-workflow-settings/agentic-workflow-settings.tsx
@@ -121,7 +121,7 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
   const content = PAGE_CONTENT[page]
   useDocumentTitle(`${content.title} - Service settings`)
   const workflow = service && isAgenticWorkflow(service) ? service : undefined
-  const { data: gitTokens = [] } = useGitTokens({
+  const { data: gitTokens = [], isLoading: gitTokensLoading } = useGitTokens({
     organizationId,
     enabled: page === 'connections' && workflow?.project_repositories.some(({ git_token_id }) => git_token_id != null),
   })
@@ -224,7 +224,9 @@ export function AgenticWorkflowSettings({ page }: AgenticWorkflowSettingsProps) 
         {page === 'ai-configuration' ? (
           <AgenticWorkflowAiConfigurationSettings environmentId={environmentId} form={form} />
         ) : null}
-        {page === 'connections' ? <AgenticWorkflowConnectionsSettings form={form} /> : null}
+        {page === 'connections' ? (
+          <AgenticWorkflowConnectionsSettings form={form} gitTokensLoading={gitTokensLoading} />
+        ) : null}
         {page === 'automations' ? <AgenticWorkflowAutomationsSettings form={form} /> : null}
         {page === 'governance' ? <AgenticWorkflowGovernanceSettings form={form} /> : null}
         {page === 'advanced-settings' ? <AgenticWorkflowAdvancedSettings form={form} /> : null}

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/context/git-context-card.spec.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/context/git-context-card.spec.tsx
@@ -37,4 +37,15 @@ describe('GitContextCompactCard', () => {
 
     expect(onClick).toHaveBeenCalled()
   })
+
+  it('prevents managing the context when disabled', async () => {
+    const onClick = jest.fn()
+    const { userEvent } = renderWithProviders(<GitContextCompactCard disabled repository="my-repo" onClick={onClick} />)
+
+    const manageButton = screen.getByRole('button', { name: 'Manage context' })
+    expect(manageButton).toBeDisabled()
+    await userEvent.click(manageButton)
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
 })

--- a/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/context/git-context-card.tsx
+++ b/libs/domains/services/feature/src/lib/service-creation-flow/agentic-workflow/agentic-workflow-configuration/context/git-context-card.tsx
@@ -28,10 +28,12 @@ export function GitContextCard({ onClick }: { onClick: () => void }) {
 }
 
 export function GitContextCompactCard({
+  disabled = false,
   onClick,
   provider,
   repository,
 }: {
+  disabled?: boolean
   onClick: () => void
   provider?: string | null
   repository: string
@@ -51,6 +53,7 @@ export function GitContextCompactCard({
         iconOnly
         aria-label="Manage context"
         className="absolute right-3 top-1/2 -translate-y-1/2"
+        disabled={disabled}
         onClick={onClick}
       >
         <Icon iconName="gear" />


### PR DESCRIPTION
## Summary

**Issue**: N/A — trivial UX fix (reported in Slack: editing an Agent Task Git repository did not load the target repo/branch)

Editing an Agent Task's Git repository ("Edit Git repository" modal) only rendered the Git account field. The **Repository** and **Branch** selects stayed hidden, so the saved target repo/branch never loaded on edit.

The modal gates those two selects on a truthy `provider` (`GitRepositorySetting` on `provider`, `GitBranchSettings` on `provider && repository`). When the settings form mapped the saved `project_repositories` back into its values, `provider` was never set, so `context.provider` was `undefined` and both selects were skipped.

### Changes

- `agentic-workflow-settings.tsx`: derive `provider` from the repository URL via `guessGitProvider(url)` when mapping saved repositories, so the Repository and Branch selects render and preselect their saved values on edit.

The save payload is unchanged — `formatAgenticWorkflowRepositories` still emits only `{ url, branch, git_token_id }`, so `provider` is purely a UI-side hint used to render the selects.

## Screenshots / Recordings

_Not captured in the agent environment._

## Testing

- [ ] Changes tested locally in the relevant Console's pages and Storybooks
- [ ] `yarn test` or `yarn test -u` (if you need to regenerate snapshots)
- [ ] `yarn format`
- [ ] `yarn lint`

> Note: local checks could not be run in the agent environment (no Node/Yarn toolchain available). CI (`pull-request.yml`) will validate format, lint, typecheck, and tests. The change is a 2-line, UI-only derivation with no payload impact.

## PR Checklist

- [x] I followed naming, styling, and TypeScript rules (see `.cursor/rules`)
- [x] I performed a self-review (diff inspected, dead code removed)
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope) with a scope when possible
- [x] I only kept necessary comments, written in English
- [ ] I involved a designer to validate UI changes if I am not a designer
- [ ] I covered new business logic with tests (unit)
- [ ] I confirmed CI is green (Codecov red can be accepted)
- [ ] I reviewed and executed locally any AI-assisted code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Agent Task "Edit Git repository" modal so the Repository and Branch selects render and preselect their saved values on edit, including for self-hosted repositories. Previously only the Git account field appeared because `provider` was never set when mapping saved `project_repositories` back into the form; now `provider` is derived from the associated Git token's type when available, falling back to `guessGitProvider(url)`. The save payload is unchanged. While Git tokens are loading, the Manage context button is disabled for repositories referencing a token so the provider is resolved before editing.

<sup>Written for commit 0b1f081a1d31cb45acfffb259b7877ebc99e9399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/console/pull/2949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

